### PR TITLE
fix(tokenizer): default to chatTemplate + auto-inline chat_template.jinja

### DIFF
--- a/Sources/ZImage/Tokenizer/Tokenizer.swift
+++ b/Sources/ZImage/Tokenizer/Tokenizer.swift
@@ -74,6 +74,13 @@ public final class QwenTokenizer {
       throw QwenTokenizerError.fileNotFound(tokenizerConfigURL)
     }
 
+    // Idempotently inline `chat_template.jinja` into `tokenizer_config.json`
+    // when the HF snapshot uses the modern jinja-sidecar layout. This
+    // replaces the manual /tmp/inject_chat_template.py operator workaround
+    // that would otherwise have to be re-run any time the snapshot is
+    // resynced. Operators can opt out with `ZIMAGE_NO_TOKENIZER_PATCH=1`.
+    try? ensureInlineChatTemplate(in: tokenizerDirectory)
+
     let tokenizerConfig = try hubApi.configuration(fileURL: tokenizerConfigURL)
     let addedTokensURL = tokenizerDirectory.appending(path: "added_tokens.json")
     var addedTokens: [String: Int] = [:]
@@ -403,6 +410,80 @@ public final class QwenTokenizer {
       return tokenizerPath
     }
     return directory
+  }
+
+  /// When a HuggingFace tokenizer ships its chat template as a sidecar
+  /// `chat_template.jinja` instead of inlining it in `tokenizer_config.json`,
+  /// swift-transformers' `applyChatTemplate` trips over `missingChatTemplate`
+  /// because it only reads the inline field. Upstream snapshots of
+  /// `Tongyi-MAI/Z-Image-Turbo` (and many modern HF model cards) ship the
+  /// jinja-sidecar layout.
+  ///
+  /// This helper merges the sidecar into the inline field at load time,
+  /// atomically and idempotently, with a `.bak` of the original config on
+  /// first patch. Subsequent loads see the inline field and no-op.
+  ///
+  /// Opt out via `ZIMAGE_NO_TOKENIZER_PATCH=1` (e.g. when running against a
+  /// read-only snapshot mount or a model whose chat_template must not be
+  /// augmented).
+  ///
+  /// Errors are swallowed by the caller — a failure here degrades to the
+  /// pre-existing `missingChatTemplate` error at `applyChatTemplate` time,
+  /// which is strictly no worse than the status quo.
+  static func ensureInlineChatTemplate(
+    in tokenizerDirectory: URL,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) throws {
+    if environment["ZIMAGE_NO_TOKENIZER_PATCH"] == "1" {
+      return
+    }
+
+    let configURL = tokenizerDirectory.appending(path: "tokenizer_config.json")
+    let jinjaURL = tokenizerDirectory.appending(path: "chat_template.jinja")
+    let fm = FileManager.default
+
+    guard fm.fileExists(atPath: configURL.path),
+          fm.fileExists(atPath: jinjaURL.path) else {
+      // Nothing to do — either the config is missing (caller will surface a
+      // clearer error) or there is no sidecar to merge.
+      return
+    }
+
+    let configData = try Data(contentsOf: configURL)
+    guard var configJSON = try JSONSerialization.jsonObject(with: configData, options: []) as? [String: Any] else {
+      return
+    }
+
+    // Already inlined — no-op. We treat any non-empty string as "inlined",
+    // matching what swift-transformers will accept downstream.
+    if let existing = configJSON["chat_template"] as? String, !existing.isEmpty {
+      return
+    }
+
+    let jinjaTemplate = try String(contentsOf: jinjaURL, encoding: .utf8)
+    guard !jinjaTemplate.isEmpty else { return }
+
+    configJSON["chat_template"] = jinjaTemplate
+
+    // Write backup on first patch (never overwrite an existing .bak).
+    let backupURL = configURL.appendingPathExtension("bak")
+    if !fm.fileExists(atPath: backupURL.path) {
+      try? fm.copyItem(at: configURL, to: backupURL)
+    }
+
+    // Atomic write via temp sibling + rename, so readers never see a
+    // torn file. .sortedKeys for stable diffs on subsequent patches.
+    let tmpURL = configURL.appendingPathExtension("patch.\(UUID().uuidString).tmp")
+    let patchedData = try JSONSerialization.data(
+      withJSONObject: configJSON,
+      options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    )
+    try patchedData.write(to: tmpURL, options: [.atomic])
+    _ = try fm.replaceItemAt(configURL, withItemAt: tmpURL)
+
+    FileHandle.standardError.write(Data(
+      "[zimage] inlined chat_template.jinja (\(jinjaTemplate.count) chars) into \(configURL.path); backup at \(backupURL.lastPathComponent)\n".utf8
+    ))
   }
 
   private static let promptPrefix: String = """

--- a/Sources/ZImage/Weights/ModelPaths.swift
+++ b/Sources/ZImage/Weights/ModelPaths.swift
@@ -40,6 +40,15 @@ public enum ZImageFiles {
   public static let defaultTextEncoderDirectory = "text_encoder"
   public static let preferredTextEncoderDirectory = "text_encoder QWen Large"
   public static let textEncoderEnvironmentVariable = "ZIMAGE_ENCODER_PATH"
+  /// When set to "plain", forces `resolvePromptEncodingMode` to return `.plain`
+  /// regardless of what tokenizer assets are present. Used by operators whose
+  /// text encoder variant was trained on bare (un-templated) prompts.
+  /// Default (unset or any other value) is `.chatTemplate`, which matches the
+  /// upstream z-image-turbo training recipe.
+  public static let promptModeEnvironmentVariable = "ZIMAGE_PROMPT_MODE"
+  /// Standard filename for the HF chat-template fallback when a tokenizer
+  /// doesn't embed the template inline in `tokenizer_config.json`.
+  public static let chatTemplateJinjaFilename = "chat_template.jinja"
   // Legacy defaults for current snapshot; dynamic resolvers should be preferred.
   public static let transformerWeights = [
     "transformer/diffusion_pytorch_model-00001-of-00003.safetensors",
@@ -105,20 +114,39 @@ public enum ZImageFiles {
     return TextEncoderSelection(directory: defaultDirectory, source: .defaultDirectory)
   }
 
+  /// Determine whether prompts should be encoded via the tokenizer's chat
+  /// template (`<|im_start|>user\n...<|im_end|>...`) or tokenized plain.
+  ///
+  /// Historically this was decided by whether the selected text-encoder
+  /// directory was the default `text_encoder/` or an alternate (e.g. the
+  /// preferred single-file `text_encoder QWen Large/`). That heuristic was
+  /// wrong for z-image-turbo: all three known encoder shardings for the
+  /// same underlying model (2-shard, 4-shard legacy, single-file Large)
+  /// are identical in training and so all expect chat-templated input.
+  /// Routing the Large variant through plain mode produced the mosaic /
+  /// NaN-conditioning regression fixed here.
+  ///
+  /// New contract:
+  ///   - Default: `.chatTemplate` — matches upstream z-image-turbo training.
+  ///   - Opt out by setting `ZIMAGE_PROMPT_MODE=plain` (exposed as
+  ///     `promptModeEnvironmentVariable`) for encoders trained on bare
+  ///     prompts.
+  ///
+  /// `snapshot` and `selection` are kept in the signature for source and
+  /// binary compatibility with existing callers, and so future versions
+  /// can probe the tokenizer assets if we ever need a third mode.
   public static func resolvePromptEncodingMode(
     at snapshot: URL?,
-    selection: TextEncoderSelection?
+    selection: TextEncoderSelection?,
+    environment: [String: String] = ProcessInfo.processInfo.environment
   ) -> PromptEncodingMode {
-    guard let snapshot, let selection else {
-      return .chatTemplate
+    _ = snapshot
+    _ = selection
+    if let raw = environment[promptModeEnvironmentVariable]?.lowercased(),
+       raw == "plain" {
+      return .plain
     }
-
-    let defaultDirectory = snapshot
-      .appendingPathComponent(defaultTextEncoderDirectory, isDirectory: true)
-      .standardizedFileURL
-    let selectedDirectory = selection.directory.standardizedFileURL
-
-    return selectedDirectory == defaultDirectory ? .chatTemplate : .plain
+    return .chatTemplate
   }
 
   // MARK: - Dynamic weight resolution

--- a/Tests/ZImageTests/Tokenizer/TokenizerChatTemplateInlineTests.swift
+++ b/Tests/ZImageTests/Tokenizer/TokenizerChatTemplateInlineTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import ZImage
+
+/// Covers `QwenTokenizer.ensureInlineChatTemplate`, the idempotent merger
+/// that hoists `chat_template.jinja` into `tokenizer_config.json` so
+/// swift-transformers' `applyChatTemplate` can find the template inline.
+///
+/// Regression: upstream HF snapshots of `Tongyi-MAI/Z-Image-Turbo` ship
+/// the template as a sidecar `.jinja` file, and swift-transformers only
+/// reads the inline field — producing `missingChatTemplate` pipeline
+/// errors. Operators previously patched the config by hand via
+/// `/tmp/inject_chat_template.py`; this helper does the same merge at
+/// load time, preserving a `.bak` of the original on first patch.
+final class TokenizerChatTemplateInlineTests: XCTestCase {
+
+  func testInlinesJinjaWhenConfigMissingChatTemplate() throws {
+    let tokenizerDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tokenizerDir) }
+
+    let configURL = tokenizerDir.appending(path: "tokenizer_config.json")
+    let jinjaURL = tokenizerDir.appending(path: "chat_template.jinja")
+
+    let originalConfig: [String: Any] = ["pad_token": "<|endoftext|>", "model_max_length": 131072]
+    try write(json: originalConfig, to: configURL)
+    let jinjaBody = "{% for message in messages %}<|im_start|>{{ message.role }}\n{{ message.content }}<|im_end|>\n{% endfor %}"
+    try jinjaBody.write(to: jinjaURL, atomically: true, encoding: .utf8)
+
+    try QwenTokenizer.ensureInlineChatTemplate(in: tokenizerDir, environment: [:])
+
+    let patched = try readJSON(from: configURL)
+    XCTAssertEqual(patched["chat_template"] as? String, jinjaBody,
+      "jinja contents must be inlined verbatim into tokenizer_config.json")
+    XCTAssertEqual(patched["pad_token"] as? String, "<|endoftext|>",
+      "pre-existing fields must be preserved")
+    XCTAssertEqual(patched["model_max_length"] as? Int, 131072)
+
+    let backupURL = configURL.appendingPathExtension("bak")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: backupURL.path),
+      ".bak must be written on first patch so the original config is recoverable")
+    let backup = try readJSON(from: backupURL)
+    XCTAssertNil(backup["chat_template"], "backup must be the pre-patch config (no chat_template key)")
+  }
+
+  func testIdempotentWhenChatTemplateAlreadyInline() throws {
+    let tokenizerDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tokenizerDir) }
+
+    let configURL = tokenizerDir.appending(path: "tokenizer_config.json")
+    let jinjaURL = tokenizerDir.appending(path: "chat_template.jinja")
+
+    let originalTemplate = "inline-original"
+    let originalConfig: [String: Any] = ["chat_template": originalTemplate, "pad_token": "<|endoftext|>"]
+    try write(json: originalConfig, to: configURL)
+    try "sidecar-should-be-ignored".write(to: jinjaURL, atomically: true, encoding: .utf8)
+
+    try QwenTokenizer.ensureInlineChatTemplate(in: tokenizerDir, environment: [:])
+
+    let after = try readJSON(from: configURL)
+    XCTAssertEqual(after["chat_template"] as? String, originalTemplate,
+      "existing inline template must not be overwritten by the sidecar")
+
+    let backupURL = configURL.appendingPathExtension("bak")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: backupURL.path),
+      "no backup should be written when no patch is necessary")
+  }
+
+  func testNoOpWhenJinjaSidecarMissing() throws {
+    let tokenizerDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tokenizerDir) }
+
+    let configURL = tokenizerDir.appending(path: "tokenizer_config.json")
+    let originalConfig: [String: Any] = ["pad_token": "<|endoftext|>"]
+    try write(json: originalConfig, to: configURL)
+
+    // No chat_template.jinja in the directory.
+    try QwenTokenizer.ensureInlineChatTemplate(in: tokenizerDir, environment: [:])
+
+    let after = try readJSON(from: configURL)
+    XCTAssertNil(after["chat_template"],
+      "config must be untouched when no sidecar is available to merge")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: configURL.appendingPathExtension("bak").path))
+  }
+
+  func testOptOutViaEnvironmentVariable() throws {
+    let tokenizerDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tokenizerDir) }
+
+    let configURL = tokenizerDir.appending(path: "tokenizer_config.json")
+    let jinjaURL = tokenizerDir.appending(path: "chat_template.jinja")
+
+    try write(json: ["pad_token": "<|endoftext|>"], to: configURL)
+    try "body".write(to: jinjaURL, atomically: true, encoding: .utf8)
+
+    try QwenTokenizer.ensureInlineChatTemplate(
+      in: tokenizerDir,
+      environment: ["ZIMAGE_NO_TOKENIZER_PATCH": "1"]
+    )
+
+    let after = try readJSON(from: configURL)
+    XCTAssertNil(after["chat_template"],
+      "ZIMAGE_NO_TOKENIZER_PATCH=1 must suppress the auto-patch")
+  }
+
+  func testDoesNotOverwriteExistingBackup() throws {
+    let tokenizerDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tokenizerDir) }
+
+    let configURL = tokenizerDir.appending(path: "tokenizer_config.json")
+    let jinjaURL = tokenizerDir.appending(path: "chat_template.jinja")
+    let backupURL = configURL.appendingPathExtension("bak")
+
+    // Seed a pre-existing backup with a sentinel payload — if the helper
+    // clobbered it, we'd lose an operator-saved snapshot from an earlier
+    // migration.
+    let sentinel: [String: Any] = ["sentinel": "preserve-me"]
+    try write(json: sentinel, to: backupURL)
+
+    try write(json: ["pad_token": "<|endoftext|>"], to: configURL)
+    try "body".write(to: jinjaURL, atomically: true, encoding: .utf8)
+
+    try QwenTokenizer.ensureInlineChatTemplate(in: tokenizerDir, environment: [:])
+
+    let backup = try readJSON(from: backupURL)
+    XCTAssertEqual(backup["sentinel"] as? String, "preserve-me",
+      "existing .bak must not be overwritten by a subsequent patch")
+  }
+
+  // MARK: - Helpers
+
+  private func makeTempDir() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func write(json object: [String: Any], to url: URL) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted])
+    try data.write(to: url, options: [.atomic])
+  }
+
+  private func readJSON(from url: URL) throws -> [String: Any] {
+    let data = try Data(contentsOf: url)
+    guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+      XCTFail("\(url.path) did not parse as JSON dictionary")
+      return [:]
+    }
+    return json
+  }
+}

--- a/Tests/ZImageTests/Weights/ModelPathResolutionTests.swift
+++ b/Tests/ZImageTests/Weights/ModelPathResolutionTests.swift
@@ -82,7 +82,62 @@ final class ModelPathResolutionTests: XCTestCase {
     XCTAssertEqual(defaultSelection.source, .defaultDirectory)
   }
 
-  func testPromptEncodingModeUsesChatForDefaultDirectoryEvenWhenSelectedExplicitly() throws {
+  func testPromptEncodingModeDefaultsToChatTemplateForAllSelections() throws {
+    // New contract (post-mosaic fix): every encoder directory routes through
+    // the chat template unless explicitly opted out. Previously, any
+    // non-default directory (including the auto-preferred
+    // "text_encoder QWen Large") silently flipped to `.plain`, which
+    // corrupted conditioning embeddings and produced mosaic artifacts.
+    let modelDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: modelDir) }
+
+    let standardDir = modelDir.appendingPathComponent("text_encoder")
+    let preferredDir = modelDir.appendingPathComponent("text_encoder QWen Large")
+    let customDir = modelDir.appendingPathComponent("encoder-override")
+    try makeDirectory(standardDir)
+    try makeDirectory(preferredDir)
+    try makeDirectory(customDir)
+    FileManager.default.createFile(atPath: standardDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
+    FileManager.default.createFile(atPath: preferredDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
+    FileManager.default.createFile(atPath: customDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
+
+    let defaultSelection = ZImageFiles.resolveTextEncoderSelection(
+      at: modelDir,
+      overridePath: nil,
+      environment: [:]
+    )
+    XCTAssertEqual(defaultSelection.source, .autoDetectedPreferred,
+      "with both dirs present, the preferred dir is auto-selected; that's the hot path that used to trigger the bug")
+    XCTAssertEqual(
+      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: defaultSelection, environment: [:]),
+      .chatTemplate,
+      "auto-preferred QWen Large directory MUST now resolve to chatTemplate, not plain"
+    )
+
+    let overrideSelection = ZImageFiles.resolveTextEncoderSelection(
+      at: modelDir,
+      overridePath: customDir.path,
+      environment: [:]
+    )
+    XCTAssertEqual(
+      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: overrideSelection, environment: [:]),
+      .chatTemplate,
+      "override path MUST route through chatTemplate by default"
+    )
+
+    let environmentSelection = ZImageFiles.resolveTextEncoderSelection(
+      at: modelDir,
+      overridePath: nil,
+      environment: ["ZIMAGE_ENCODER_PATH": standardDir.path]
+    )
+    XCTAssertEqual(
+      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: environmentSelection, environment: [:]),
+      .chatTemplate,
+      "env-selected path MUST route through chatTemplate by default"
+    )
+  }
+
+  func testPromptEncodingModeOptsOutToPlainWhenEnvRequests() throws {
     let modelDir = try makeTempDirectory()
     defer { try? FileManager.default.removeItem(at: modelDir) }
 
@@ -94,72 +149,49 @@ final class ModelPathResolutionTests: XCTestCase {
       attributes: nil
     )
 
-    let defaultSelection = ZImageFiles.resolveTextEncoderSelection(
+    let selection = ZImageFiles.resolveTextEncoderSelection(
       at: modelDir,
       overridePath: nil,
       environment: [:]
     )
     XCTAssertEqual(
-      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: defaultSelection),
-      .chatTemplate
+      ZImageFiles.resolvePromptEncodingMode(
+        at: modelDir,
+        selection: selection,
+        environment: ["ZIMAGE_PROMPT_MODE": "plain"]
+      ),
+      .plain,
+      "explicit opt-out via ZIMAGE_PROMPT_MODE=plain must be honored"
     )
 
-    let overrideSelection = ZImageFiles.resolveTextEncoderSelection(
-      at: modelDir,
-      overridePath: standardDir.path,
-      environment: [:]
-    )
     XCTAssertEqual(
-      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: overrideSelection),
-      .chatTemplate
+      ZImageFiles.resolvePromptEncodingMode(
+        at: modelDir,
+        selection: selection,
+        environment: ["ZIMAGE_PROMPT_MODE": "PLAIN"]
+      ),
+      .plain,
+      "opt-out is case-insensitive"
     )
 
-    let environmentSelection = ZImageFiles.resolveTextEncoderSelection(
-      at: modelDir,
-      overridePath: nil,
-      environment: ["ZIMAGE_ENCODER_PATH": standardDir.path]
-    )
     XCTAssertEqual(
-      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: environmentSelection),
-      .chatTemplate
+      ZImageFiles.resolvePromptEncodingMode(
+        at: modelDir,
+        selection: selection,
+        environment: ["ZIMAGE_PROMPT_MODE": "chat"]
+      ),
+      .chatTemplate,
+      "any value other than 'plain' preserves the default chatTemplate"
     )
-  }
 
-  func testPromptEncodingModeUsesPlainForNonDefaultEncoderDirectory() throws {
-    let modelDir = try makeTempDirectory()
-    defer { try? FileManager.default.removeItem(at: modelDir) }
-
-    let standardDir = modelDir.appendingPathComponent("text_encoder")
-    let preferredDir = modelDir.appendingPathComponent("text_encoder QWen Large")
-    let customDir = modelDir.appendingPathComponent("encoder-override")
-
-    try makeDirectory(standardDir)
-    try makeDirectory(preferredDir)
-    try makeDirectory(customDir)
-
-    FileManager.default.createFile(atPath: standardDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
-    FileManager.default.createFile(atPath: preferredDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
-    FileManager.default.createFile(atPath: customDir.appendingPathComponent("model.safetensors").path, contents: Data(), attributes: nil)
-
-    let autoSelection = ZImageFiles.resolveTextEncoderSelection(
-      at: modelDir,
-      overridePath: nil,
-      environment: [:]
-    )
-    XCTAssertEqual(autoSelection.source, .autoDetectedPreferred)
     XCTAssertEqual(
-      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: autoSelection),
-      .plain
-    )
-
-    let overrideSelection = ZImageFiles.resolveTextEncoderSelection(
-      at: modelDir,
-      overridePath: customDir.path,
-      environment: [:]
-    )
-    XCTAssertEqual(
-      ZImageFiles.resolvePromptEncodingMode(at: modelDir, selection: overrideSelection),
-      .plain
+      ZImageFiles.resolvePromptEncodingMode(
+        at: modelDir,
+        selection: selection,
+        environment: [:]
+      ),
+      .chatTemplate,
+      "unset env variable preserves the default chatTemplate"
     )
   }
 


### PR DESCRIPTION
Closes BarkadaBrew/coffeeshop-server#440.

## Two-layer fix for the z-image-turbo mosaic / missingChatTemplate regression

Previously the Mac warm server required two hand-applied filesystem workarounds on the HuggingFace snapshot cache to keep rendering cleanly. Both ran the risk of being undone by any \`z-image-turbo-bf16/\` resync. This PR makes zimage.swift self-healing on both fronts.

### Layer A — resolvePromptEncodingMode now defaults to \`.chatTemplate\`

**Before:** mode was \`.chatTemplate\` iff the selected text-encoder directory equaled the default \`text_encoder/\`. The \`autoDetectedPreferred\` branch (\`text_encoder QWen Large/\`) therefore silently flipped every render to \`.plain\`, producing corrupted conditioning embeddings → mosaic / solid-black. The only mitigation was manually renaming the Large directory out of the snapshot.

**After:** every selection routes through \`.chatTemplate\`. All three known encoder shardings of z-image-turbo (2-shard default, 4-shard legacy, single-file Large) are trained identically; routing any through plain mode was a mix-up of directory-name heuristics with actual capability.

Operators who genuinely need plain mode (a different encoder variant trained on bare prompts) can opt out explicitly:

\`\`\`
ZIMAGE_PROMPT_MODE=plain
\`\`\`

### Layer B — auto-inline \`chat_template.jinja\` at tokenizer load time

**Before:** modern HF snapshots ship the chat template as a sidecar \`chat_template.jinja\` rather than embedded in \`tokenizer_config.json\`. swift-transformers' \`applyChatTemplate\` only reads the inline field, so these snapshots error with \`missingChatTemplate\` on first render.

**After:** \`QwenTokenizer.ensureInlineChatTemplate(in:)\` runs at the top of \`QwenTokenizer.load\` and, when the sidecar is present and the inline field is absent/empty, merges the two atomically with a \`.bak\` of the original config. Idempotent: subsequent loads see the inline field and no-op. Opt out via \`ZIMAGE_NO_TOKENIZER_PATCH=1\`.

The prior operator workaround — running \`/tmp/inject_chat_template.py\` on every cache resync — becomes unnecessary.

## Deployment impact

**Currently-running Mac warm server remains correct on deploy.** The tokenizer config already has the inline \`chat_template\` field (injected manually 2026-04-19); the merger detects this and no-ops. The rename of \`text_encoder QWen Large/\` → \`_text_encoder_QWen_Large.bak/\` can be reverted post-merge if desired, since chat mode no longer depends on directory name.

## Tests

- \`ModelPathResolutionTests\` retarget the new contract: all selections route through chatTemplate, plain mode requires explicit opt-in. Deleted \`testPromptEncodingModeUsesPlainForNonDefaultEncoderDirectory\` (codified the broken behavior this PR fixes).
- New \`TokenizerChatTemplateInlineTests\` covers: inlines when missing, idempotent when already present, respects opt-out env var, preserves an existing \`.bak\`, no-ops when sidecar is absent.

## Semantic change note

This PR changes the default behavior for any caller that was relying on \`resolvePromptEncodingMode\` to auto-select \`.plain\` for non-default encoder directories. No such caller exists in our fork — the default behavior is being corrected to match z-image-turbo training, not changed away from an intentional contract. Explicit opt-in via \`ZIMAGE_PROMPT_MODE=plain\` preserves plain mode for anyone who genuinely needs it.

## Test plan

- [ ] \`swift test --filter ZImageTests\` on Mac — all pass (requires Mac toolchain, cannot verify from Linux)
- [ ] Mac warm server restart after merge — renders still clean (should be no-op on current state)
- [ ] Post-merge: temporarily un-inline \`tokenizer_config.json\` on a sandbox cache, restart warm server, confirm auto-inject runs + \`.bak\` written + render succeeds
- [ ] Post-merge: temporarily un-rename \`text_encoder QWen Large/\`, restart warm server, confirm chat mode still selected and render succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)