### PR TITLE
feat(comfybridge): Phase 1 ComfyUI protocol bridge

### DIFF
--- a/Sources/ZImage/Model/Transformer/ZImageRopeEmbedder.swift
+++ b/Sources/ZImage/Model/Transformer/ZImageRopeEmbedder.swift
@@ -138,7 +138,7 @@ public final class ZImageRopeEmbedder {
       return MLX.concatenated(outputs, axis: 1)
     }
 
-// YaRN is not yet implemented — fall back to NTK with a warning.
+    // YaRN is not yet implemented — fall back to NTK with a warning.
     // YaRN adds timestep-aware damping on top of NTK. For now, NTK-only.
     if dyPE.method == .yarn {
       print("[DyPE] WARNING: YaRN method requested but not yet implemented — falling back to NTK scaling")

--- a/Sources/ZImage/Model/Transformer/ZImageRopeEmbedder.swift
+++ b/Sources/ZImage/Model/Transformer/ZImageRopeEmbedder.swift
@@ -138,7 +138,7 @@ public final class ZImageRopeEmbedder {
       return MLX.concatenated(outputs, axis: 1)
     }
 
-    // YaRN is not yet implemented — fall back to NTK with a warning.
+// YaRN is not yet implemented — fall back to NTK with a warning.
     // YaRN adds timestep-aware damping on top of NTK. For now, NTK-only.
     if dyPE.method == .yarn {
       print("[DyPE] WARNING: YaRN method requested but not yet implemented — falling back to NTK scaling")

--- a/Sources/ZImage/Pipeline/InpaintUtilities.swift
+++ b/Sources/ZImage/Pipeline/InpaintUtilities.swift
@@ -125,35 +125,70 @@ enum InpaintUtilities {
     latentW: Int,
     grow: Int = 0,
     feather: Int = 0,
+    cropX: Int = 0,
+    cropY: Int = 0,
+    cropWidth: Int = 0,
+    cropHeight: Int = 0,
     logger: Logger? = nil
   ) throws -> MLXArray {
     #if canImport(CoreGraphics)
-    guard let rgbaMask = convertToRGBA(maskImage) else {
+    // If crop coordinates are provided, crop the full-canvas mask to selection bounds.
+    // The Krita AI Diffusion plugin sends masks at full canvas resolution, but the
+    // source image is pre-cropped to the selection bounding box. The ImageCrop node
+    // in the workflow specifies the crop region.
+    var effectiveMask = maskImage
+    // Crop when mask dimensions differ from the target generation dimensions.
+    // Krita "Selection bounds" sends mask at full canvas resolution but source image
+    // is pre-cropped to the selection bounding box.
+    let needsCrop = cropWidth > 0 && cropHeight > 0 && (maskImage.width != cropWidth || maskImage.height != cropHeight)
+    if needsCrop {
+      let cropRect = CGRect(x: cropX, y: cropY, width: cropWidth, height: cropHeight)
+      if let cropped = maskImage.cropping(to: cropRect) {
+        logger?.info("InpaintUtilities: cropped mask from \(maskImage.width)x\(maskImage.height) to \(cropped.width)x\(cropped.height) at (\(cropX),\(cropY))")
+        effectiveMask = cropped
+      } else {
+        logger?.warning("InpaintUtilities: mask crop failed for rect \(cropRect), using full mask")
+      }
+    }
+
+    guard let rgbaMask = convertToRGBA(effectiveMask) else {
       throw InpaintError.maskLoadFailed("Failed to convert mask to RGBA")
     }
 
     // Work at pixel resolution for grow/feather, then downsample.
     // Cap at 8x latent dims to avoid excessive memory usage.
-    let workH = min(maskImage.height, latentH * 8)
-    let workW = min(maskImage.width, latentW * 8)
+    let workH = min(effectiveMask.height, latentH * 8)
+    let workW = min(effectiveMask.width, latentW * 8)
 
-    // Load mask at working resolution — NHWC format [1, H, W, C]
-    let maskArray = try QwenImageIO.resizedPixelArray(
+    // Load mask at working resolution — resizedPixelArray returns NCHW [1, 3, H, W]
+    let maskArrayNCHW = try QwenImageIO.resizedPixelArray(
       from: rgbaMask,
       width: workW,
       height: workH,
       addBatchDimension: true,
       dtype: .float32
     )
+    // Transpose to NHWC [1, H, W, 3] for conv2d operations downstream
+    let maskArray = maskArrayNCHW.transposed(0, 2, 3, 1)
 
     // Convert to single-channel grayscale [1, H, W, 1]
     var mask = MLX.mean(maskArray, axis: -1, keepDims: true)
     // Binarize at 0.5 threshold
+    // Pre-binarization stats
+    let preBinMin = MLX.min(mask).item(Float.self)
+    let preBinMax = MLX.max(mask).item(Float.self)
+    let preBinMean = MLX.mean(mask).item(Float.self)
+    let preBinNonzero = MLX.sum(MLX.where(mask .> 0.01, MLXArray(Float(1.0)), MLXArray(Float(0.0)))).item(Float.self)
+    logger?.info("InpaintUtilities: pre-binarize grayscale — min=\(preBinMin), max=\(preBinMax), mean=\(String(format: "%.4f", preBinMean)), nonzero(>0.01)=\(Int(preBinNonzero))/\(workH*workW)")
+
     mask = MLX.where(mask .>= 0.5, MLXArray(Float(1.0)), MLXArray(Float(0.0)))
     MLX.eval(mask)
+    
+    let postBinWhite = MLX.sum(mask).item(Float.self)
+    logger?.info("InpaintUtilities: post-binarize — white=\(Int(postBinWhite))/\(workH*workW) (\(String(format: "%.1f", (postBinWhite / Float(workH*workW)) * 100))%)")
 
     // Scale grow/feather from original pixel space to working resolution
-    let scale = Float(workW) / Float(maskImage.width)
+    let scale = Float(workW) / Float(effectiveMask.width)
 
     // --- Grow (dilate) using conv2d with ones kernel + threshold ---
     let scaledGrow = max(0, Int(Float(grow) * scale))
@@ -229,7 +264,10 @@ enum InpaintUtilities {
     let final = result.reshaped([1, 1, latentH, latentW])
     MLX.eval(final)
 
-    logger?.info("InpaintUtilities: final mask shape \(final.shape), range [\(final.min().item(Float.self)), \(final.max().item(Float.self))]")
+    let totalPixels = Float(latentH * latentW)
+    let regeneratePixels = final.sum().item(Float.self)
+    let pct = (regeneratePixels / totalPixels) * 100.0
+    logger?.info("InpaintUtilities: final mask shape \(final.shape), range [\(final.min().item(Float.self)), \(final.max().item(Float.self))], regenerate=\(Int(regeneratePixels))/\(Int(totalPixels)) (\(String(format: "%.1f", pct))%)")
     return final
     #else
     throw InpaintError.maskLoadFailed("CoreGraphics not available")

--- a/Sources/ZImage/Pipeline/InpaintUtilities.swift
+++ b/Sources/ZImage/Pipeline/InpaintUtilities.swift
@@ -109,41 +109,134 @@ enum InpaintUtilities {
 
   // MARK: - Mask to Latent
 
-  /// Convert a pixel-space mask image to latent-space mask.
+  /// Convert a pixel-space mask image to latent-space mask with optional grow and feather.
   ///
   /// Input: CGImage mask where white (255) = region to regenerate, black (0) = preserve.
   /// Output: MLXArray of shape [1, 1, latentH, latentW] with 1.0 = regenerate, 0.0 = preserve.
   ///
-  /// The mask is downsampled to latent dimensions using nearest-neighbor interpolation
-  /// (preserves sharp mask boundaries).
-  static func pixelMaskToLatent(_ maskImage: CGImage, latentH: Int, latentW: Int) throws -> MLXArray {
+  /// Processing pipeline:
+  /// 1. Convert to grayscale float array at working resolution
+  /// 2. Grow (dilate) the mask using conv2d with ones kernel + threshold
+  /// 3. Feather (blur) the mask edges with separable Gaussian convolution
+  /// 4. Downsample to latent dimensions
+  static func pixelMaskToLatent(
+    _ maskImage: CGImage,
+    latentH: Int,
+    latentW: Int,
+    grow: Int = 0,
+    feather: Int = 0,
+    logger: Logger? = nil
+  ) throws -> MLXArray {
     #if canImport(CoreGraphics)
     guard let rgbaMask = convertToRGBA(maskImage) else {
       throw InpaintError.maskLoadFailed("Failed to convert mask to RGBA")
     }
 
-    // Resize mask to latent dimensions
+    // Work at pixel resolution for grow/feather, then downsample.
+    // Cap at 8x latent dims to avoid excessive memory usage.
+    let workH = min(maskImage.height, latentH * 8)
+    let workW = min(maskImage.width, latentW * 8)
+
+    // Load mask at working resolution — NHWC format [1, H, W, C]
     let maskArray = try QwenImageIO.resizedPixelArray(
       from: rgbaMask,
-      width: latentW,
-      height: latentH,
+      width: workW,
+      height: workH,
       addBatchDimension: true,
-      dtype: .float32,
-      interpolation: .none  // Nearest-neighbor for sharp edges
+      dtype: .float32
     )
 
-    // Convert to grayscale and binarize (threshold at 0.5)
-    let grayscale = MLX.mean(maskArray, axis: 1, keepDims: true)  // [1, 1, H, W]
-    let binarized = MLX.where(grayscale .>= 0.5, MLXArray(Float(1.0)), MLXArray(Float(0.0)))
+    // Convert to single-channel grayscale [1, H, W, 1]
+    var mask = MLX.mean(maskArray, axis: -1, keepDims: true)
+    // Binarize at 0.5 threshold
+    mask = MLX.where(mask .>= 0.5, MLXArray(Float(1.0)), MLXArray(Float(0.0)))
+    MLX.eval(mask)
 
-    MLX.eval(binarized)
-    return binarized
+    // Scale grow/feather from original pixel space to working resolution
+    let scale = Float(workW) / Float(maskImage.width)
+
+    // --- Grow (dilate) using conv2d with ones kernel + threshold ---
+    let scaledGrow = max(0, Int(Float(grow) * scale))
+    if scaledGrow > 0 {
+      let kernelSize = scaledGrow * 2 + 1
+      // Conv2d weight: [Cout, kH, kW, Cin] = [1, k, k, 1], all ones
+      let onesKernel = MLXArray.ones([1, kernelSize, kernelSize, 1])
+      // Pad input to maintain spatial dimensions
+      let padded = MLX.padded(mask, widths: [IntOrPair((0, 0)), IntOrPair((scaledGrow, scaledGrow)), IntOrPair((scaledGrow, scaledGrow)), IntOrPair((0, 0))])
+      // Convolve — any overlap with a white pixel gives a positive value
+      let dilated = conv2d(padded, onesKernel)
+      // Threshold: > 0 means at least one white pixel was in the kernel
+      mask = MLX.where(dilated .> 0, MLXArray(Float(1.0)), MLXArray(Float(0.0)))
+      MLX.eval(mask)
+      logger?.info("InpaintUtilities: mask grown by \(scaledGrow)px (kernel \(kernelSize))")
+    }
+
+    // --- Feather (Gaussian blur) using separable convolution ---
+    let scaledFeather = max(0, Int(Float(feather) * scale))
+    if scaledFeather > 0 {
+      let sigma = Float(scaledFeather) / 3.0  // 3-sigma rule
+      let kSize = scaledFeather * 2 + 1
+
+      // Build 1D Gaussian kernel
+      var kernel1D: [Float] = []
+      var sum: Float = 0
+      for i in 0..<kSize {
+        let x = Float(i - scaledFeather)
+        let g = exp(-(x * x) / (2.0 * sigma * sigma))
+        kernel1D.append(g)
+        sum += g
+      }
+      kernel1D = kernel1D.map { $0 / sum }
+
+      // Horizontal pass: weight [1, 1, kSize, 1]
+      let hKernel = MLXArray(kernel1D).reshaped([1, 1, kSize, 1])
+      let hPadded = MLX.padded(mask, widths: [IntOrPair((0, 0)), IntOrPair((0, 0)), IntOrPair((scaledFeather, scaledFeather)), IntOrPair((0, 0))], mode: .edge)
+      let blurH = conv2d(hPadded, hKernel)
+
+      // Vertical pass: weight [1, kSize, 1, 1]
+      let vKernel = MLXArray(kernel1D).reshaped([1, kSize, 1, 1])
+      let vPadded = MLX.padded(blurH, widths: [IntOrPair((0, 0)), IntOrPair((scaledFeather, scaledFeather)), IntOrPair((0, 0)), IntOrPair((0, 0))], mode: .edge)
+      mask = conv2d(vPadded, vKernel)
+      MLX.eval(mask)
+      logger?.info("InpaintUtilities: mask feathered with radius \(scaledFeather)px")
+    }
+
+    // --- Downsample to latent dimensions ---
+    // Use QwenImageIO for reliable resize, then extract single channel
+    // First convert back to CGImage for resize
+    let clampedMask = MLX.clip(mask, min: 0.0, max: 1.0)
+
+    // Simple nearest-neighbor downsample via stride
+    // mask is [1, workH, workW, 1], need [1, 1, latentH, latentW]
+    let strideH = max(1, workH / latentH)
+    let strideW = max(1, workW / latentW)
+    let downsampled = clampedMask[0..., .stride(by: strideH), .stride(by: strideW), 0...]
+    // Trim or pad to exact latent dimensions
+    let trimH = min(downsampled.dim(1), latentH)
+    let trimW = min(downsampled.dim(2), latentW)
+    var result = downsampled[0..<1, 0..<trimH, 0..<trimW]
+
+    // If trimmed dimensions don't match, pad with zeros
+    if trimH < latentH || trimW < latentW {
+      result = MLX.padded(result, widths: [
+        IntOrPair((0, 0)),
+        IntOrPair((0, latentH - trimH)),
+        IntOrPair((0, latentW - trimW))
+      ])
+    }
+
+    // Reshape to [1, 1, latentH, latentW] for NCHW format expected by the denoising loop
+    let final = result.reshaped([1, 1, latentH, latentW])
+    MLX.eval(final)
+
+    logger?.info("InpaintUtilities: final mask shape \(final.shape), range [\(final.min().item(Float.self)), \(final.max().item(Float.self))]")
+    return final
     #else
     throw InpaintError.maskLoadFailed("CoreGraphics not available")
     #endif
   }
 
-  // MARK: - Image Compositing
+    // MARK: - Image Compositing
 
   /// Composite generated output onto original image using mask.
   ///

--- a/Sources/ZImage/Pipeline/InpaintUtilities.swift
+++ b/Sources/ZImage/Pipeline/InpaintUtilities.swift
@@ -1,0 +1,220 @@
+// InpaintUtilities.swift — Latent-space inpainting helpers
+//
+// Provides VAE encoding of input images, pixel-to-latent mask conversion,
+// and CGImage loading from raw Data. Used by ZImagePipeline for inpainting.
+
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import CoreImage
+#endif
+
+/// Utilities for latent-space inpainting in the base ZImagePipeline.
+enum InpaintUtilities {
+
+  enum InpaintError: Error, CustomStringConvertible {
+    case imageLoadFailed(String)
+    case maskLoadFailed(String)
+
+    var description: String {
+      switch self {
+      case .imageLoadFailed(let msg): return "Inpaint image load failed: \(msg)"
+      case .maskLoadFailed(let msg): return "Mask load failed: \(msg)"
+      }
+    }
+  }
+
+  // MARK: - CGImage from Data
+
+  /// Load a CGImage from raw PNG/JPEG data.
+  static func loadCGImage(from data: Data) throws -> CGImage {
+    #if canImport(CoreGraphics)
+    guard let provider = CGDataProvider(data: data as CFData),
+          let cgImage = CGImage(
+            pngDataProviderSource: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+          ) else {
+      // Try JPEG fallback
+      guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        throw InpaintError.imageLoadFailed("Failed to decode image data (\(data.count) bytes)")
+      }
+      return image
+    }
+    return cgImage
+    #else
+    throw InpaintError.imageLoadFailed("CoreGraphics not available on this platform")
+    #endif
+  }
+
+  // MARK: - VAE Encode
+
+  /// Encode a CGImage to latent space using the VAE encoder.
+  static func encodeImageToLatents(
+    cgImage: CGImage,
+    vae: AutoencoderKL,
+    vaeConfig: ZImageVAEConfig,
+    pixelH: Int,
+    pixelW: Int,
+    logger: Logger
+  ) throws -> MLXArray {
+    logger.info("InpaintUtilities: VAE encoding \(cgImage.width)x\(cgImage.height) -> \(pixelW)x\(pixelH)")
+
+    #if canImport(CoreGraphics)
+    guard let rgbaImage = convertToRGBA(cgImage) else {
+      throw InpaintError.imageLoadFailed("Failed to convert to RGBA")
+    }
+
+    let imageArray = try QwenImageIO.resizedPixelArray(
+      from: rgbaImage,
+      width: pixelW,
+      height: pixelH,
+      addBatchDimension: true,
+      dtype: .float32
+    )
+    guard imageArray.ndim == 4 else {
+      throw InpaintError.imageLoadFailed("Image array has wrong dimensions: \(imageArray.ndim), expected 4")
+    }
+
+    let normalized = QwenImageIO.normalizeForEncoder(imageArray)
+    MLX.eval(normalized)
+
+    // Check for NaN values
+    let hasNaN = MLX.any(MLX.isNaN(normalized)).item(Bool.self)
+    if hasNaN {
+      throw InpaintError.imageLoadFailed("Image contains NaN values after normalization")
+    }
+
+    GPU.clearCache()
+
+    let encodedLatents = vae.encode(normalized)
+    MLX.eval(encodedLatents)
+
+    let latentChannels = vaeConfig.latentChannels
+    let latents = encodedLatents[0..., 0..<latentChannels, 0..., 0...]
+    let normalizedLatents = (latents - vaeConfig.shiftFactor) * vaeConfig.scalingFactor
+
+    logger.info("InpaintUtilities: encoded to latent shape \(normalizedLatents.shape)")
+    return normalizedLatents
+    #else
+    throw InpaintError.imageLoadFailed("CoreGraphics not available")
+    #endif
+  }
+
+  // MARK: - Mask to Latent
+
+  /// Convert a pixel-space mask image to latent-space mask.
+  ///
+  /// Input: CGImage mask where white (255) = region to regenerate, black (0) = preserve.
+  /// Output: MLXArray of shape [1, 1, latentH, latentW] with 1.0 = regenerate, 0.0 = preserve.
+  ///
+  /// The mask is downsampled to latent dimensions using nearest-neighbor interpolation
+  /// (preserves sharp mask boundaries).
+  static func pixelMaskToLatent(_ maskImage: CGImage, latentH: Int, latentW: Int) throws -> MLXArray {
+    #if canImport(CoreGraphics)
+    guard let rgbaMask = convertToRGBA(maskImage) else {
+      throw InpaintError.maskLoadFailed("Failed to convert mask to RGBA")
+    }
+
+    // Resize mask to latent dimensions
+    let maskArray = try QwenImageIO.resizedPixelArray(
+      from: rgbaMask,
+      width: latentW,
+      height: latentH,
+      addBatchDimension: true,
+      dtype: .float32,
+      interpolation: .none  // Nearest-neighbor for sharp edges
+    )
+
+    // Convert to grayscale and binarize (threshold at 0.5)
+    let grayscale = MLX.mean(maskArray, axis: 1, keepDims: true)  // [1, 1, H, W]
+    let binarized = MLX.where(grayscale .>= 0.5, MLXArray(Float(1.0)), MLXArray(Float(0.0)))
+
+    MLX.eval(binarized)
+    return binarized
+    #else
+    throw InpaintError.maskLoadFailed("CoreGraphics not available")
+    #endif
+  }
+
+  // MARK: - Image Compositing
+
+  /// Composite generated output onto original image using mask.
+  ///
+  /// For latent-space inpainting, the blending happens in latent space during denoising.
+  /// This method provides an additional pixel-space composite for clean edges.
+  ///
+  /// - Parameters:
+  ///   - generated: The fully decoded generated image (MLXArray [1, C, H, W]).
+  ///   - original: The original image data (PNG).
+  ///   - mask: The mask data (PNG, white = generated region).
+  ///   - width: Target pixel width.
+  ///   - height: Target pixel height.
+  /// - Returns: Composited MLXArray.
+  static func compositeWithMask(
+    generated: MLXArray,
+    originalData: Data,
+    maskData: Data,
+    width: Int,
+    height: Int
+  ) throws -> MLXArray {
+    #if canImport(CoreGraphics)
+    let origCG = try loadCGImage(from: originalData)
+    let maskCG = try loadCGImage(from: maskData)
+
+    guard let origRGBA = convertToRGBA(origCG),
+          let maskRGBA = convertToRGBA(maskCG) else {
+      throw InpaintError.imageLoadFailed("Failed to convert images for compositing")
+    }
+
+    let origArray = try QwenImageIO.resizedPixelArray(
+      from: origRGBA, width: width, height: height,
+      addBatchDimension: true, dtype: .float32
+    )
+    let maskArray = try QwenImageIO.resizedPixelArray(
+      from: maskRGBA, width: width, height: height,
+      addBatchDimension: true, dtype: .float32
+    )
+
+    // Grayscale mask [1, 1, H, W]
+    let maskGray = MLX.mean(maskArray, axis: 1, keepDims: true)
+    // Broadcast to match image channels
+    let maskBroadcast = MLX.broadcast(maskGray, to: generated.shape)
+
+    // Blend: mask=1 → generated, mask=0 → original
+    let composited = maskBroadcast * generated + (1.0 - maskBroadcast) * origArray
+    return composited
+    #else
+    throw InpaintError.imageLoadFailed("CoreGraphics not available")
+    #endif
+  }
+
+  // MARK: - Helpers
+
+  #if canImport(CoreGraphics)
+  /// Convert a CGImage to RGBA format (required for pixel array conversion).
+  private static func convertToRGBA(_ image: CGImage) -> CGImage? {
+    let width = image.width
+    let height = image.height
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+    guard let context = CGContext(
+      data: nil, width: width, height: height,
+      bitsPerComponent: 8, bytesPerRow: width * 4,
+      space: colorSpace, bitmapInfo: bitmapInfo.rawValue
+    ) else {
+      return nil
+    }
+
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return context.makeImage()
+  }
+  #endif
+}

--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -58,6 +58,9 @@ public struct ZImageGenerationRequest: Sendable {
   public var maskGrow: Int
   /// Mask feather radius in pixels (default 0 = hard edges).
   public var maskFeather: Int
+  /// ImageCrop x,y offset for cropping full-canvas mask to selection bounds.
+  public var maskCropX: Int
+  public var maskCropY: Int
 
   public init(
     prompt: String,
@@ -84,7 +87,9 @@ public struct ZImageGenerationRequest: Sendable {
     maskData: Data? = nil,
     denoise: Float = 1.0,
     maskGrow: Int = 0,
-    maskFeather: Int = 0
+    maskFeather: Int = 0,
+    maskCropX: Int = 0,
+    maskCropY: Int = 0
   ) {
     self.prompt = prompt
     self.negativePrompt = negativePrompt
@@ -110,6 +115,8 @@ public struct ZImageGenerationRequest: Sendable {
     self.denoise = denoise
     self.maskGrow = maskGrow
     self.maskFeather = maskFeather
+    self.maskCropX = maskCropX
+    self.maskCropY = maskCropY
   }
 }
 
@@ -939,6 +946,7 @@ public final class ZImagePipeline {
       logger.info("Inpainting mode: encoding input image and mask...")
       let cgImage = try InpaintUtilities.loadCGImage(from: imageData)
       let maskCG = try InpaintUtilities.loadCGImage(from: maskDataRaw)
+      logger.info("Inpainting: source=\(cgImage.width)x\(cgImage.height), mask=\(maskCG.width)x\(maskCG.height), gen=\(request.width)x\(request.height), cropXY=(\(request.maskCropX),\(request.maskCropY))")
 
       let pixelH = latentH * vaeDivisor
       let pixelW = latentW * vaeDivisor
@@ -956,7 +964,10 @@ public final class ZImagePipeline {
       // Convert pixel mask to latent-space mask with optional grow/feather
       latentMask = try InpaintUtilities.pixelMaskToLatent(
         maskCG, latentH: latentH, latentW: latentW,
-        grow: request.maskGrow, feather: request.maskFeather, logger: logger
+        grow: request.maskGrow, feather: request.maskFeather,
+        cropX: request.maskCropX, cropY: request.maskCropY,
+        cropWidth: request.width, cropHeight: request.height,
+        logger: logger
       )
 
       // Store the initial noise for sigma blending at each step

--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -54,6 +54,10 @@ public struct ZImageGenerationRequest: Sendable {
   /// Denoising strength for inpainting (0.0–1.0). Lower values preserve more of the original.
   /// Default: 1.0 (full denoise, equivalent to txt2img).
   public var denoise: Float
+  /// Mask expansion in pixels (default 0 = no expansion).
+  public var maskGrow: Int
+  /// Mask feather radius in pixels (default 0 = hard edges).
+  public var maskFeather: Int
 
   public init(
     prompt: String,
@@ -78,7 +82,9 @@ public struct ZImageGenerationRequest: Sendable {
     dyPE: DyPEConfig = .disabled,
     inpaintImageData: Data? = nil,
     maskData: Data? = nil,
-    denoise: Float = 1.0
+    denoise: Float = 1.0,
+    maskGrow: Int = 0,
+    maskFeather: Int = 0
   ) {
     self.prompt = prompt
     self.negativePrompt = negativePrompt
@@ -102,6 +108,8 @@ public struct ZImageGenerationRequest: Sendable {
     self.inpaintImageData = inpaintImageData
     self.maskData = maskData
     self.denoise = denoise
+    self.maskGrow = maskGrow
+    self.maskFeather = maskFeather
   }
 }
 
@@ -945,9 +953,10 @@ public final class ZImagePipeline {
       )
       originalLatents = origLatents
 
-      // Convert pixel mask to latent-space mask (1 = regenerate, 0 = preserve)
+      // Convert pixel mask to latent-space mask with optional grow/feather
       latentMask = try InpaintUtilities.pixelMaskToLatent(
-        maskCG, latentH: latentH, latentW: latentW
+        maskCG, latentH: latentH, latentW: latentW,
+        grow: request.maskGrow, feather: request.maskFeather, logger: logger
       )
 
       // Store the initial noise for sigma blending at each step

--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -45,6 +45,16 @@ public struct ZImageGenerationRequest: Sendable {
   /// When enabled, modifies RoPE frequencies to support resolutions above training scale.
   public var dyPE: DyPEConfig
 
+  // --- Latent-space inpainting (Phase 3) ---
+
+  /// Raw PNG data of the image to inpaint. When set, enables latent-space inpainting.
+  public var inpaintImageData: Data?
+  /// Raw PNG data of the mask. White (255) = regenerate, black (0) = preserve original.
+  public var maskData: Data?
+  /// Denoising strength for inpainting (0.0–1.0). Lower values preserve more of the original.
+  /// Default: 1.0 (full denoise, equivalent to txt2img).
+  public var denoise: Float
+
   public init(
     prompt: String,
     negativePrompt: String? = nil,
@@ -65,7 +75,10 @@ public struct ZImageGenerationRequest: Sendable {
     schedulerKind: SchedulerKind = .euler,
     sigmaSchedule: SigmaScheduleKind = .flow,
     eta: Float? = nil,
-    dyPE: DyPEConfig = .disabled
+    dyPE: DyPEConfig = .disabled,
+    inpaintImageData: Data? = nil,
+    maskData: Data? = nil,
+    denoise: Float = 1.0
   ) {
     self.prompt = prompt
     self.negativePrompt = negativePrompt
@@ -86,6 +99,9 @@ public struct ZImageGenerationRequest: Sendable {
     self.sigmaSchedule = sigmaSchedule
     self.eta = eta
     self.dyPE = dyPE
+    self.inpaintImageData = inpaintImageData
+    self.maskData = maskData
+    self.denoise = denoise
   }
 }
 
@@ -116,6 +132,8 @@ public final class ZImagePipeline {
   private var textEncoder: QwenTextEncoder?
   private var transformer: ZImageTransformer2DModel?
   private var vae: VAEImageDecoding?
+  /// Full VAE with encoder — lazily loaded on first inpaint request.
+  private var fullVAE: AutoencoderKL?
   private var modelConfigs: ZImageModelConfigs?
   private var quantManifest: ZImageQuantizationManifest?
   private var isModelLoaded: Bool = false
@@ -151,6 +169,7 @@ public final class ZImagePipeline {
     textEncoder = nil
     transformer = nil
     vae = nil
+    fullVAE = nil
     modelConfigs = nil
     quantManifest = nil
     isModelLoaded = false
@@ -279,6 +298,43 @@ public final class ZImagePipeline {
       sampleSize: config.sampleSize,
       midBlockAddAttention: config.midBlockAddAttention
     ))
+  }
+
+  /// Load the full VAE with encoder for inpainting.
+  /// Called lazily on first inpaint request. Encoder weights are loaded from the same snapshot.
+  private func ensureFullVAE() throws -> AutoencoderKL {
+    if let existing = fullVAE { return existing }
+
+    guard let configs = modelConfigs else {
+      throw PipelineError.modelNotLoaded
+    }
+    guard let snapshot = modelSnapshot else {
+      throw PipelineError.modelNotLoaded
+    }
+
+    logger.info("Loading full VAE with encoder for inpainting...")
+    let vaeConfig = configs.vae
+    let v = AutoencoderKL(configuration: .init(
+      inChannels: vaeConfig.inChannels,
+      outChannels: vaeConfig.outChannels,
+      latentChannels: vaeConfig.latentChannels,
+      scalingFactor: vaeConfig.scalingFactor,
+      shiftFactor: vaeConfig.shiftFactor,
+      blockOutChannels: vaeConfig.blockOutChannels,
+      layersPerBlock: vaeConfig.layersPerBlock,
+      normNumGroups: vaeConfig.normNumGroups,
+      sampleSize: vaeConfig.sampleSize,
+      midBlockAddAttention: vaeConfig.midBlockAddAttention
+    ))
+
+    // Load ALL VAE weights (encoder + decoder)
+    let weightsMapper = ZImageWeightsMapper(snapshot: snapshot, logger: logger)
+    let allVAEWeights = try weightsMapper.loadVAE()
+    try ZImageWeightsMapping.applyVAE(weights: allVAEWeights, to: v, manifest: quantManifest, logger: logger)
+
+    fullVAE = v
+    logger.info("Full VAE loaded (encoder + decoder)")
+    return v
   }
 
   private func encodePrompt(_ prompt: String, tokenizer: QwenTokenizer, textEncoder: QwenTextEncoder, maxLength: Int) throws -> (MLXArray, MLXArray) {
@@ -865,6 +921,50 @@ public final class ZImagePipeline {
     let timestepsArray = scheduler.timesteps.asArray(Float.self)
     let numTrainTimestepsF = Float(modelConfigs.scheduler.numTrainTimesteps)
 
+    // --- Latent-space inpainting setup ---
+    var originalLatents: MLXArray?
+    var latentMask: MLXArray?
+    var inpaintNoise: MLXArray?
+    var inpaintStartStep = 0
+
+    if let imageData = request.inpaintImageData, let maskDataRaw = request.maskData {
+      logger.info("Inpainting mode: encoding input image and mask...")
+      let cgImage = try InpaintUtilities.loadCGImage(from: imageData)
+      let maskCG = try InpaintUtilities.loadCGImage(from: maskDataRaw)
+
+      let pixelH = latentH * vaeDivisor
+      let pixelW = latentW * vaeDivisor
+
+      // Need full VAE (with encoder) for inpainting
+      let encoderVAE = try ensureFullVAE()
+
+      // VAE-encode the input image to latent space
+      let origLatents = try InpaintUtilities.encodeImageToLatents(
+        cgImage: cgImage, vae: encoderVAE, vaeConfig: modelConfigs.vae,
+        pixelH: pixelH, pixelW: pixelW, logger: logger
+      )
+      originalLatents = origLatents
+
+      // Convert pixel mask to latent-space mask (1 = regenerate, 0 = preserve)
+      latentMask = try InpaintUtilities.pixelMaskToLatent(
+        maskCG, latentH: latentH, latentW: latentW
+      )
+
+      // Store the initial noise for sigma blending at each step
+      inpaintNoise = latents
+
+      // Handle denoise < 1.0: start from partially noised original
+      if request.denoise < 1.0 {
+        inpaintStartStep = max(0, request.steps - Int(ceil(Float(request.steps) * request.denoise)))
+        let startSigma = scheduler.sigmas[inpaintStartStep].item(Float.self)
+        latents = MLXArray(startSigma) * latents + MLXArray(1.0 - startSigma) * origLatents
+        MLX.eval(latents)
+        logger.info("Inpaint: denoise=\(request.denoise), starting at step \(inpaintStartStep)/\(request.steps), sigma=\(startSigma)")
+      } else {
+        logger.info("Inpaint: full denoise (1.0), running all \(request.steps) steps")
+      }
+    }
+
     logger.info("Running \(request.steps) denoising steps (sampler: \(request.schedulerKind.rawValue), schedule: \(request.sigmaSchedule.rawValue))...")
     do {
       guard let transformer = transformer else {
@@ -876,7 +976,7 @@ public final class ZImagePipeline {
       if request.dyPE.enabled {
         logger.info("DyPE enabled: \(request.dyPE.method.rawValue) (base \(request.dyPE.baseResolution)px → \(request.width)x\(request.height))")
       }
-      for stepIndex in 0..<request.steps {
+      for stepIndex in inpaintStartStep..<request.steps {
         try Task.checkCancellation()
         progressHandler?(GenerationProgress(stage: .denoising, stepIndex: stepIndex, totalSteps: request.steps))
         let timestep = timestepsArray[stepIndex]
@@ -946,6 +1046,18 @@ public final class ZImagePipeline {
           )
         } else {
           latents = scheduler.step(modelOutput: -guidedNoise, timestepIndex: stepIndex, sample: latents)
+        }
+        // Inpaint: blend with original in unmasked regions at current noise level
+        if let origLatents = originalLatents, let mask = latentMask, let noise = inpaintNoise {
+          let nextSigma = scheduler.sigmas[stepIndex + 1].item(Float.self)
+          if nextSigma > 0 {
+            // Noise the original to the current noise level for seamless blending
+            let noisedOriginal = MLXArray(nextSigma) * noise + MLXArray(1.0 - nextSigma) * origLatents
+            latents = mask * latents + (1.0 - mask) * noisedOriginal
+          } else {
+            // Final step: blend clean original (no noise)
+            latents = mask * latents + (1.0 - mask) * origLatents
+          }
         }
         MLX.eval(latents)
       }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -20,7 +20,8 @@ final class ComfyBridge {
   let wsManager: ComfyWebSocketManager
   private let imageCache: ComfyImageCache
 
-  // Lazily built and cached on first request.
+  // Lazily built and cached on first request. Guarded by cacheLock.
+  private let cacheLock = NSLock()
   private var cachedSystemStats: Data?
   private var cachedObjectInfo: Data?
 
@@ -89,7 +90,11 @@ final class ComfyBridge {
   // MARK: - GET /system_stats
 
   private func handleSystemStats() -> RoutedResponse {
-    if let cached = cachedSystemStats {
+    cacheLock.lock()
+    let cached = cachedSystemStats
+    cacheLock.unlock()
+
+    if let cached {
       return .json(.rawJSON(status: 200, data: cached))
     }
 
@@ -109,7 +114,9 @@ final class ComfyBridge {
     ]
 
     if let data = try? JSONSerialization.data(withJSONObject: stats) {
+      cacheLock.lock()
       cachedSystemStats = data
+      cacheLock.unlock()
       logger.info("ComfyBridge: /system_stats — \(deviceName), \(totalMemory / (1024*1024*1024))GB")
       return .json(.rawJSON(status: 200, data: data))
     }
@@ -128,14 +135,20 @@ final class ComfyBridge {
   // MARK: - GET /object_info
 
   private func handleObjectInfo() -> RoutedResponse {
-    if let cached = cachedObjectInfo {
+    cacheLock.lock()
+    let cached = cachedObjectInfo
+    cacheLock.unlock()
+
+    if let cached {
       return .json(.rawJSON(status: 200, data: cached))
     }
 
     let info = ComfyBridgeObjectInfo.build()
 
     if let data = try? JSONSerialization.data(withJSONObject: info) {
+      cacheLock.lock()
       cachedObjectInfo = data
+      cacheLock.unlock()
       logger.info("ComfyBridge: /object_info — \(info.count) nodes declared")
       return .json(.rawJSON(status: 200, data: data))
     }
@@ -210,7 +223,9 @@ final class ComfyBridge {
       return .error(.error(status: 400, message: "Empty image body"))
     }
 
-    imageCache.store(id: id, data: body)
+    guard imageCache.store(id: id, data: body) else {
+      return .error(.error(status: 500, message: "Failed to persist image \(id)"))
+    }
     logger.info("ComfyBridge: stored image \(id) (\(body.count) bytes)")
     return .json(status: 200, payload: EmptyObject())
   }
@@ -227,9 +242,33 @@ final class ComfyBridge {
 
   /// Build the HTTP 101 WebSocket upgrade response for a validated request.
   /// Returns the raw response bytes to send, or nil if the request is not a valid upgrade.
+  ///
+  /// Validates RFC 6455 Section 4.2.1 requirements:
+  /// - Upgrade: websocket header present
+  /// - Connection header contains "Upgrade"
+  /// - Sec-WebSocket-Key is a valid 16-byte base64 value
+  /// - Sec-WebSocket-Version is 13
   func handleWebSocketUpgrade(request: HTTPRequest, connection: NWConnection, queue: DispatchQueue) -> Data? {
-    guard request.headers["upgrade"]?.lowercased() == "websocket",
-          let wsKey = request.headers["sec-websocket-key"] else {
+    // Validate Upgrade header.
+    guard request.headers["upgrade"]?.lowercased() == "websocket" else {
+      return nil
+    }
+
+    // Validate Connection header contains "Upgrade" (case-insensitive, may be comma-separated).
+    guard let connectionHeader = request.headers["connection"],
+          connectionHeader.lowercased().contains("upgrade") else {
+      return nil
+    }
+
+    // Validate Sec-WebSocket-Version is 13.
+    guard request.headers["sec-websocket-version"] == "13" else {
+      return nil
+    }
+
+    // Validate Sec-WebSocket-Key is present and is a valid 16-byte base64 value.
+    guard let wsKey = request.headers["sec-websocket-key"],
+          let decoded = Data(base64Encoded: wsKey),
+          decoded.count == 16 else {
       return nil
     }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -78,8 +78,17 @@ final class ComfyBridge {
         }
       }
 
-      // Model info endpoint (placeholder for Phase 2+).
+      // Model info endpoint — returns metadata for our available models.
       if request.path.hasPrefix("/api/etn/model_info/") {
+        let folder = String(request.path.dropFirst("/api/etn/model_info/".count))
+        return handleModelInfo(folder: folder, queryString: request.queryString)
+      }
+
+      // Translation languages endpoint.
+      if request.path == "/api/etn/languages" {
+        if let data = try? JSONSerialization.data(withJSONObject: [] as [Any]) {
+          return .json(.rawJSON(status: 200, data: data))
+        }
         return .json(status: 200, payload: EmptyObject())
       }
 
@@ -236,6 +245,42 @@ final class ComfyBridge {
     }
 
     return .json(.binary(status: 200, contentType: "image/png", data: data))
+  }
+
+
+  // MARK: - GET /api/etn/model_info/{folder}
+
+  private func handleModelInfo(folder: String, queryString: String?) -> RoutedResponse {
+    // Parse offset/limit from query string for pagination.
+    var offset = 0
+    var limit = 8
+    if let qs = queryString {
+      for param in qs.split(separator: "&") {
+        let parts = param.split(separator: "=", maxSplits: 1)
+        if parts.count == 2 {
+          if parts[0] == "offset", let v = Int(parts[1]) { offset = v }
+          if parts[0] == "limit", let v = Int(parts[1]) { limit = v }
+        }
+      }
+    }
+
+    let models = ComfyBridgeModelInfo.models(for: folder)
+    let total = models.count
+
+    // Apply pagination.
+    let keys = Array(models.keys).sorted()
+    let pageKeys = Array(keys.dropFirst(offset).prefix(limit))
+    var page: [String: Any] = [:]
+    for key in pageKeys {
+      page[key] = models[key]
+    }
+    page["_meta"] = ["total": total]
+
+    if let data = try? JSONSerialization.data(withJSONObject: page) {
+      logger.info("ComfyBridge: /api/etn/model_info/\(folder) — \(pageKeys.count)/\(total) models (offset=\(offset))")
+      return .json(.rawJSON(status: 200, data: data))
+    }
+    return .error(.error(status: 500, message: "Failed to serialize model_info"))
   }
 
   // MARK: - WebSocket Upgrade

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -4,6 +4,7 @@
 // so the Krita AI Diffusion plugin can connect directly.
 //
 // Phase 1: Discovery endpoints (static responses) + WebSocket skeleton + image cache.
+// Phase 2: Workflow parsing + async generation + WebSocket progress events.
 
 import Foundation
 import Logging
@@ -13,12 +14,16 @@ import Network
 /// ComfyUI protocol bridge — translates ComfyUI API calls into ZImageCLI operations.
 ///
 /// Phase 1 implements discovery endpoints that satisfy the Krita plugin's connection
-/// handshake and node validation. The bridge is designed as a clean layer that can be
-/// enabled/disabled without affecting the existing `/v1/generate` API.
+/// handshake and node validation. Phase 2 adds workflow parsing and actual generation
+/// routed through the warm server pipeline.
 final class ComfyBridge {
   private let logger: Logger
   let wsManager: ComfyWebSocketManager
-  private let imageCache: ComfyImageCache
+  let imageCache: ComfyImageCache
+
+  /// The executor handles async generation and WebSocket event dispatch.
+  /// Configured after init via `configureExecutor()`.
+  private(set) var executor: ComfyBridgeExecutor?
 
   // Lazily built and cached on first request. Guarded by cacheLock.
   private let cacheLock = NSLock()
@@ -29,6 +34,18 @@ final class ComfyBridge {
     self.logger = logger
     self.wsManager = ComfyWebSocketManager(logger: logger)
     self.imageCache = ComfyImageCache(logger: logger)
+  }
+
+  /// Configure the executor with a generation handler.
+  /// Called by WarmServer after init to wire in the coordinator.
+  func configureExecutor(generateHandler: @escaping ComfyBridgeGenerateHandler) {
+    self.executor = ComfyBridgeExecutor(
+      logger: logger,
+      wsManager: wsManager,
+      imageCache: imageCache,
+      generateHandler: generateHandler
+    )
+    logger.info("ComfyBridge: executor configured — Phase 2 generation enabled")
   }
 
   // MARK: - Route Dispatch
@@ -78,13 +95,13 @@ final class ComfyBridge {
         }
       }
 
-      // Model info endpoint — returns metadata for our available models.
+      // Model info endpoint with pagination.
       if request.path.hasPrefix("/api/etn/model_info/") {
         let folder = String(request.path.dropFirst("/api/etn/model_info/".count))
         return handleModelInfo(folder: folder, queryString: request.queryString)
       }
 
-      // Translation languages endpoint.
+      // Languages endpoint.
       if request.path == "/api/etn/languages" {
         if let data = try? JSONSerialization.data(withJSONObject: [] as [Any]) {
           return .json(.rawJSON(status: 200, data: data))
@@ -110,8 +127,6 @@ final class ComfyBridge {
     let deviceName = queryMetalDeviceName()
     let totalMemory = ProcessInfo.processInfo.physicalMemory
 
-    // Build the response manually to avoid snake_case encoding of the fields
-    // that ComfyUI expects in their exact casing.
     let stats: [String: Any] = [
       "devices": [
         [
@@ -133,7 +148,6 @@ final class ComfyBridge {
     return .error(.error(status: 500, message: "Failed to serialize system_stats"))
   }
 
-  /// Query the Metal device name. Falls back to a sensible default.
   private func queryMetalDeviceName() -> String {
     if let device = MTLCreateSystemDefaultDevice() {
       return device.name
@@ -168,9 +182,9 @@ final class ComfyBridge {
   // MARK: - GET /queue
 
   private func handleGetQueue() -> RoutedResponse {
-    // Phase 1: always report empty queues.
+    let isRunning = executor?.isExecuting ?? false
     let queue: [String: Any] = [
-      "queue_running": [] as [Any],
+      "queue_running": isRunning ? [["placeholder"]] as [Any] : [] as [Any],
       "queue_pending": [] as [Any]
     ]
     if let data = try? JSONSerialization.data(withJSONObject: queue) {
@@ -182,14 +196,12 @@ final class ComfyBridge {
   // MARK: - POST /queue (delete queued jobs)
 
   private func handlePostQueue() -> RoutedResponse {
-    // Phase 1: acknowledge the delete request, nothing to cancel.
     return .json(status: 200, payload: EmptyObject())
   }
 
   // MARK: - POST /prompt
 
   private func handlePrompt(_ request: HTTPRequest) -> RoutedResponse {
-    // Phase 1: validate the shape, echo back prompt_id, don't execute.
     guard let json = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any] else {
       return .error(.error(status: 400, message: "Invalid JSON body"))
     }
@@ -203,14 +215,35 @@ final class ComfyBridge {
     }
 
     let clientId = json["client_id"] as? String ?? "unknown"
-    logger.info("ComfyBridge: /prompt received — prompt_id=\(promptId), client_id=\(clientId)")
 
-    // Phase 2 will extract workflow parameters and route to the pipeline.
-    // For now, just acknowledge.
-    let response: [String: Any] = [
-      "prompt_id": promptId
-    ]
+    // Phase 2: parse the workflow and dispatch async generation.
+    guard let executor = executor else {
+      // No executor configured — acknowledge but don't generate (Phase 1 behavior).
+      logger.info("ComfyBridge: /prompt received (no executor) — prompt_id=\(promptId), client_id=\(clientId)")
+      let response: [String: Any] = ["prompt_id": promptId]
+      if let data = try? JSONSerialization.data(withJSONObject: response) {
+        return .json(.rawJSON(status: 200, data: data))
+      }
+      return .error(.error(status: 500, message: "Failed to serialize prompt response"))
+    }
 
+    // Parse the workflow into generation parameters.
+    let generateRequest: ComfyBridgeGenerateRequest
+    do {
+      generateRequest = try ComfyBridgeWorkflowParser.parse(json)
+    } catch {
+      logger.error("ComfyBridge: workflow parse failed — \(error)")
+      return .error(.error(status: 400, message: "Workflow parse error: \(error)"))
+    }
+
+    logger.info("ComfyBridge: /prompt — \(generateRequest.width)x\(generateRequest.height), \(generateRequest.steps) steps, cfg=\(generateRequest.guidance), seed=\(generateRequest.seed.map(String.init) ?? "random")")
+
+    // Acknowledge immediately — generation runs async via WebSocket events.
+    Task {
+      await executor.execute(generateRequest)
+    }
+
+    let response: [String: Any] = ["prompt_id": promptId]
     if let data = try? JSONSerialization.data(withJSONObject: response) {
       return .json(.rawJSON(status: 200, data: data))
     }
@@ -220,8 +253,11 @@ final class ComfyBridge {
   // MARK: - POST /interrupt
 
   private func handleInterrupt() -> RoutedResponse {
-    // Phase 1: acknowledge, nothing to cancel yet.
-    logger.info("ComfyBridge: /interrupt received (no active job)")
+    if let executor, executor.interrupt() {
+      logger.info("ComfyBridge: /interrupt — active generation interrupted")
+    } else {
+      logger.info("ComfyBridge: /interrupt — no active generation")
+    }
     return .json(status: 200, payload: EmptyObject())
   }
 
@@ -247,29 +283,31 @@ final class ComfyBridge {
     return .json(.binary(status: 200, contentType: "image/png", data: data))
   }
 
-
-  // MARK: - GET /api/etn/model_info/{folder}
+  // MARK: - Model Info
 
   private func handleModelInfo(folder: String, queryString: String?) -> RoutedResponse {
-    // Parse offset/limit from query string for pagination.
     var offset = 0
     var limit = 8
+
     if let qs = queryString {
-      for param in qs.split(separator: "&") {
-        let parts = param.split(separator: "=", maxSplits: 1)
-        if parts.count == 2 {
-          if parts[0] == "offset", let v = Int(parts[1]) { offset = v }
-          if parts[0] == "limit", let v = Int(parts[1]) { limit = v }
+      for pair in qs.split(separator: "&") {
+        let parts = pair.split(separator: "=", maxSplits: 1)
+        guard parts.count == 2 else { continue }
+        let key = String(parts[0])
+        let val = String(parts[1])
+        switch key {
+        case "offset": offset = max(0, Int(val) ?? 0)
+        case "limit": limit = max(1, min(100, Int(val) ?? 8))
+        default: break
         }
       }
     }
 
     let models = ComfyBridgeModelInfo.models(for: folder)
     let total = models.count
-
-    // Apply pagination.
     let keys = Array(models.keys).sorted()
     let pageKeys = Array(keys.dropFirst(offset).prefix(limit))
+
     var page: [String: Any] = [:]
     for key in pageKeys {
       page[key] = models[key]
@@ -277,7 +315,6 @@ final class ComfyBridge {
     page["_meta"] = ["total": total]
 
     if let data = try? JSONSerialization.data(withJSONObject: page) {
-      logger.info("ComfyBridge: /api/etn/model_info/\(folder) — \(pageKeys.count)/\(total) models (offset=\(offset))")
       return .json(.rawJSON(status: 200, data: data))
     }
     return .error(.error(status: 500, message: "Failed to serialize model_info"))
@@ -286,31 +323,20 @@ final class ComfyBridge {
   // MARK: - WebSocket Upgrade
 
   /// Build the HTTP 101 WebSocket upgrade response for a validated request.
-  /// Returns the raw response bytes to send, or nil if the request is not a valid upgrade.
-  ///
-  /// Validates RFC 6455 Section 4.2.1 requirements:
-  /// - Upgrade: websocket header present
-  /// - Connection header contains "Upgrade"
-  /// - Sec-WebSocket-Key is a valid 16-byte base64 value
-  /// - Sec-WebSocket-Version is 13
   func handleWebSocketUpgrade(request: HTTPRequest, connection: NWConnection, queue: DispatchQueue) -> Data? {
-    // Validate Upgrade header.
     guard request.headers["upgrade"]?.lowercased() == "websocket" else {
       return nil
     }
 
-    // Validate Connection header contains "Upgrade" (case-insensitive, may be comma-separated).
     guard let connectionHeader = request.headers["connection"],
           connectionHeader.lowercased().contains("upgrade") else {
       return nil
     }
 
-    // Validate Sec-WebSocket-Version is 13.
     guard request.headers["sec-websocket-version"] == "13" else {
       return nil
     }
 
-    // Validate Sec-WebSocket-Key is present and is a valid 16-byte base64 value.
     guard let wsKey = request.headers["sec-websocket-key"],
           let decoded = Data(base64Encoded: wsKey),
           decoded.count == 16 else {

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -227,6 +227,18 @@ final class ComfyBridge {
       return .error(.error(status: 500, message: "Failed to serialize prompt response"))
     }
 
+    // Debug: dump raw workflow JSON
+    if let dumpData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
+       let dumpStr = String(data: dumpData, encoding: .utf8) {
+      try? dumpStr.write(toFile: "/tmp/zimage-debug-workflow.json", atomically: true, encoding: .utf8)
+      logger.info("ComfyBridge: dumped workflow to /tmp/zimage-debug-workflow.json (\(dumpData.count) bytes)")
+      // Also log the node class types
+      if let prompt = json["prompt"] as? [String: [String: Any]] {
+        let nodeTypes = prompt.values.compactMap { ($0["class_type"] as? String) }.sorted()
+        logger.info("ComfyBridge: workflow node types: \(nodeTypes.joined(separator: ", "))")
+      }
+    }
+
     // Parse the workflow into generation parameters.
     let generateRequest: ComfyBridgeGenerateRequest
     do {

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -1,0 +1,254 @@
+// ComfyBridge.swift — ComfyUI protocol bridge for ZImageCLI
+//
+// Makes ZImageCLI's warm server speak ComfyUI's HTTP + WebSocket protocol
+// so the Krita AI Diffusion plugin can connect directly.
+//
+// Phase 1: Discovery endpoints (static responses) + WebSocket skeleton + image cache.
+
+import Foundation
+import Logging
+import Metal
+import Network
+
+/// ComfyUI protocol bridge — translates ComfyUI API calls into ZImageCLI operations.
+///
+/// Phase 1 implements discovery endpoints that satisfy the Krita plugin's connection
+/// handshake and node validation. The bridge is designed as a clean layer that can be
+/// enabled/disabled without affecting the existing `/v1/generate` API.
+final class ComfyBridge {
+  private let logger: Logger
+  let wsManager: ComfyWebSocketManager
+  private let imageCache: ComfyImageCache
+
+  // Lazily built and cached on first request.
+  private var cachedSystemStats: Data?
+  private var cachedObjectInfo: Data?
+
+  init(logger: Logger) {
+    self.logger = logger
+    self.wsManager = ComfyWebSocketManager(logger: logger)
+    self.imageCache = ComfyImageCache(logger: logger)
+  }
+
+  // MARK: - Route Dispatch
+
+  /// Attempt to route a request through the ComfyUI bridge.
+  /// Returns nil if this request is not a ComfyUI endpoint (falls through to WarmServer routes).
+  func route(_ request: HTTPRequest) -> RoutedResponse? {
+    switch (request.method, request.path) {
+
+    case ("GET", "/system_stats"):
+      return handleSystemStats()
+
+    case ("GET", "/object_info"):
+      return handleObjectInfo()
+
+    case ("GET", "/queue"):
+      return handleGetQueue()
+
+    case ("POST", "/queue"):
+      return handlePostQueue()
+
+    case ("POST", "/prompt"):
+      return handlePrompt(request)
+
+    case ("POST", "/interrupt"):
+      return handleInterrupt()
+
+    case ("GET", "/ws"):
+      // WebSocket upgrade is handled separately in ConnectionHandler.
+      // Return websocketUpgrade to signal the router that this path is claimed.
+      return .websocketUpgrade
+
+    default:
+      // Image cache endpoints use path-prefix matching.
+      if request.path.hasPrefix("/api/etn/image/") {
+        let id = String(request.path.dropFirst("/api/etn/image/".count))
+        guard !id.isEmpty else {
+          return .error(.error(status: 400, message: "Missing image ID"))
+        }
+        switch request.method {
+        case "PUT":
+          return handleImagePut(id: id, body: request.body)
+        case "GET":
+          return handleImageGet(id: id)
+        default:
+          return .error(.error(status: 405, message: "Method not allowed"))
+        }
+      }
+
+      // Model info endpoint (placeholder for Phase 2+).
+      if request.path.hasPrefix("/api/etn/model_info/") {
+        return .json(status: 200, payload: EmptyObject())
+      }
+
+      return nil
+    }
+  }
+
+  // MARK: - GET /system_stats
+
+  private func handleSystemStats() -> RoutedResponse {
+    if let cached = cachedSystemStats {
+      return .json(.rawJSON(status: 200, data: cached))
+    }
+
+    let deviceName = queryMetalDeviceName()
+    let totalMemory = ProcessInfo.processInfo.physicalMemory
+
+    // Build the response manually to avoid snake_case encoding of the fields
+    // that ComfyUI expects in their exact casing.
+    let stats: [String: Any] = [
+      "devices": [
+        [
+          "name": deviceName,
+          "type": "mps",
+          "vram_total": totalMemory
+        ]
+      ]
+    ]
+
+    if let data = try? JSONSerialization.data(withJSONObject: stats) {
+      cachedSystemStats = data
+      logger.info("ComfyBridge: /system_stats — \(deviceName), \(totalMemory / (1024*1024*1024))GB")
+      return .json(.rawJSON(status: 200, data: data))
+    }
+
+    return .error(.error(status: 500, message: "Failed to serialize system_stats"))
+  }
+
+  /// Query the Metal device name. Falls back to a sensible default.
+  private func queryMetalDeviceName() -> String {
+    if let device = MTLCreateSystemDefaultDevice() {
+      return device.name
+    }
+    return "Apple Silicon"
+  }
+
+  // MARK: - GET /object_info
+
+  private func handleObjectInfo() -> RoutedResponse {
+    if let cached = cachedObjectInfo {
+      return .json(.rawJSON(status: 200, data: cached))
+    }
+
+    let info = ComfyBridgeObjectInfo.build()
+
+    if let data = try? JSONSerialization.data(withJSONObject: info) {
+      cachedObjectInfo = data
+      logger.info("ComfyBridge: /object_info — \(info.count) nodes declared")
+      return .json(.rawJSON(status: 200, data: data))
+    }
+
+    return .error(.error(status: 500, message: "Failed to serialize object_info"))
+  }
+
+  // MARK: - GET /queue
+
+  private func handleGetQueue() -> RoutedResponse {
+    // Phase 1: always report empty queues.
+    let queue: [String: Any] = [
+      "queue_running": [] as [Any],
+      "queue_pending": [] as [Any]
+    ]
+    if let data = try? JSONSerialization.data(withJSONObject: queue) {
+      return .json(.rawJSON(status: 200, data: data))
+    }
+    return .error(.error(status: 500, message: "Failed to serialize queue"))
+  }
+
+  // MARK: - POST /queue (delete queued jobs)
+
+  private func handlePostQueue() -> RoutedResponse {
+    // Phase 1: acknowledge the delete request, nothing to cancel.
+    return .json(status: 200, payload: EmptyObject())
+  }
+
+  // MARK: - POST /prompt
+
+  private func handlePrompt(_ request: HTTPRequest) -> RoutedResponse {
+    // Phase 1: validate the shape, echo back prompt_id, don't execute.
+    guard let json = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any] else {
+      return .error(.error(status: 400, message: "Invalid JSON body"))
+    }
+
+    guard let promptId = json["prompt_id"] as? String else {
+      return .error(.error(status: 400, message: "Missing prompt_id"))
+    }
+
+    guard json["prompt"] is [String: Any] else {
+      return .error(.error(status: 400, message: "Missing or invalid 'prompt' object"))
+    }
+
+    let clientId = json["client_id"] as? String ?? "unknown"
+    logger.info("ComfyBridge: /prompt received — prompt_id=\(promptId), client_id=\(clientId)")
+
+    // Phase 2 will extract workflow parameters and route to the pipeline.
+    // For now, just acknowledge.
+    let response: [String: Any] = [
+      "prompt_id": promptId
+    ]
+
+    if let data = try? JSONSerialization.data(withJSONObject: response) {
+      return .json(.rawJSON(status: 200, data: data))
+    }
+    return .error(.error(status: 500, message: "Failed to serialize prompt response"))
+  }
+
+  // MARK: - POST /interrupt
+
+  private func handleInterrupt() -> RoutedResponse {
+    // Phase 1: acknowledge, nothing to cancel yet.
+    logger.info("ComfyBridge: /interrupt received (no active job)")
+    return .json(status: 200, payload: EmptyObject())
+  }
+
+  // MARK: - Image Cache
+
+  private func handleImagePut(id: String, body: Data) -> RoutedResponse {
+    guard !body.isEmpty else {
+      return .error(.error(status: 400, message: "Empty image body"))
+    }
+
+    imageCache.store(id: id, data: body)
+    logger.info("ComfyBridge: stored image \(id) (\(body.count) bytes)")
+    return .json(status: 200, payload: EmptyObject())
+  }
+
+  private func handleImageGet(id: String) -> RoutedResponse {
+    guard let data = imageCache.retrieve(id: id) else {
+      return .error(.error(status: 404, message: "Image not found: \(id)"))
+    }
+
+    return .json(.binary(status: 200, contentType: "image/png", data: data))
+  }
+
+  // MARK: - WebSocket Upgrade
+
+  /// Build the HTTP 101 WebSocket upgrade response for a validated request.
+  /// Returns the raw response bytes to send, or nil if the request is not a valid upgrade.
+  func handleWebSocketUpgrade(request: HTTPRequest, connection: NWConnection, queue: DispatchQueue) -> Data? {
+    guard request.headers["upgrade"]?.lowercased() == "websocket",
+          let wsKey = request.headers["sec-websocket-key"] else {
+      return nil
+    }
+
+    let acceptKey = ComfyWebSocketManager.computeAcceptKey(from: wsKey)
+    let response = [
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      "Sec-WebSocket-Accept: \(acceptKey)",
+      "",
+      ""
+    ].joined(separator: "\r\n")
+
+    logger.info("ComfyBridge: WebSocket upgrade for clientId=\(request.queryParameters["clientId"] ?? "unknown")")
+    return Data(response.utf8)
+  }
+}
+
+// MARK: - Helpers
+
+/// Empty JSON object for responses that need `{}`.
+private struct EmptyObject: Encodable {}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
@@ -10,7 +10,12 @@ import Logging
 
 /// Callback type for generating images via the warm server pipeline.
 /// Accepts a ComfyBridgeGenerateRequest and returns the output path + timing.
-typealias ComfyBridgeGenerateHandler = @Sendable (ComfyBridgeGenerateRequest) async throws -> ComfyBridgeGenerateResult
+/// Progress callback sent during generation — maps to WebSocket progress events.
+typealias ComfyBridgeProgressHandler = @Sendable (Int, Int) -> Void  // (stepIndex, totalSteps)
+
+/// Callback type for generating images via the warm server pipeline.
+/// Accepts a request and optional progress callback, returns output path + timing.
+typealias ComfyBridgeGenerateHandler = @Sendable (ComfyBridgeGenerateRequest, ComfyBridgeProgressHandler?) async throws -> ComfyBridgeGenerateResult
 
 /// Manages async generation execution and WebSocket event dispatch.
 final class ComfyBridgeExecutor {
@@ -92,7 +97,23 @@ final class ComfyBridgeExecutor {
 
     // --- Phase 3: run actual generation ---
     do {
-      let result = try await handler(request)
+      // Create a progress callback that sends WebSocket events.
+      let progressCallback: ComfyBridgeProgressHandler = { [wsManager, clientId = request.clientId, promptId = request.promptId] step, total in
+        let event: [String: Any] = [
+          "type": "progress",
+          "data": [
+            "prompt_id": promptId,
+            "value": step,
+            "max": total
+          ] as [String: Any]
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: event),
+           let text = String(data: data, encoding: .utf8) {
+          wsManager.send(to: clientId, text: text)
+        }
+      }
+
+      let result = try await handler(request, progressCallback)
 
       // Read the output image.
       let outputURL = URL(fileURLWithPath: result.outputPath)

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
@@ -1,0 +1,223 @@
+// ComfyBridgeExecutor.swift — Async generation lifecycle for ComfyUI bridge
+//
+// Manages the full lifecycle of a generation request:
+// parse workflow → enqueue via warm server → send WebSocket progress events → store output.
+//
+// Phase 2: txt2img execution with WebSocket event dispatch.
+
+import Foundation
+import Logging
+
+/// Callback type for generating images via the warm server pipeline.
+/// Accepts a ComfyBridgeGenerateRequest and returns the output path + timing.
+typealias ComfyBridgeGenerateHandler = @Sendable (ComfyBridgeGenerateRequest) async throws -> ComfyBridgeGenerateResult
+
+/// Manages async generation execution and WebSocket event dispatch.
+final class ComfyBridgeExecutor {
+  private let logger: Logger
+  private let wsManager: ComfyWebSocketManager
+  private let imageCache: ComfyImageCache
+  let generateHandler: ComfyBridgeGenerateHandler?
+
+  /// Active prompt being executed, if any.
+  private let lock = NSLock()
+  private var activePromptId: String?
+
+  init(
+    logger: Logger,
+    wsManager: ComfyWebSocketManager,
+    imageCache: ComfyImageCache,
+    generateHandler: ComfyBridgeGenerateHandler?
+  ) {
+    self.logger = logger
+    self.wsManager = wsManager
+    self.imageCache = imageCache
+    self.generateHandler = generateHandler
+  }
+
+  /// Whether a generation is currently in progress.
+  var isExecuting: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return activePromptId != nil
+  }
+
+  /// Execute a parsed generation request asynchronously.
+  /// Sends the full sequence of ComfyUI WebSocket events during execution.
+  func execute(_ request: ComfyBridgeGenerateRequest) async {
+    guard let handler = generateHandler else {
+      logger.error("ComfyBridge: no generate handler configured — generation disabled")
+      sendError(promptId: request.promptId, clientId: request.clientId,
+                message: "Generation not configured on this server")
+      return
+    }
+
+    lock.lock()
+    activePromptId = request.promptId
+    lock.unlock()
+
+    defer {
+      lock.lock()
+      activePromptId = nil
+      lock.unlock()
+    }
+
+    let promptPreview = request.prompt.count > 80
+      ? String(request.prompt.prefix(77)) + "..."
+      : request.prompt
+    logger.info("ComfyBridge: executing prompt_id=\(request.promptId) — \(request.width)x\(request.height), \(request.steps) steps, cfg=\(request.guidance)")
+    logger.info("ComfyBridge: prompt — \"\(promptPreview)\"")
+
+    // --- Phase 1: execution_start ---
+    sendEvent(to: request.clientId, type: "execution_start", data: [
+      "prompt_id": request.promptId
+    ])
+
+    // --- Phase 2: simulate node progression for loader nodes ---
+    // Send executing events for the early nodes (model loading, text encoding).
+    // These complete instantly since the model is already warm.
+    let loaderNodes = ["1", "2", "3", "4", "5", "6"]
+    for nodeId in loaderNodes {
+      sendEvent(to: request.clientId, type: "execution_cached", data: [
+        "prompt_id": request.promptId,
+        "nodes": [nodeId]
+      ])
+    }
+
+    // The sampler node is where actual work happens.
+    sendEvent(to: request.clientId, type: "executing", data: [
+      "prompt_id": request.promptId,
+      "node": "11"  // SamplerCustomAdvanced
+    ])
+
+    // --- Phase 3: run actual generation ---
+    do {
+      let result = try await handler(request)
+
+      // Read the output image.
+      let outputURL = URL(fileURLWithPath: result.outputPath)
+      guard let imageData = try? Data(contentsOf: outputURL) else {
+        logger.error("ComfyBridge: failed to read output at \(result.outputPath)")
+        sendError(promptId: request.promptId, clientId: request.clientId,
+                  message: "Failed to read generated image")
+        return
+      }
+
+      // Store in the image cache.
+      let imageId = UUID().uuidString
+      guard imageCache.store(id: imageId, data: imageData) else {
+        logger.error("ComfyBridge: failed to cache output image \(imageId)")
+        sendError(promptId: request.promptId, clientId: request.clientId,
+                  message: "Failed to cache generated image")
+        return
+      }
+
+      // --- Phase 4: send output events ---
+
+      // Mark the output node as executing.
+      sendEvent(to: request.clientId, type: "executing", data: [
+        "prompt_id": request.promptId,
+        "node": request.outputNodeId
+      ])
+
+      // Send the executed event with the image reference.
+      sendExecutedEvent(
+        to: request.clientId,
+        promptId: request.promptId,
+        nodeId: request.outputNodeId,
+        imageId: imageId
+      )
+
+      // Workflow complete — node=null signals done.
+      sendExecutingDone(to: request.clientId, promptId: request.promptId)
+
+      logger.info("ComfyBridge: generation complete — prompt_id=\(request.promptId), \(result.durationMs)ms, image=\(imageId) (\(imageData.count) bytes)")
+
+      // Clean up the temp file — the image is now in the cache.
+      try? FileManager.default.removeItem(at: outputURL)
+
+    } catch {
+      logger.error("ComfyBridge: generation failed — prompt_id=\(request.promptId): \(error)")
+      sendError(promptId: request.promptId, clientId: request.clientId,
+                message: error.localizedDescription)
+    }
+  }
+
+  /// Interrupt the active generation.
+  /// Returns true if there was an active prompt to interrupt.
+  func interrupt() -> Bool {
+    lock.lock()
+    let active = activePromptId
+    lock.unlock()
+
+    guard let promptId = active else { return false }
+
+    wsManager.broadcast(text: jsonString([
+      "type": "execution_interrupted",
+      "data": ["prompt_id": promptId]
+    ]))
+
+    logger.info("ComfyBridge: interrupted prompt_id=\(promptId)")
+    return true
+  }
+
+  // MARK: - WebSocket Event Helpers
+
+  private func sendEvent(to clientId: String, type: String, data: [String: Any]) {
+    let event: [String: Any] = ["type": type, "data": data]
+    let text = jsonString(event)
+    wsManager.send(to: clientId, text: text)
+  }
+
+  private func sendExecutedEvent(to clientId: String, promptId: String, nodeId: String, imageId: String) {
+    let event: [String: Any] = [
+      "type": "executed",
+      "data": [
+        "prompt_id": promptId,
+        "node": nodeId,
+        "output": [
+          "images": [
+            ["source": "http", "id": imageId]
+          ]
+        ]
+      ] as [String: Any]
+    ]
+    wsManager.send(to: clientId, text: jsonString(event))
+  }
+
+  private func sendExecutingDone(to clientId: String, promptId: String) {
+    // node: null signals workflow completion.
+    // JSONSerialization renders NSNull() as JSON null.
+    let event: [String: Any] = [
+      "type": "executing",
+      "data": [
+        "prompt_id": promptId,
+        "node": NSNull()
+      ] as [String: Any]
+    ]
+    wsManager.send(to: clientId, text: jsonString(event))
+  }
+
+  private func sendError(promptId: String, clientId: String, message: String) {
+    let event: [String: Any] = [
+      "type": "execution_error",
+      "data": [
+        "prompt_id": promptId,
+        "exception_message": message,
+        "traceback": [] as [String]
+      ] as [String: Any]
+    ]
+    wsManager.send(to: clientId, text: jsonString(event))
+
+    // Also send executing-done so the plugin cleans up the prompt state.
+    sendExecutingDone(to: clientId, promptId: promptId)
+  }
+
+  private func jsonString(_ dict: [String: Any]) -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: dict),
+          let str = String(data: data, encoding: .utf8) else {
+      return "{}"
+    }
+    return str
+  }
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
@@ -67,10 +67,34 @@ final class ComfyBridgeExecutor {
       lock.unlock()
     }
 
-    let promptPreview = request.prompt.count > 80
-      ? String(request.prompt.prefix(77)) + "..."
-      : request.prompt
-    logger.info("ComfyBridge: executing prompt_id=\(request.promptId) — \(request.width)x\(request.height), \(request.steps) steps, cfg=\(request.guidance)")
+    // --- Load inpaint images from cache if this is an inpaint request ---
+    var mutableRequest = request
+    if let imageId = request.inpaintImageId {
+      guard let imageData = imageCache.retrieve(id: imageId) else {
+        logger.error("ComfyBridge: inpaint image not found in cache: \(imageId)")
+        sendError(promptId: request.promptId, clientId: request.clientId,
+                  message: "Inpaint image not found: \(imageId)")
+        return
+      }
+      mutableRequest.inpaintImageData = imageData
+      logger.info("ComfyBridge: loaded inpaint image \(imageId) (\(imageData.count) bytes)")
+    }
+    if let maskId = request.maskImageId {
+      guard let maskData = imageCache.retrieve(id: maskId) else {
+        logger.error("ComfyBridge: mask image not found in cache: \(maskId)")
+        sendError(promptId: request.promptId, clientId: request.clientId,
+                  message: "Mask image not found: \(maskId)")
+        return
+      }
+      mutableRequest.maskImageData = maskData
+      logger.info("ComfyBridge: loaded mask image \(maskId) (\(maskData.count) bytes)")
+    }
+
+    let promptPreview = mutableRequest.prompt.count > 80
+      ? String(mutableRequest.prompt.prefix(77)) + "..."
+      : mutableRequest.prompt
+    let modeLabel = mutableRequest.isInpaint ? "inpaint" : "txt2img"
+    logger.info("ComfyBridge: executing \(modeLabel) prompt_id=\(mutableRequest.promptId) — \(mutableRequest.width)x\(mutableRequest.height), \(mutableRequest.steps) steps, denoise=\(mutableRequest.denoise)")
     logger.info("ComfyBridge: prompt — \"\(promptPreview)\"")
 
     // --- Phase 1: execution_start ---
@@ -113,7 +137,7 @@ final class ComfyBridgeExecutor {
         }
       }
 
-      let result = try await handler(request, progressCallback)
+      let result = try await handler(mutableRequest, progressCallback)
 
       // Read the output image.
       let outputURL = URL(fileURLWithPath: result.outputPath)

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeExecutor.swift
@@ -89,11 +89,21 @@ final class ComfyBridgeExecutor {
       mutableRequest.maskImageData = maskData
       logger.info("ComfyBridge: loaded mask image \(maskId) (\(maskData.count) bytes)")
     }
+    if let controlImageId = request.controlImageId {
+      guard let controlData = imageCache.retrieve(id: controlImageId) else {
+        logger.error("ComfyBridge: control image not found in cache: \(controlImageId)")
+        sendError(promptId: request.promptId, clientId: request.clientId,
+                  message: "Control image not found: \(controlImageId)")
+        return
+      }
+      mutableRequest.controlImageData = controlData
+      logger.info("ComfyBridge: loaded control image \(controlImageId) (\(controlData.count) bytes)")
+    }
 
     let promptPreview = mutableRequest.prompt.count > 80
       ? String(mutableRequest.prompt.prefix(77)) + "..."
       : mutableRequest.prompt
-    let modeLabel = mutableRequest.isInpaint ? "inpaint" : "txt2img"
+    let modeLabel = mutableRequest.isControlNet ? "controlnet" : (mutableRequest.isInpaint ? "inpaint" : "txt2img")
     logger.info("ComfyBridge: executing \(modeLabel) prompt_id=\(mutableRequest.promptId) — \(mutableRequest.width)x\(mutableRequest.height), \(mutableRequest.steps) steps, denoise=\(mutableRequest.denoise)")
     logger.info("ComfyBridge: prompt — \"\(promptPreview)\"")
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeImageCache.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeImageCache.swift
@@ -4,7 +4,7 @@
 // via GET /api/etn/image/<id>. Images are keyed by their CRC32 hash ID
 // (computed by the Krita plugin from the PNG data).
 //
-// Uses a temp directory with automatic cleanup on dealloc.
+// Uses a temp directory. The directory is cleaned up in deinit and via cleanup().
 
 import Foundation
 import Logging
@@ -16,6 +16,9 @@ final class ComfyImageCache {
   private let lock = NSLock()
   /// In-memory index of stored image IDs for fast existence checks.
   private var storedIds: Set<String> = []
+
+  /// Maximum number of cached images before oldest entries are evicted.
+  private static let maxCacheEntries = 256
 
   init(logger: Logger) {
     self.logger = logger
@@ -34,16 +37,30 @@ final class ComfyImageCache {
     logger.info("ComfyImageCache: using \(tempBase.path)")
   }
 
+  deinit {
+    cleanupDirectory()
+  }
+
   /// Store image data with the given ID. Overwrites any existing image with the same ID.
-  func store(id: String, data: Data) {
+  /// Returns true on success, false if the write failed.
+  @discardableResult
+  func store(id: String, data: Data) -> Bool {
     let url = fileURL(for: id)
     do {
       try data.write(to: url, options: .atomic)
       lock.lock()
       storedIds.insert(id)
+      let count = storedIds.count
       lock.unlock()
+
+      // Evict oldest files if cache is over the size limit.
+      if count > Self.maxCacheEntries {
+        evictOldest()
+      }
+      return true
     } catch {
       logger.error("ComfyImageCache: failed to write image \(id): \(error)")
+      return false
     }
   }
 
@@ -96,6 +113,12 @@ final class ComfyImageCache {
     return storedIds.count
   }
 
+  /// Explicitly clean up all cached files and the temp directory.
+  func cleanup() {
+    clear()
+    cleanupDirectory()
+  }
+
   // MARK: - Helpers
 
   private func fileURL(for id: String) -> URL {
@@ -103,5 +126,41 @@ final class ComfyImageCache {
     let safeId = id.replacingOccurrences(of: "/", with: "_")
       .replacingOccurrences(of: "..", with: "_")
     return cacheDirectory.appendingPathComponent(safeId)
+  }
+
+  /// Remove the oldest files when the cache exceeds maxCacheEntries.
+  private func evictOldest() {
+    let fm = FileManager.default
+    guard let files = try? fm.contentsOfDirectory(
+      at: cacheDirectory,
+      includingPropertiesForKeys: [.contentModificationDateKey],
+      options: .skipsHiddenFiles
+    ) else { return }
+
+    // Sort by modification date ascending (oldest first).
+    let sorted = files.compactMap { url -> (URL, Date)? in
+      guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+            let date = values.contentModificationDate else { return nil }
+      return (url, date)
+    }.sorted { $0.1 < $1.1 }
+
+    let toRemove = sorted.count - Self.maxCacheEntries
+    guard toRemove > 0 else { return }
+
+    lock.lock()
+    for i in 0..<toRemove {
+      let url = sorted[i].0
+      let id = url.lastPathComponent
+      storedIds.remove(id)
+      try? fm.removeItem(at: url)
+    }
+    lock.unlock()
+
+    logger.info("ComfyImageCache: evicted \(toRemove) oldest images")
+  }
+
+  /// Remove the temp directory and all contents.
+  private func cleanupDirectory() {
+    try? FileManager.default.removeItem(at: cacheDirectory)
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeImageCache.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeImageCache.swift
@@ -1,0 +1,107 @@
+// ComfyBridgeImageCache.swift — Temporary image storage for ComfyUI bridge
+//
+// Stores images uploaded via PUT /api/etn/image/<id> and serves them back
+// via GET /api/etn/image/<id>. Images are keyed by their CRC32 hash ID
+// (computed by the Krita plugin from the PNG data).
+//
+// Uses a temp directory with automatic cleanup on dealloc.
+
+import Foundation
+import Logging
+
+/// Thread-safe temporary image storage for the ComfyUI ETN image transfer protocol.
+final class ComfyImageCache {
+  private let logger: Logger
+  private let cacheDirectory: URL
+  private let lock = NSLock()
+  /// In-memory index of stored image IDs for fast existence checks.
+  private var storedIds: Set<String> = []
+
+  init(logger: Logger) {
+    self.logger = logger
+
+    // Create a dedicated temp directory for bridge images.
+    let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("zimage-comfybridge", isDirectory: true)
+
+    do {
+      try FileManager.default.createDirectory(at: tempBase, withIntermediateDirectories: true)
+    } catch {
+      logger.error("ComfyImageCache: failed to create cache directory: \(error)")
+    }
+
+    self.cacheDirectory = tempBase
+    logger.info("ComfyImageCache: using \(tempBase.path)")
+  }
+
+  /// Store image data with the given ID. Overwrites any existing image with the same ID.
+  func store(id: String, data: Data) {
+    let url = fileURL(for: id)
+    do {
+      try data.write(to: url, options: .atomic)
+      lock.lock()
+      storedIds.insert(id)
+      lock.unlock()
+    } catch {
+      logger.error("ComfyImageCache: failed to write image \(id): \(error)")
+    }
+  }
+
+  /// Retrieve image data by ID. Returns nil if not found.
+  func retrieve(id: String) -> Data? {
+    lock.lock()
+    let exists = storedIds.contains(id)
+    lock.unlock()
+
+    guard exists else { return nil }
+
+    let url = fileURL(for: id)
+    return try? Data(contentsOf: url)
+  }
+
+  /// Check whether an image with the given ID exists in the cache.
+  func contains(id: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedIds.contains(id)
+  }
+
+  /// Remove a specific image from the cache.
+  func remove(id: String) {
+    lock.lock()
+    storedIds.remove(id)
+    lock.unlock()
+
+    let url = fileURL(for: id)
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  /// Remove all cached images.
+  func clear() {
+    lock.lock()
+    let ids = storedIds
+    storedIds.removeAll()
+    lock.unlock()
+
+    for id in ids {
+      try? FileManager.default.removeItem(at: fileURL(for: id))
+    }
+    logger.info("ComfyImageCache: cleared \(ids.count) images")
+  }
+
+  /// Number of cached images.
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedIds.count
+  }
+
+  // MARK: - Helpers
+
+  private func fileURL(for id: String) -> URL {
+    // Sanitize the ID to prevent path traversal.
+    let safeId = id.replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "..", with: "_")
+    return cacheDirectory.appendingPathComponent(safeId)
+  }
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
@@ -1,0 +1,49 @@
+// ComfyBridgeModelInfo.swift — Model metadata for /api/etn/model_info endpoint
+//
+// Returns model classification data that the Krita AI Diffusion plugin uses
+// to determine which architectures (workloads) are available.
+
+import Foundation
+
+/// Provides model metadata for the `/api/etn/model_info/{folder}` endpoint.
+enum ComfyBridgeModelInfo {
+
+  /// Return model metadata for the given folder name.
+  /// Folders: "checkpoints", "diffusion_models", "unet", "unet_gguf"
+  static func models(for folder: String) -> [String: Any] {
+    switch folder {
+    case "checkpoints":
+      // We don't use checkpoint format — Z-Image uses diffusion_models.
+      return [:]
+
+    case "diffusion_models", "unet":
+      return [
+        "z-image-turbo-bf16": [
+          "base_model": "zimage",
+          "type": "eps",
+          "is_inpaint": false,
+          "quant": "none",
+        ] as [String: Any],
+        "z-image-turbo-q8": [
+          "base_model": "zimage",
+          "type": "eps",
+          "is_inpaint": false,
+          "quant": "q8",
+        ] as [String: Any],
+        "z-image-turbo-q4": [
+          "base_model": "zimage",
+          "type": "eps",
+          "is_inpaint": false,
+          "quant": "q4",
+        ] as [String: Any],
+      ]
+
+    case "unet_gguf":
+      // No GGUF models — feature is disabled in our bridge.
+      return [:]
+
+    default:
+      return [:]
+    }
+  }
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -1,0 +1,435 @@
+// ComfyBridgeObjectInfo.swift — Static /object_info response for ComfyUI bridge
+//
+// Declares all node types that the Krita AI Diffusion plugin checks for during
+// connection validation. Each node has the minimum input/output schema the plugin
+// expects. Model discovery nodes return option lists with our available models.
+
+import Foundation
+
+/// Builds the complete `/object_info` response dictionary.
+///
+/// The Krita plugin calls `_check_for_missing_nodes` against `required_custom_nodes`
+/// in resources.py. Every node listed here must appear in the response or the plugin
+/// will refuse to connect.
+enum ComfyBridgeObjectInfo {
+
+  /// Build the full object_info dictionary. All keys are node class_type names.
+  static func build() -> [String: Any] {
+    var info: [String: Any] = [:]
+
+    // --- comfyui-tooling-nodes (required) ---
+    info["ETN_LoadImageCache"] = nodeDefinition(
+      required: ["id": stringInput()],
+      outputs: ["IMAGE", "MASK"]
+    )
+    info["ETN_SaveImageCache"] = nodeDefinition(
+      required: [
+        "images": imageInput(),
+        "format": optionInput(["PNG", "JPEG", "WEBP"]),
+      ],
+      optional: ["id": stringInput()],
+      outputs: []
+    )
+    info["ETN_Translate"] = nodeDefinition(
+      required: [
+        "text": stringInput(),
+        "source_language": stringInput(),
+        "target_language": stringInput(),
+      ],
+      outputs: ["STRING"]
+    )
+
+    // --- comfyui-inpaint-nodes (required) ---
+    info["INPAINT_LoadFooocusInpaint"] = nodeDefinition(
+      required: [
+        "head": stringInput(),
+        "patch": stringInput(),
+      ],
+      outputs: ["INPAINT_PATCH"]
+    )
+    info["INPAINT_ShrinkMask"] = nodeDefinition(
+      required: [
+        "mask": maskInput(),
+        "shrink": intInput(default: 4),
+      ],
+      outputs: ["MASK"]
+    )
+    info["INPAINT_StabilizeMask"] = nodeDefinition(
+      required: [
+        "mask": maskInput(),
+        "threshold": floatInput(default: 0.5),
+      ],
+      outputs: ["MASK"]
+    )
+    info["INPAINT_ColorMatch"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "reference": imageInput(),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["INPAINT_ExpandMask"] = nodeDefinition(
+      required: [
+        "mask": maskInput(),
+        "grow": intInput(default: 16),
+        "feather": intInput(default: 8),
+      ],
+      outputs: ["MASK"]
+    )
+    info["INPAINT_MaskedBlur"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "mask": maskInput(),
+        "blur_radius": intInput(default: 32),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["INPAINT_VAEEncodeInpaintConditioning"] = nodeDefinition(
+      required: [
+        "vae": vaeInput(),
+        "image": imageInput(),
+        "mask": maskInput(),
+      ],
+      outputs: ["LATENT", "LATENT"]
+    )
+
+    // --- comfyui_controlnet_aux (required) ---
+    info["InpaintPreprocessor"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "mask": maskInput(),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["DepthAnythingV2Preprocessor"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+      ],
+      optional: [
+        "resolution": intInput(default: 512),
+      ],
+      outputs: ["IMAGE"]
+    )
+
+    // --- ComfyUI_IPAdapter_plus (required) ---
+    info["IPAdapterModelLoader"] = nodeDefinition(
+      required: [
+        "ipadapter_file": stringInput(),
+      ],
+      outputs: ["IPADAPTER"]
+    )
+    info["IPAdapter"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "ipadapter": stringInput(),
+        "image": imageInput(),
+      ],
+      optional: [
+        "weight": floatInput(default: 1.0),
+      ],
+      outputs: ["MODEL"]
+    )
+
+    // --- Core ComfyUI nodes (model loading) ---
+    info["UNETLoader"] = nodeDefinition(
+      required: [
+        "unet_name": optionInput(zimageUnetModels()),
+        "weight_dtype": optionInput(["default", "fp8_e4m3fn", "fp8_e5m2"]),
+      ],
+      outputs: ["MODEL"]
+    )
+    info["CLIPLoader"] = nodeDefinition(
+      required: [
+        "clip_name": optionInput(zimageClipModels()),
+        "type": optionInput(["stable_diffusion", "stable_cascade", "sd3", "stable_audio", "lumina2"]),
+      ],
+      outputs: ["CLIP"]
+    )
+    info["DualCLIPLoader"] = nodeDefinition(
+      required: [
+        "clip_name1": optionInput(zimageClipModels()),
+        "clip_name2": optionInput(zimageClipModels()),
+        "type": optionInput(["sdxl", "sd3", "flux", "hunyuan_video"]),
+      ],
+      outputs: ["CLIP"]
+    )
+    info["DualCLIPLoaderGGUF"] = nodeDefinition(
+      required: [
+        "clip_name1": optionInput(zimageClipModels()),
+        "clip_name2": optionInput(zimageClipModels()),
+        "type": optionInput(["sdxl", "sd3", "flux", "hunyuan_video"]),
+      ],
+      outputs: ["CLIP"]
+    )
+    info["VAELoader"] = nodeDefinition(
+      required: [
+        "vae_name": optionInput(zimageVaeModels()),
+      ],
+      outputs: ["VAE"]
+    )
+    info["ControlNetLoader"] = nodeDefinition(
+      required: [
+        "control_net_name": optionInput(zimageControlnetModels()),
+      ],
+      outputs: ["CONTROL_NET"]
+    )
+    info["UpscaleModelLoader"] = nodeDefinition(
+      required: [
+        "model_name": optionInput(zimageUpscaleModels()),
+      ],
+      outputs: ["UPSCALE_MODEL"]
+    )
+
+    // --- Z-Image custom nodes ---
+    info["NunchakuZImageDiTLoader"] = nodeDefinition(
+      required: [
+        "unet_name": optionInput(zimageUnetModels()),
+      ],
+      outputs: ["MODEL"]
+    )
+    info["ModelPatchLoader"] = nodeDefinition(
+      required: [
+        "name": optionInput(zimageControlnetPatchModels()),
+      ],
+      outputs: ["MODEL_PATCH"]
+    )
+    info["ZImageFunControlnet"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "model_patch": stringInput(),
+        "inpaint_image": imageInput(),
+        "mask": maskInput(),
+        "vae": vaeInput(),
+      ],
+      optional: [
+        "strength": floatInput(default: 0.5),
+        "start": floatInput(default: 0.0),
+        "end": floatInput(default: 1.0),
+      ],
+      outputs: ["MODEL"]
+    )
+
+    // --- Core ComfyUI nodes (pipeline) ---
+    info["CLIPTextEncode"] = nodeDefinition(
+      required: [
+        "text": stringInput(),
+        "clip": clipInput(),
+      ],
+      outputs: ["CONDITIONING"]
+    )
+    info["EmptySD3LatentImage"] = nodeDefinition(
+      required: [
+        "width": intInput(default: 1024),
+        "height": intInput(default: 1024),
+        "batch_size": intInput(default: 1),
+      ],
+      outputs: ["LATENT"]
+    )
+    info["SamplerCustomAdvanced"] = nodeDefinition(
+      required: [
+        "noise": noiseInput(),
+        "guider": guiderInput(),
+        "sampler": samplerInput(),
+        "sigmas": sigmasInput(),
+        "latent_image": latentInput(),
+      ],
+      outputs: ["LATENT", "LATENT"]
+    )
+    info["VAEDecode"] = nodeDefinition(
+      required: [
+        "samples": latentInput(),
+        "vae": vaeInput(),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["VAEEncode"] = nodeDefinition(
+      required: [
+        "pixels": imageInput(),
+        "vae": vaeInput(),
+      ],
+      outputs: ["LATENT"]
+    )
+
+    // --- Sampling helper nodes ---
+    info["BasicGuider"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "conditioning": conditioningInput(),
+      ],
+      outputs: ["GUIDER"]
+    )
+    info["CFGGuider"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "positive": conditioningInput(),
+        "negative": conditioningInput(),
+        "cfg": floatInput(default: 1.0),
+      ],
+      outputs: ["GUIDER"]
+    )
+    info["BasicScheduler"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "scheduler": optionInput(["normal", "karras", "exponential", "sgm_uniform", "simple", "ddim_uniform", "beta"]),
+        "steps": intInput(default: 9),
+        "denoise": floatInput(default: 1.0),
+      ],
+      outputs: ["SIGMAS"]
+    )
+    info["KSamplerSelect"] = nodeDefinition(
+      required: [
+        "sampler_name": optionInput(["euler", "heun", "dpmpp_2m", "dpmpp_2s_ancestral", "deis", "ddim", "uni_pc"]),
+      ],
+      outputs: ["SAMPLER"]
+    )
+    info["RandomNoise"] = nodeDefinition(
+      required: [
+        "noise_seed": intInput(default: 0),
+      ],
+      outputs: ["NOISE"]
+    )
+    info["SetLatentNoiseMask"] = nodeDefinition(
+      required: [
+        "samples": latentInput(),
+        "mask": maskInput(),
+      ],
+      outputs: ["LATENT"]
+    )
+    info["DifferentialDiffusion"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+      ],
+      outputs: ["MODEL"]
+    )
+
+    // --- Image utility nodes ---
+    info["ETN_ApplyMaskToImage"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "mask": maskInput(),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["ImageScale"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "upscale_method": optionInput(["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]),
+        "width": intInput(default: 1024),
+        "height": intInput(default: 1024),
+        "crop": optionInput(["disabled", "center"]),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["ImageUpscaleWithModel"] = nodeDefinition(
+      required: [
+        "upscale_model": stringInput(),
+        "image": imageInput(),
+      ],
+      outputs: ["IMAGE"]
+    )
+
+    return info
+  }
+
+  // MARK: - Node Definition Helpers
+
+  /// Build a standard node definition dict matching ComfyUI's schema.
+  private static func nodeDefinition(
+    required: [String: Any],
+    optional: [String: Any] = [:],
+    outputs: [String]
+  ) -> [String: Any] {
+    var input: [String: Any] = ["required": required]
+    if !optional.isEmpty {
+      input["optional"] = optional
+    }
+    return [
+      "input": input,
+      "output_name": outputs
+    ]
+  }
+
+  // MARK: - Input Type Helpers
+
+  /// String input: ["STRING", {}]
+  private static func stringInput() -> [Any] {
+    return ["STRING", [:] as [String: Any]]
+  }
+
+  /// Integer input with default: ["INT", {"default": N}]
+  private static func intInput(default value: Int) -> [Any] {
+    return ["INT", ["default": value] as [String: Any]]
+  }
+
+  /// Float input with default: ["FLOAT", {"default": N}]
+  private static func floatInput(default value: Float) -> [Any] {
+    return ["FLOAT", ["default": value] as [String: Any]]
+  }
+
+  /// Dropdown/option input: [["option1", "option2", ...]]
+  private static func optionInput(_ options: [String]) -> [Any] {
+    return [options]
+  }
+
+  /// Typed connector inputs.
+  private static func imageInput() -> [Any] { return ["IMAGE"] }
+  private static func maskInput() -> [Any] { return ["MASK"] }
+  private static func modelInput() -> [Any] { return ["MODEL"] }
+  private static func vaeInput() -> [Any] { return ["VAE"] }
+  private static func clipInput() -> [Any] { return ["CLIP"] }
+  private static func latentInput() -> [Any] { return ["LATENT"] }
+  private static func conditioningInput() -> [Any] { return ["CONDITIONING"] }
+  private static func noiseInput() -> [Any] { return ["NOISE"] }
+  private static func guiderInput() -> [Any] { return ["GUIDER"] }
+  private static func samplerInput() -> [Any] { return ["SAMPLER"] }
+  private static func sigmasInput() -> [Any] { return ["SIGMAS"] }
+
+  // MARK: - Model Discovery
+
+  // These return the model options that the Krita plugin will see when it queries
+  // available models. For Phase 1 we declare the known Z-Image model names.
+  // Phase 2+ can scan the filesystem for actually available models.
+
+  private static func zimageUnetModels() -> [String] {
+    [
+      "z-image-turbo",
+      "z-image-turbo-q8",
+      "z-image-turbo-q4",
+    ]
+  }
+
+  private static func zimageClipModels() -> [String] {
+    [
+      "qwen_3_4b",
+      "qwen_3_4b_q8",
+    ]
+  }
+
+  private static func zimageVaeModels() -> [String] {
+    [
+      "z-image-vae",
+      "flux-vae",
+    ]
+  }
+
+  private static func zimageControlnetModels() -> [String] {
+    [
+      "z-image-turbo-fun-controlnet-union-2.1",
+      "z-image-turbo-fun-controlnet-tile-2.1",
+    ]
+  }
+
+  private static func zimageControlnetPatchModels() -> [String] {
+    [
+      "z-image-turbo-fun-controlnet-union-2.1",
+      "z-image-turbo-fun-controlnet-tile-2.1",
+    ]
+  }
+
+  private static func zimageUpscaleModels() -> [String] {
+    [
+      "4x-UltraSharp",
+      "RealESRGAN_x4",
+    ]
+  }
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -121,7 +121,7 @@ enum ComfyBridgeObjectInfo {
     info["IPAdapter"] = nodeDefinition(
       required: [
         "model": modelInput(),
-        "ipadapter": stringInput(),
+        "ipadapter": ipadapterInput(),
         "image": imageInput(),
       ],
       optional: [
@@ -183,7 +183,12 @@ enum ComfyBridgeObjectInfo {
     // --- Z-Image custom nodes ---
     info["NunchakuZImageDiTLoader"] = nodeDefinition(
       required: [
-        "unet_name": optionInput(zimageUnetModels()),
+        "model_name": optionInput(zimageUnetModels()),
+      ],
+      optional: [
+        "cpu_offload": optionInput(["disable", "enable"]),
+        "num_blocks_on_gpu": intInput(default: 0),
+        "use_pin_memory": optionInput(["disable", "enable"]),
       ],
       outputs: ["MODEL"]
     )
@@ -196,7 +201,7 @@ enum ComfyBridgeObjectInfo {
     info["ZImageFunControlnet"] = nodeDefinition(
       required: [
         "model": modelInput(),
-        "model_patch": stringInput(),
+        "model_patch": modelPatchInput(),
         "inpaint_image": imageInput(),
         "mask": maskInput(),
         "vae": vaeInput(),
@@ -302,6 +307,38 @@ enum ComfyBridgeObjectInfo {
       outputs: ["MODEL"]
     )
 
+    // --- Additional loader nodes (probed by Krita during connect/resource discovery) ---
+    info["CLIPVisionLoader"] = nodeDefinition(
+      required: [:],
+      optional: [
+        "clip_name": optionInput(zimageClipVisionModels()),
+      ],
+      outputs: ["CLIP_VISION"]
+    )
+    info["StyleModelLoader"] = nodeDefinition(
+      required: [:],
+      optional: [
+        "style_model_name": optionInput(zimageStyleModels()),
+      ],
+      outputs: ["STYLE_MODEL"]
+    )
+    info["LoraLoader"] = nodeDefinition(
+      required: [
+        "model": modelInput(),
+        "clip": clipInput(),
+        "lora_name": optionInput(zimageLoraModels()),
+        "strength_model": floatInput(default: 1.0),
+        "strength_clip": floatInput(default: 1.0),
+      ],
+      outputs: ["MODEL", "CLIP"]
+    )
+    info["INPAINT_LoadInpaintModel"] = nodeDefinition(
+      required: [
+        "model_name": stringInput(),
+      ],
+      outputs: ["INPAINT_MODEL"]
+    )
+
     // --- Image utility nodes ---
     info["ETN_ApplyMaskToImage"] = nodeDefinition(
       required: [
@@ -322,7 +359,7 @@ enum ComfyBridgeObjectInfo {
     )
     info["ImageUpscaleWithModel"] = nodeDefinition(
       required: [
-        "upscale_model": stringInput(),
+        "upscale_model": upscaleModelInput(),
         "image": imageInput(),
       ],
       outputs: ["IMAGE"]
@@ -383,6 +420,9 @@ enum ComfyBridgeObjectInfo {
   private static func guiderInput() -> [Any] { return ["GUIDER"] }
   private static func samplerInput() -> [Any] { return ["SAMPLER"] }
   private static func sigmasInput() -> [Any] { return ["SIGMAS"] }
+  private static func ipadapterInput() -> [Any] { return ["IPADAPTER"] }
+  private static func modelPatchInput() -> [Any] { return ["MODEL_PATCH"] }
+  private static func upscaleModelInput() -> [Any] { return ["UPSCALE_MODEL"] }
 
   // MARK: - Model Discovery
 
@@ -431,5 +471,22 @@ enum ComfyBridgeObjectInfo {
       "4x-UltraSharp",
       "RealESRGAN_x4",
     ]
+  }
+
+  private static func zimageClipVisionModels() -> [String] {
+    [
+      "clip-vit-large-patch14",
+    ]
+  }
+
+  private static func zimageStyleModels() -> [String] {
+    [
+      "style-model-default",
+    ]
+  }
+
+  private static func zimageLoraModels() -> [String] {
+    // Phase 2+ can scan the filesystem for available LoRA files.
+    []
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -114,7 +114,7 @@ enum ComfyBridgeObjectInfo {
     // --- ComfyUI_IPAdapter_plus (required) ---
     info["IPAdapterModelLoader"] = nodeDefinition(
       required: [
-        "ipadapter_file": stringInput(),
+        "ipadapter_file": optionInput(["ip-adapter_sd15.safetensors", "ip-adapter-plus_sdxl_vit-h.safetensors"]),
       ],
       outputs: ["IPADAPTER"]
     )
@@ -309,15 +309,13 @@ enum ComfyBridgeObjectInfo {
 
     // --- Additional loader nodes (probed by Krita during connect/resource discovery) ---
     info["CLIPVisionLoader"] = nodeDefinition(
-      required: [:],
-      optional: [
+      required: [
         "clip_name": optionInput(zimageClipVisionModels()),
       ],
       outputs: ["CLIP_VISION"]
     )
     info["StyleModelLoader"] = nodeDefinition(
-      required: [:],
-      optional: [
+      required: [
         "style_model_name": optionInput(zimageStyleModels()),
       ],
       outputs: ["STYLE_MODEL"]
@@ -334,7 +332,7 @@ enum ComfyBridgeObjectInfo {
     )
     info["INPAINT_LoadInpaintModel"] = nodeDefinition(
       required: [
-        "model_name": stringInput(),
+        "model_name": optionInput(zimageInpaintModels()),
       ],
       outputs: ["INPAINT_MODEL"]
     )
@@ -363,6 +361,22 @@ enum ComfyBridgeObjectInfo {
         "image": imageInput(),
       ],
       outputs: ["IMAGE"]
+    )
+
+    // --- Checkpoint loader (fallback model discovery) ---
+    info["CheckpointLoaderSimple"] = nodeDefinition(
+      required: [
+        "ckpt_name": optionInput(zimageUnetModels()),
+      ],
+      outputs: ["MODEL", "CLIP", "VAE"]
+    )
+
+    // --- Additional diffusion model loader ---
+    info["UnetLoaderGGUF"] = nodeDefinition(
+      required: [
+        "unet_name": optionInput([]),
+      ],
+      outputs: ["MODEL"]
     )
 
     return info
@@ -433,6 +447,7 @@ enum ComfyBridgeObjectInfo {
   private static func zimageUnetModels() -> [String] {
     [
       "z-image-turbo",
+      "z-image-turbo-bf16",
       "z-image-turbo-q8",
       "z-image-turbo-q4",
     ]
@@ -470,6 +485,10 @@ enum ComfyBridgeObjectInfo {
     [
       "4x-UltraSharp",
       "RealESRGAN_x4",
+      "OmniSR_X2_DIV2K.safetensors",
+      "OmniSR_X3_DIV2K.safetensors",
+      "OmniSR_X4_DIV2K.safetensors",
+      "4x_NMKD-Superscale-SP_178000_G.pth",
     ]
   }
 
@@ -485,8 +504,31 @@ enum ComfyBridgeObjectInfo {
     ]
   }
 
+  private static func zimageInpaintModels() -> [String] {
+    [
+      "MAT_Places512_G_fp16.safetensors",
+    ]
+  }
+
   private static func zimageLoraModels() -> [String] {
-    // Phase 2+ can scan the filesystem for available LoRA files.
-    []
+    // Z-Image LoRAs available on this system.
+    [
+      "nudeart6-e10.safetensors",
+      "RealisticSnapshot-Zimage-Turbov5.safetensors",
+      "darkBeast_darkblitz6_r128.safetensors",
+      "deedee_amateur_photography_zimage_base_and_turbo_v1.safetensors",
+      "moodyPornMix_v10DPO_zimage_turbo_lora_r128.safetensors",
+      "moodyRealMix_zitV4DPO_zimage_turbo_lora_r128.safetensors",
+      "Jibs_Realistic_z-image_lora_V1.safetensors",
+      "beyond_reality_3.0_zimage_lora_r128.safetensors",
+      "NIceAsians_Zimage.safetensors",
+      "Z Seasian.safetensors",
+      "algertiles.safetensors",
+      "algertiles2.safetensors",
+      "algertiles3.safetensors",
+      "algertiles4.safetensors",
+      "oxman-tiles-v2.safetensors",
+      "zimage_flat_color_v2.1.safetensors",
+    ]
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -468,17 +468,14 @@ enum ComfyBridgeObjectInfo {
   }
 
   private static func zimageControlnetModels() -> [String] {
-    [
-      "z-image-turbo-fun-controlnet-union-2.1",
-      "z-image-turbo-fun-controlnet-tile-2.1",
-    ]
+    // Phase 3: no control model weights available yet.
+    // Empty list forces Krita to use latent-space inpainting fallback.
+    []
   }
 
   private static func zimageControlnetPatchModels() -> [String] {
-    [
-      "z-image-turbo-fun-controlnet-union-2.1",
-      "z-image-turbo-fun-controlnet-tile-2.1",
-    ]
+    // Phase 3: no control model weights available yet.
+    []
   }
 
   private static func zimageUpscaleModels() -> [String] {

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -507,25 +507,19 @@ enum ComfyBridgeObjectInfo {
     ]
   }
 
+  /// Default LoRA directory path. Matches the wrapper script's --lora location.
+  private static let loraDirectoryPath = ("~/bin/zimage/loras" as NSString).expandingTildeInPath
+
   private static func zimageLoraModels() -> [String] {
-    // Z-Image LoRAs available on this system.
-    [
-      "nudeart6-e10.safetensors",
-      "RealisticSnapshot-Zimage-Turbov5.safetensors",
-      "darkBeast_darkblitz6_r128.safetensors",
-      "deedee_amateur_photography_zimage_base_and_turbo_v1.safetensors",
-      "moodyPornMix_v10DPO_zimage_turbo_lora_r128.safetensors",
-      "moodyRealMix_zitV4DPO_zimage_turbo_lora_r128.safetensors",
-      "Jibs_Realistic_z-image_lora_V1.safetensors",
-      "beyond_reality_3.0_zimage_lora_r128.safetensors",
-      "NIceAsians_Zimage.safetensors",
-      "Z Seasian.safetensors",
-      "algertiles.safetensors",
-      "algertiles2.safetensors",
-      "algertiles3.safetensors",
-      "algertiles4.safetensors",
-      "oxman-tiles-v2.safetensors",
-      "zimage_flat_color_v2.1.safetensors",
-    ]
+    // Dynamically scan LoRA directory for .safetensors files.
+    let loraDir = loraDirectoryPath
+    let fm = FileManager.default
+    guard let entries = try? fm.contentsOfDirectory(atPath: loraDir) else {
+      // Fallback: return empty if directory is inaccessible.
+      return []
+    }
+    return entries
+      .filter { $0.hasSuffix(".safetensors") }
+      .sorted()
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -467,15 +467,42 @@ enum ComfyBridgeObjectInfo {
     ]
   }
 
+  /// Default ControlNet directory path — matches zimageLoraModels pattern.
+  private static let controlnetDirectoryPath = ("~/bin/zimage/controlnet" as NSString).expandingTildeInPath
+
   private static func zimageControlnetModels() -> [String] {
-    // Phase 3: no control model weights available yet.
-    // Empty list forces Krita to use latent-space inpainting fallback.
-    []
+    // Phase 4: dynamically scan ControlNet directory for weights.
+    // Supports .safetensors files and subdirectories containing them.
+    let controlnetDir = controlnetDirectoryPath
+    let fm = FileManager.default
+    guard let entries = try? fm.contentsOfDirectory(atPath: controlnetDir) else {
+      return []
+    }
+    var models: [String] = []
+    for entry in entries {
+      let fullPath = controlnetDir + "/" + entry
+      var isDir: ObjCBool = false
+      if fm.fileExists(atPath: fullPath, isDirectory: &isDir) {
+        if isDir.boolValue {
+          // Subdirectory containing .safetensors — use directory name as model name
+          if let subEntries = try? fm.contentsOfDirectory(atPath: fullPath),
+             subEntries.contains(where: { $0.hasSuffix(".safetensors") }) {
+            models.append(entry)
+          }
+        } else if entry.hasSuffix(".safetensors") {
+          // Single safetensors file
+          models.append(entry)
+        }
+      }
+    }
+    // Also include HuggingFace model IDs that are known to work
+    models.append("alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1")
+    return models.sorted()
   }
 
   private static func zimageControlnetPatchModels() -> [String] {
-    // Phase 3: no control model weights available yet.
-    []
+    // Phase 4: ModelPatchLoader uses the same model list as ControlNetLoader.
+    zimageControlnetModels()
   }
 
   private static func zimageUpscaleModels() -> [String] {

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
@@ -87,7 +87,7 @@ final class ComfyWebSocketManager {
 
   /// Compute the Sec-WebSocket-Accept value per RFC 6455 Section 4.2.2.
   static func computeAcceptKey(from clientKey: String) -> String {
-    let magic = "258EAFA5-E914-47DA-95CA-5AB5DC11AD35"
+    let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     let combined = clientKey + magic
     let data = Data(combined.utf8)
     let digest = Insecure.SHA1.hash(data: data)

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
@@ -1,0 +1,282 @@
+// ComfyBridgeWebSocket.swift — WebSocket connection manager for ComfyUI bridge
+//
+// Implements RFC 6455 WebSocket framing over NWConnection. Manages per-client
+// connections and provides methods to send ComfyUI protocol messages.
+//
+// Phase 1: Accept connections, send status on connect, handle ping/pong.
+// Phase 2: Will add progress events, preview images, and execution messages.
+
+import Foundation
+import Logging
+import Network
+import CryptoKit
+
+/// Manages WebSocket connections for the ComfyUI bridge protocol.
+///
+/// Each Krita plugin instance connects with a unique `clientId`. The manager
+/// keeps connections alive and routes execution events to the correct client.
+final class ComfyWebSocketManager {
+  private let logger: Logger
+  private let lock = NSLock()
+  private var connections: [String: WebSocketConnection] = [:]
+
+  init(logger: Logger) {
+    self.logger = logger
+  }
+
+  /// Register a new WebSocket connection after the HTTP 101 upgrade.
+  /// Sends the initial `{"type": "status"}` message and begins listening for frames.
+  func registerConnection(clientId: String, connection: NWConnection, queue: DispatchQueue) {
+    let ws = WebSocketConnection(
+      clientId: clientId,
+      connection: connection,
+      queue: queue,
+      logger: logger,
+      onClose: { [weak self] id in
+        self?.removeConnection(id: id)
+      }
+    )
+
+    lock.lock()
+    // Close any existing connection with the same clientId.
+    if let existing = connections[clientId] {
+      logger.info("ComfyWS: replacing existing connection for clientId=\(clientId)")
+      existing.close()
+    }
+    connections[clientId] = ws
+    lock.unlock()
+
+    ws.start()
+  }
+
+  /// Send a text message to a specific client.
+  func send(to clientId: String, text: String) {
+    lock.lock()
+    let ws = connections[clientId]
+    lock.unlock()
+
+    ws?.sendText(text)
+  }
+
+  /// Send a text message to all connected clients.
+  func broadcast(text: String) {
+    lock.lock()
+    let all = Array(connections.values)
+    lock.unlock()
+
+    for ws in all {
+      ws.sendText(text)
+    }
+  }
+
+  /// Number of active connections.
+  var connectionCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return connections.count
+  }
+
+  private func removeConnection(id: String) {
+    lock.lock()
+    connections.removeValue(forKey: id)
+    lock.unlock()
+    logger.info("ComfyWS: connection closed for clientId=\(id)")
+  }
+
+  // MARK: - WebSocket Accept Key
+
+  /// Compute the Sec-WebSocket-Accept value per RFC 6455 Section 4.2.2.
+  static func computeAcceptKey(from clientKey: String) -> String {
+    let magic = "258EAFA5-E914-47DA-95CA-5AB5DC11AD35"
+    let combined = clientKey + magic
+    let data = Data(combined.utf8)
+    let digest = Insecure.SHA1.hash(data: data)
+    return Data(digest).base64EncodedString()
+  }
+}
+
+// MARK: - WebSocket Connection
+
+/// A single WebSocket connection handling RFC 6455 framing.
+private final class WebSocketConnection {
+  private let clientId: String
+  private let connection: NWConnection
+  private let queue: DispatchQueue
+  private let logger: Logger
+  private let onClose: (String) -> Void
+
+  private var isActive = true
+  /// Self-retention to keep the connection alive while frames are being processed.
+  private var retainSelf: WebSocketConnection?
+
+  init(
+    clientId: String,
+    connection: NWConnection,
+    queue: DispatchQueue,
+    logger: Logger,
+    onClose: @escaping (String) -> Void
+  ) {
+    self.clientId = clientId
+    self.connection = connection
+    self.queue = queue
+    self.logger = logger
+    self.onClose = onClose
+  }
+
+  func start() {
+    retainSelf = self
+    // Send the initial status message that triggers Krita's "connected" event.
+    let statusMsg = #"{"type":"status"}"#
+    sendText(statusMsg)
+    receiveFrame()
+  }
+
+  func close() {
+    guard isActive else { return }
+    isActive = false
+    connection.cancel()
+    retainSelf = nil
+  }
+
+  // MARK: - Send
+
+  func sendText(_ text: String) {
+    guard isActive else { return }
+    let payload = Data(text.utf8)
+    let frame = encodeFrame(opcode: .text, payload: payload)
+    connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+      if let error {
+        self?.logger.warning("ComfyWS: send error for \(self?.clientId ?? "?"): \(error)")
+        self?.close()
+        self?.onClose(self?.clientId ?? "")
+      }
+    })
+  }
+
+  func sendBinary(_ data: Data) {
+    guard isActive else { return }
+    let frame = encodeFrame(opcode: .binary, payload: data)
+    connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+      if let error {
+        self?.logger.warning("ComfyWS: binary send error for \(self?.clientId ?? "?"): \(error)")
+        self?.close()
+        self?.onClose(self?.clientId ?? "")
+      }
+    })
+  }
+
+  // MARK: - Receive
+
+  private func receiveFrame() {
+    guard isActive else { return }
+
+    // Read at least 2 bytes (minimum WebSocket frame header).
+    connection.receive(minimumIncompleteLength: 2, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
+      guard let self, self.isActive else { return }
+
+      if isComplete || error != nil {
+        self.close()
+        self.onClose(self.clientId)
+        return
+      }
+
+      guard let data, data.count >= 2 else {
+        self.receiveFrame()
+        return
+      }
+
+      self.handleReceivedData(data)
+      self.receiveFrame()
+    }
+  }
+
+  private func handleReceivedData(_ data: Data) {
+    let byte0 = data[data.startIndex]
+    let opcode = WebSocketOpcode(rawValue: byte0 & 0x0F) ?? .text
+
+    switch opcode {
+    case .ping:
+      // Respond with pong, echoing the payload.
+      let maskBit = data[data.startIndex + 1]
+      let payloadLength = Int(maskBit & 0x7F)
+      let maskStart = data.startIndex + 2
+      let dataStart = maskStart + (maskBit & 0x80 != 0 ? 4 : 0)
+
+      if dataStart + payloadLength <= data.endIndex {
+        var payload = Data(data[dataStart..<(dataStart + payloadLength)])
+        // Unmask if masked (client frames are always masked per RFC 6455).
+        if maskBit & 0x80 != 0, maskStart + 4 <= data.endIndex {
+          let mask = Array(data[maskStart..<(maskStart + 4)])
+          for i in 0..<payload.count {
+            payload[payload.startIndex + i] ^= mask[i % 4]
+          }
+        }
+        sendPong(payload: payload)
+      } else {
+        sendPong(payload: Data())
+      }
+
+    case .close:
+      // Send close frame back and tear down.
+      let closeFrame = encodeFrame(opcode: .close, payload: Data())
+      connection.send(content: closeFrame, completion: .contentProcessed { [weak self] _ in
+        self?.close()
+        if let clientId = self?.clientId {
+          self?.onClose(clientId)
+        }
+      })
+
+    case .text, .binary:
+      // Phase 1: log and ignore incoming data frames.
+      // Phase 2 may need to handle client commands.
+      break
+
+    case .pong:
+      // Received pong — connection is alive, nothing to do.
+      break
+    }
+  }
+
+  private func sendPong(payload: Data) {
+    let frame = encodeFrame(opcode: .pong, payload: payload)
+    connection.send(content: frame, completion: .contentProcessed { _ in })
+  }
+
+  // MARK: - Frame Encoding (Server → Client)
+
+  /// Encode a WebSocket frame. Server frames are never masked (RFC 6455 Section 5.1).
+  private func encodeFrame(opcode: WebSocketOpcode, payload: Data) -> Data {
+    var frame = Data()
+
+    // FIN bit + opcode.
+    frame.append(0x80 | opcode.rawValue)
+
+    // Payload length (no mask bit for server frames).
+    let length = payload.count
+    if length < 126 {
+      frame.append(UInt8(length))
+    } else if length <= 65535 {
+      frame.append(126)
+      frame.append(UInt8((length >> 8) & 0xFF))
+      frame.append(UInt8(length & 0xFF))
+    } else {
+      frame.append(127)
+      for i in (0..<8).reversed() {
+        frame.append(UInt8((length >> (8 * i)) & 0xFF))
+      }
+    }
+
+    frame.append(payload)
+    return frame
+  }
+}
+
+// MARK: - WebSocket Opcodes
+
+private enum WebSocketOpcode: UInt8 {
+  case text = 0x1
+  case binary = 0x2
+  case close = 0x8
+  case ping = 0x9
+  case pong = 0xA
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWebSocket.swift
@@ -97,7 +97,8 @@ final class ComfyWebSocketManager {
 
 // MARK: - WebSocket Connection
 
-/// A single WebSocket connection handling RFC 6455 framing.
+/// A single WebSocket connection handling RFC 6455 framing with proper
+/// buffering, extended payload lengths, and continuation frame support.
 private final class WebSocketConnection {
   private let clientId: String
   private let connection: NWConnection
@@ -108,6 +109,16 @@ private final class WebSocketConnection {
   private var isActive = true
   /// Self-retention to keep the connection alive while frames are being processed.
   private var retainSelf: WebSocketConnection?
+
+  /// Receive buffer for assembling frames from partial TCP reads.
+  private var receiveBuffer = Data()
+  /// Buffer for reassembling fragmented messages (continuation frames).
+  private var fragmentBuffer = Data()
+  /// Opcode of the first frame in a fragmented sequence.
+  private var fragmentOpcode: WebSocketOpcode?
+
+  /// Maximum single message size (16 MB) to prevent memory exhaustion.
+  private static let maxMessageSize = 16 * 1024 * 1024
 
   init(
     clientId: String,
@@ -128,7 +139,7 @@ private final class WebSocketConnection {
     // Send the initial status message that triggers Krita's "connected" event.
     let statusMsg = #"{"type":"status"}"#
     sendText(statusMsg)
-    receiveFrame()
+    receiveLoop()
   }
 
   func close() {
@@ -167,12 +178,15 @@ private final class WebSocketConnection {
 
   // MARK: - Receive
 
-  private func receiveFrame() {
+  private func receiveLoop() {
     guard isActive else { return }
 
-    // Read at least 2 bytes (minimum WebSocket frame header).
-    connection.receive(minimumIncompleteLength: 2, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
       guard let self, self.isActive else { return }
+
+      if let data, !data.isEmpty {
+        self.receiveBuffer.append(data)
+      }
 
       if isComplete || error != nil {
         self.close()
@@ -180,41 +194,127 @@ private final class WebSocketConnection {
         return
       }
 
-      guard let data, data.count >= 2 else {
-        self.receiveFrame()
-        return
-      }
-
-      self.handleReceivedData(data)
-      self.receiveFrame()
+      // Parse as many complete frames as possible from the buffer.
+      self.drainFrames()
+      self.receiveLoop()
     }
   }
 
-  private func handleReceivedData(_ data: Data) {
-    let byte0 = data[data.startIndex]
+  /// Parse and handle all complete frames currently in the receive buffer.
+  private func drainFrames() {
+    while isActive {
+      guard let frame = parseFrame() else { break }
+      handleFrame(frame)
+    }
+  }
+
+  /// Attempt to parse one WebSocket frame from the receive buffer.
+  /// Returns nil if the buffer does not contain a complete frame.
+  /// Consumes the frame bytes from the buffer on success.
+  private func parseFrame() -> ParsedFrame? {
+    let buf = receiveBuffer
+    guard buf.count >= 2 else { return nil }
+
+    let byte0 = buf[buf.startIndex]
+    let byte1 = buf[buf.startIndex + 1]
+
+    let fin = (byte0 & 0x80) != 0
     let opcode = WebSocketOpcode(rawValue: byte0 & 0x0F) ?? .text
+    let masked = (byte1 & 0x80) != 0
+    let lengthField = byte1 & 0x7F
 
-    switch opcode {
-    case .ping:
-      // Respond with pong, echoing the payload.
-      let maskBit = data[data.startIndex + 1]
-      let payloadLength = Int(maskBit & 0x7F)
-      let maskStart = data.startIndex + 2
-      let dataStart = maskStart + (maskBit & 0x80 != 0 ? 4 : 0)
+    var headerSize = 2
+    var payloadLength: Int
 
-      if dataStart + payloadLength <= data.endIndex {
-        var payload = Data(data[dataStart..<(dataStart + payloadLength)])
-        // Unmask if masked (client frames are always masked per RFC 6455).
-        if maskBit & 0x80 != 0, maskStart + 4 <= data.endIndex {
-          let mask = Array(data[maskStart..<(maskStart + 4)])
-          for i in 0..<payload.count {
-            payload[payload.startIndex + i] ^= mask[i % 4]
-          }
-        }
-        sendPong(payload: payload)
-      } else {
-        sendPong(payload: Data())
+    if lengthField < 126 {
+      payloadLength = Int(lengthField)
+    } else if lengthField == 126 {
+      // 16-bit extended payload length.
+      guard buf.count >= 4 else { return nil }
+      payloadLength = Int(buf[buf.startIndex + 2]) << 8 | Int(buf[buf.startIndex + 3])
+      headerSize = 4
+    } else {
+      // 64-bit extended payload length.
+      guard buf.count >= 10 else { return nil }
+      payloadLength = 0
+      for i in 0..<8 {
+        payloadLength = (payloadLength << 8) | Int(buf[buf.startIndex + 2 + i])
       }
+      headerSize = 10
+
+      // Sanity check — reject frames larger than our limit.
+      if payloadLength > Self.maxMessageSize {
+        logger.warning("ComfyWS: frame too large (\(payloadLength) bytes), closing \(clientId)")
+        closeWithProtocolError()
+        return nil
+      }
+    }
+
+    let maskSize = masked ? 4 : 0
+    let totalFrameSize = headerSize + maskSize + payloadLength
+
+    guard buf.count >= totalFrameSize else { return nil }
+
+    // Extract and unmask payload.
+    let maskStart = buf.startIndex + headerSize
+    let dataStart = maskStart + maskSize
+
+    var payload = Data(buf[dataStart..<(dataStart + payloadLength)])
+    if masked {
+      let mask = Array(buf[maskStart..<(maskStart + 4)])
+      for i in 0..<payload.count {
+        payload[payload.startIndex + i] ^= mask[i % 4]
+      }
+    }
+
+    // Consume the frame from the buffer.
+    receiveBuffer.removeSubrange(receiveBuffer.startIndex..<(receiveBuffer.startIndex + totalFrameSize))
+
+    return ParsedFrame(fin: fin, opcode: opcode, payload: payload)
+  }
+
+  /// Handle a fully parsed WebSocket frame, including fragmentation reassembly.
+  private func handleFrame(_ frame: ParsedFrame) {
+    switch frame.opcode {
+    case .continuation:
+      // Continuation frame — append to fragment buffer.
+      guard fragmentOpcode != nil else {
+        logger.warning("ComfyWS: unexpected continuation frame for \(clientId)")
+        closeWithProtocolError()
+        return
+      }
+      fragmentBuffer.append(frame.payload)
+      if fragmentBuffer.count > Self.maxMessageSize {
+        logger.warning("ComfyWS: fragmented message too large for \(clientId)")
+        closeWithProtocolError()
+        return
+      }
+      if frame.fin {
+        // Reassembly complete.
+        let completePayload = fragmentBuffer
+        let opcode = fragmentOpcode!
+        fragmentBuffer.removeAll()
+        fragmentOpcode = nil
+        handleMessage(opcode: opcode, payload: completePayload)
+      }
+
+    case .text, .binary:
+      if frame.fin {
+        // Single-frame message.
+        handleMessage(opcode: frame.opcode, payload: frame.payload)
+      } else {
+        // First frame of a fragmented message.
+        fragmentOpcode = frame.opcode
+        fragmentBuffer = frame.payload
+      }
+
+    case .ping:
+      // Control frames may appear between fragmented data frames.
+      sendPong(payload: frame.payload)
+
+    case .pong:
+      // Received pong — connection is alive, nothing to do.
+      break
 
     case .close:
       // Send close frame back and tear down.
@@ -225,16 +325,29 @@ private final class WebSocketConnection {
           self?.onClose(clientId)
         }
       })
-
-    case .text, .binary:
-      // Phase 1: log and ignore incoming data frames.
-      // Phase 2 may need to handle client commands.
-      break
-
-    case .pong:
-      // Received pong — connection is alive, nothing to do.
-      break
     }
+  }
+
+  /// Handle a complete (possibly reassembled) WebSocket message.
+  private func handleMessage(opcode: WebSocketOpcode, payload: Data) {
+    // Phase 1: log and ignore incoming data frames.
+    // Phase 2 may need to handle client commands.
+    _ = opcode
+    _ = payload
+  }
+
+  private func closeWithProtocolError() {
+    // Send close frame with 1002 (protocol error) status code.
+    var payload = Data()
+    payload.append(UInt8(1002 >> 8))
+    payload.append(UInt8(1002 & 0xFF))
+    let frame = encodeFrame(opcode: .close, payload: payload)
+    connection.send(content: frame, completion: .contentProcessed { [weak self] _ in
+      self?.close()
+      if let clientId = self?.clientId {
+        self?.onClose(clientId)
+      }
+    })
   }
 
   private func sendPong(payload: Data) {
@@ -271,9 +384,18 @@ private final class WebSocketConnection {
   }
 }
 
+// MARK: - Parsed Frame
+
+private struct ParsedFrame {
+  let fin: Bool
+  let opcode: WebSocketOpcode
+  let payload: Data
+}
+
 // MARK: - WebSocket Opcodes
 
 private enum WebSocketOpcode: UInt8 {
+  case continuation = 0x0
   case text = 0x1
   case binary = 0x2
   case close = 0x8

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -39,6 +39,12 @@ struct ComfyBridgeGenerateRequest: Sendable {
   let maskCropX: Int
   let maskCropY: Int
 
+  // --- Phase 4: LoRA fields ---
+
+  /// LoRAs extracted from LoraLoader nodes in the workflow.
+  /// Each entry is (filename, strength_model scale).
+  let loras: [(name: String, scale: Float)]
+
   /// Whether this is an inpainting request.
   var isInpaint: Bool { inpaintImageId != nil }
 
@@ -213,9 +219,26 @@ enum ComfyBridgeWorkflowParser {
     let maskCropX = intValue(cropNode?.inputs["x"]) ?? 0
     let maskCropY = intValue(cropNode?.inputs["y"]) ?? 0
 
+    // --- Phase 4: LoRA extraction ---
+    // Find all LoraLoader nodes and extract lora_name + strength_model.
+    // LoraLoader nodes chain: each feeds its MODEL output to the next's model input.
+    // We collect all of them regardless of chain order — the pipeline applies them all.
+    let loraLoaderNodes = nodes.values
+      .filter { $0.classType == "LoraLoader" }
+      .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+    var loras: [(name: String, scale: Float)] = []
+    for loraNode in loraLoaderNodes {
+      guard let loraName = loraNode.inputs["lora_name"] as? String, !loraName.isEmpty else {
+        continue
+      }
+      let strengthModel = floatValue(loraNode.inputs["strength_model"]) ?? 1.0
+      loras.append((name: loraName, scale: strengthModel))
+    }
+
     // Debug: log workflow structure
     let _nodeTypes = nodes.values.map { $0.classType }.sorted()
-    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise)")
+    let _loraDesc = loras.isEmpty ? "none" : loras.map { "\($0.name)@\($0.scale)" }.joined(separator: ", ")
+    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise) loras=\(_loraDesc)")
 
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
@@ -235,7 +258,8 @@ enum ComfyBridgeWorkflowParser {
       maskGrow: maskGrow,
       maskFeather: maskFeather,
       maskCropX: maskCropX,
-      maskCropY: maskCropY
+      maskCropY: maskCropY,
+      loras: loras
     )
   }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -4,6 +4,7 @@
 // steps, seed, etc.) and maps them to ZImageCLI's internal format.
 //
 // Phase 2: txt2img workflow parsing.
+// Phase 3: inpaint workflow parsing (latent-space inpainting).
 
 import Foundation
 
@@ -21,6 +22,23 @@ struct ComfyBridgeGenerateRequest: Sendable {
   let batchSize: Int
   /// The node ID of the output node (ETN_SaveImageCache or PreviewImage).
   let outputNodeId: String
+
+  // --- Phase 3: Inpainting fields ---
+
+  /// Image cache ID of the input image to inpaint (from ETN_LoadImageCache node).
+  let inpaintImageId: String?
+  /// Image cache ID of the mask image (from ETN_LoadImageCache node).
+  let maskImageId: String?
+  /// Denoising strength (0.0–1.0). Higher = more change. Default 1.0 for txt2img.
+  let denoise: Float
+
+  /// Whether this is an inpainting request.
+  var isInpaint: Bool { inpaintImageId != nil }
+
+  // Populated by executor before passing to generate handler.
+  // Not set by parser — must be filled from image cache.
+  var inpaintImageData: Data?
+  var maskImageData: Data?
 }
 
 /// Result of a ComfyUI bridge generation.
@@ -93,6 +111,8 @@ enum ComfyBridgeWorkflowParser {
     }
 
     // --- Dimensions ---
+    // For txt2img: from EmptySD3LatentImage/EmptyLatentImage node.
+    // For inpaint: from the input image (or fall back to latent node if present).
     let latentNode = nodes.values.first {
       $0.classType == "EmptySD3LatentImage" || $0.classType == "EmptyLatentImage"
     }
@@ -103,6 +123,10 @@ enum ComfyBridgeWorkflowParser {
     // --- Steps ---
     let schedulerNode = nodes.values.first { $0.classType == "BasicScheduler" }
     let steps = intValue(schedulerNode?.inputs["steps"]) ?? 9
+
+    // --- Denoise strength ---
+    // BasicScheduler has an optional "denoise" input. Default 1.0 (full denoise for txt2img).
+    let denoise = floatValue(schedulerNode?.inputs["denoise"]) ?? 1.0
 
     // --- CFG ---
     let cfg: Float
@@ -123,9 +147,14 @@ enum ComfyBridgeWorkflowParser {
     } else if let previewNode = nodes.values.first(where: { $0.classType == "PreviewImage" }) {
       outputNodeId = previewNode.id
     } else {
-      // Use the highest node ID as a fallback.
       outputNodeId = nodes.keys.sorted { $0.localizedStandardCompare($1) == .orderedDescending }.first ?? "1"
     }
+
+    // --- Phase 3: Inpainting detection ---
+    // Detect inpaint workflows by finding ETN_LoadImageCache nodes.
+    // The first one is typically the input image, the second is the mask.
+    // Node connections determine which is image vs mask.
+    let (inpaintImageId, maskImageId) = extractInpaintImageIds(nodes: nodes)
 
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
@@ -138,8 +167,91 @@ enum ComfyBridgeWorkflowParser {
       guidance: cfg,
       seed: seed,
       batchSize: max(batchSize, 1),
-      outputNodeId: outputNodeId
+      outputNodeId: outputNodeId,
+      inpaintImageId: inpaintImageId,
+      maskImageId: maskImageId,
+      denoise: denoise
     )
+  }
+
+  // MARK: - Inpaint Detection
+
+  /// Extract inpaint image and mask IDs from ETN_LoadImageCache nodes.
+  ///
+  /// Heuristic: The plugin uploads images via PUT /api/etn/image/<id> where <id>
+  /// is a CRC32 hash. ETN_LoadImageCache nodes reference these by ID.
+  ///
+  /// To distinguish image from mask, we trace node connections:
+  /// - If a LoadImageCache feeds into VAEEncode or INPAINT_MaskedBlur → it's the image
+  /// - If a LoadImageCache feeds into SetLatentNoiseMask or INPAINT_ExpandMask → it's the mask
+  /// - Fallback: first by node ID order (lower = image, higher = mask)
+  private static func extractInpaintImageIds(nodes: [String: WorkflowNode]) -> (String?, String?) {
+    let loadCacheNodes = nodes.values
+      .filter { $0.classType == "ETN_LoadImageCache" }
+      .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+
+    guard !loadCacheNodes.isEmpty else { return (nil, nil) }
+
+    // Build reverse dependency map: for each node, which nodes consume its output?
+    var consumers: [String: [(nodeId: String, inputKey: String)]] = [:]
+    for (_, node) in nodes {
+      for (key, value) in node.inputs {
+        if let ref = value as? [Any], let refNodeId = ref.first as? String {
+          consumers[refNodeId, default: []].append((nodeId: node.id, inputKey: key))
+        }
+      }
+    }
+
+    var imageId: String?
+    var maskId: String?
+
+    for cacheNode in loadCacheNodes {
+      let id = cacheNode.inputs["id"] as? String ?? cacheNode.inputs["image_id"] as? String
+      guard let cacheId = id else { continue }
+
+      // Check what consumes this node's output.
+      let nodeConsumers = consumers[cacheNode.id] ?? []
+      var isImage = false
+      var isMask = false
+
+      for consumer in nodeConsumers {
+        let consumerNode = nodes[consumer.nodeId]
+        let consumerClass = consumerNode?.classType ?? ""
+
+        // Image consumers
+        if ["VAEEncode", "INPAINT_MaskedBlur", "INPAINT_ColorMatch",
+            "ETN_ApplyMaskToImage", "ZImageFunControlnet"].contains(consumerClass) {
+          if consumer.inputKey == "image" || consumer.inputKey == "inpaint_image" ||
+             consumer.inputKey == "pixels" || consumer.inputKey == "source" {
+            isImage = true
+          }
+          if consumer.inputKey == "mask" {
+            isMask = true
+          }
+        }
+
+        // Mask consumers
+        if ["SetLatentNoiseMask", "INPAINT_ExpandMask", "INPAINT_StabilizeMask",
+            "INPAINT_ShrinkMask", "DifferentialDiffusion"].contains(consumerClass) {
+          isMask = true
+        }
+        if consumer.inputKey == "mask" {
+          isMask = true
+        }
+      }
+
+      if isImage && !isMask {
+        imageId = cacheId
+      } else if isMask && !isImage {
+        maskId = cacheId
+      } else if imageId == nil {
+        imageId = cacheId  // Fallback: first = image
+      } else if maskId == nil {
+        maskId = cacheId   // Fallback: second = mask
+      }
+    }
+
+    return (imageId, maskId)
   }
 
   // MARK: - Node Graph Traversal

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -31,6 +31,10 @@ struct ComfyBridgeGenerateRequest: Sendable {
   let maskImageId: String?
   /// Denoising strength (0.0–1.0). Higher = more change. Default 1.0 for txt2img.
   let denoise: Float
+  /// Mask expansion in pixels (from INPAINT_ExpandMask grow parameter).
+  let maskGrow: Int
+  /// Mask feather radius in pixels (from INPAINT_ExpandMask feather parameter).
+  let maskFeather: Int
 
   /// Whether this is an inpainting request.
   var isInpaint: Bool { inpaintImageId != nil }
@@ -176,6 +180,12 @@ enum ComfyBridgeWorkflowParser {
     // Node connections determine which is image vs mask.
     let (inpaintImageId, maskImageId) = extractInpaintImageIds(nodes: nodes)
 
+    // --- Phase 3: Mask preprocessing parameters ---
+    // Extract grow and feather from INPAINT_ExpandMask node.
+    let expandNode = nodes.values.first { $0.classType == "INPAINT_ExpandMask" }
+    let maskGrow = intValue(expandNode?.inputs["grow"]) ?? 0
+    let maskFeather = intValue(expandNode?.inputs["feather"]) ?? 0
+
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
       clientId: clientId,
@@ -190,7 +200,9 @@ enum ComfyBridgeWorkflowParser {
       outputNodeId: outputNodeId,
       inpaintImageId: inpaintImageId,
       maskImageId: maskImageId,
-      denoise: denoise
+      denoise: denoise,
+      maskGrow: maskGrow,
+      maskFeather: maskFeather
     )
   }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -1,0 +1,186 @@
+// ComfyBridgeWorkflowParser.swift — Extracts generation parameters from ComfyUI workflow JSON
+//
+// Traverses the ComfyUI node graph to find generation parameters (prompt, dimensions,
+// steps, seed, etc.) and maps them to ZImageCLI's internal format.
+//
+// Phase 2: txt2img workflow parsing.
+
+import Foundation
+
+/// Parameters extracted from a ComfyUI workflow graph for Z-Image generation.
+struct ComfyBridgeGenerateRequest: Sendable {
+  let promptId: String
+  let clientId: String
+  let prompt: String
+  let negativePrompt: String?
+  let width: Int
+  let height: Int
+  let steps: Int
+  let guidance: Float
+  let seed: UInt64?
+  let batchSize: Int
+  /// The node ID of the output node (ETN_SaveImageCache or PreviewImage).
+  let outputNodeId: String
+}
+
+/// Result of a ComfyUI bridge generation.
+struct ComfyBridgeGenerateResult: Sendable {
+  let outputPath: String
+  let durationMs: Int
+}
+
+/// Parses ComfyUI workflow JSON into generation parameters.
+enum ComfyBridgeWorkflowParser {
+
+  struct ParseError: Error, CustomStringConvertible {
+    let description: String
+    init(_ message: String) { self.description = message }
+  }
+
+  /// Parse a /prompt request body into generation parameters.
+  static func parse(_ json: [String: Any]) throws -> ComfyBridgeGenerateRequest {
+    guard let promptId = json["prompt_id"] as? String else {
+      throw ParseError("Missing prompt_id")
+    }
+    let clientId = json["client_id"] as? String ?? "unknown"
+
+    guard let workflow = json["prompt"] as? [String: Any] else {
+      throw ParseError("Missing 'prompt' workflow object")
+    }
+
+    // Build a typed node map for easy traversal.
+    var nodes: [String: WorkflowNode] = [:]
+    for (id, value) in workflow {
+      guard let dict = value as? [String: Any],
+            let classType = dict["class_type"] as? String,
+            let inputs = dict["inputs"] as? [String: Any] else {
+        continue
+      }
+      nodes[id] = WorkflowNode(id: id, classType: classType, inputs: inputs)
+    }
+
+    // --- Prompt text ---
+    // Traverse from CFGGuider/BasicGuider → CLIPTextEncode → text
+    var positivePrompt: String?
+    var negativePrompt: String?
+
+    let guiderNode = nodes.values.first { $0.classType == "CFGGuider" || $0.classType == "BasicGuider" }
+
+    if let guider = guiderNode {
+      if guider.classType == "CFGGuider" {
+        positivePrompt = resolveTextInput(key: "positive", from: guider, nodes: nodes)
+        negativePrompt = resolveTextInput(key: "negative", from: guider, nodes: nodes)
+      } else {
+        positivePrompt = resolveTextInput(key: "conditioning", from: guider, nodes: nodes)
+      }
+    }
+
+    // Fallback: scan all CLIPTextEncode nodes ordered by ID.
+    if positivePrompt == nil {
+      let textNodes = nodes.values
+        .filter { $0.classType == "CLIPTextEncode" }
+        .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+      if let first = textNodes.first {
+        positivePrompt = first.inputs["text"] as? String
+      }
+      if textNodes.count > 1 {
+        negativePrompt = textNodes[1].inputs["text"] as? String
+      }
+    }
+
+    guard let prompt = positivePrompt, !prompt.isEmpty else {
+      throw ParseError("Could not extract prompt text from workflow")
+    }
+
+    // --- Dimensions ---
+    let latentNode = nodes.values.first {
+      $0.classType == "EmptySD3LatentImage" || $0.classType == "EmptyLatentImage"
+    }
+    let width = intValue(latentNode?.inputs["width"]) ?? 1024
+    let height = intValue(latentNode?.inputs["height"]) ?? 1024
+    let batchSize = intValue(latentNode?.inputs["batch_size"]) ?? 1
+
+    // --- Steps ---
+    let schedulerNode = nodes.values.first { $0.classType == "BasicScheduler" }
+    let steps = intValue(schedulerNode?.inputs["steps"]) ?? 9
+
+    // --- CFG ---
+    let cfg: Float
+    if let guider = guiderNode, guider.classType == "CFGGuider" {
+      cfg = floatValue(guider.inputs["cfg"]) ?? 0.0
+    } else {
+      cfg = 0.0
+    }
+
+    // --- Seed ---
+    let noiseNode = nodes.values.first { $0.classType == "RandomNoise" }
+    let seed = uint64Value(noiseNode?.inputs["noise_seed"])
+
+    // --- Output node ---
+    let outputNodeId: String
+    if let saveNode = nodes.values.first(where: { $0.classType == "ETN_SaveImageCache" }) {
+      outputNodeId = saveNode.id
+    } else if let previewNode = nodes.values.first(where: { $0.classType == "PreviewImage" }) {
+      outputNodeId = previewNode.id
+    } else {
+      // Use the highest node ID as a fallback.
+      outputNodeId = nodes.keys.sorted { $0.localizedStandardCompare($1) == .orderedDescending }.first ?? "1"
+    }
+
+    return ComfyBridgeGenerateRequest(
+      promptId: promptId,
+      clientId: clientId,
+      prompt: prompt,
+      negativePrompt: negativePrompt,
+      width: width,
+      height: height,
+      steps: steps,
+      guidance: cfg,
+      seed: seed,
+      batchSize: max(batchSize, 1),
+      outputNodeId: outputNodeId
+    )
+  }
+
+  // MARK: - Node Graph Traversal
+
+  /// Follow a node reference to resolve the text value from a CLIPTextEncode node.
+  private static func resolveTextInput(key: String, from node: WorkflowNode, nodes: [String: WorkflowNode]) -> String? {
+    guard let ref = node.inputs[key] as? [Any],
+          let refNodeId = ref.first as? String,
+          let textNode = nodes[refNodeId] else {
+      return nil
+    }
+    return textNode.inputs["text"] as? String
+  }
+
+  // MARK: - Value Extraction Helpers
+
+  private static func intValue(_ value: Any?) -> Int? {
+    if let i = value as? Int { return i }
+    if let n = value as? NSNumber { return n.intValue }
+    if let d = value as? Double { return Int(d) }
+    return nil
+  }
+
+  private static func floatValue(_ value: Any?) -> Float? {
+    if let f = value as? Float { return f }
+    if let n = value as? NSNumber { return n.floatValue }
+    if let d = value as? Double { return Float(d) }
+    return nil
+  }
+
+  private static func uint64Value(_ value: Any?) -> UInt64? {
+    guard let value else { return nil }
+    if let i = value as? Int { return UInt64(i) }
+    if let n = value as? NSNumber { return n.uint64Value }
+    return nil
+  }
+}
+
+/// A node in the ComfyUI workflow graph.
+private struct WorkflowNode {
+  let id: String
+  let classType: String
+  let inputs: [String: Any]
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -112,13 +112,33 @@ enum ComfyBridgeWorkflowParser {
 
     // --- Dimensions ---
     // For txt2img: from EmptySD3LatentImage/EmptyLatentImage node.
-    // For inpaint: from the input image (or fall back to latent node if present).
+    // For inpaint: from ImageCrop node (contains actual selection dimensions).
+    // Dimensions are rounded to nearest 16 for latent space alignment.
     let latentNode = nodes.values.first {
       $0.classType == "EmptySD3LatentImage" || $0.classType == "EmptyLatentImage"
     }
-    let width = intValue(latentNode?.inputs["width"]) ?? 1024
-    let height = intValue(latentNode?.inputs["height"]) ?? 1024
-    let batchSize = intValue(latentNode?.inputs["batch_size"]) ?? 1
+    let cropNode = nodes.values.first { $0.classType == "ImageCrop" }
+
+    let width: Int
+    let height: Int
+    let batchSize: Int
+
+    if let ln = latentNode {
+      // txt2img: dimensions from empty latent node
+      width = roundTo16(intValue(ln.inputs["width"]) ?? 1024)
+      height = roundTo16(intValue(ln.inputs["height"]) ?? 1024)
+      batchSize = intValue(ln.inputs["batch_size"]) ?? 1
+    } else if let cn = cropNode {
+      // Inpaint: dimensions from ImageCrop node (actual selection size)
+      width = roundTo16(intValue(cn.inputs["width"]) ?? 1024)
+      height = roundTo16(intValue(cn.inputs["height"]) ?? 1024)
+      batchSize = 1
+    } else {
+      // Fallback
+      width = 1024
+      height = 1024
+      batchSize = 1
+    }
 
     // --- Steps ---
     let schedulerNode = nodes.values.first { $0.classType == "BasicScheduler" }
@@ -287,6 +307,10 @@ enum ComfyBridgeWorkflowParser {
     if let i = value as? Int { return UInt64(i) }
     if let n = value as? NSNumber { return n.uint64Value }
     return nil
+  }
+
+  private static func roundTo16(_ value: Int) -> Int {
+    return ((value + 15) / 16) * 16
   }
 }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -35,6 +35,9 @@ struct ComfyBridgeGenerateRequest: Sendable {
   let maskGrow: Int
   /// Mask feather radius in pixels (from INPAINT_ExpandMask feather parameter).
   let maskFeather: Int
+  /// ImageCrop x,y offset — used to crop full-canvas mask to selection bounds.
+  let maskCropX: Int
+  let maskCropY: Int
 
   /// Whether this is an inpainting request.
   var isInpaint: Bool { inpaintImageId != nil }
@@ -127,15 +130,24 @@ enum ComfyBridgeWorkflowParser {
     let height: Int
     let batchSize: Int
 
-    if let ln = latentNode {
+    // Detect inpaint early to choose correct dimension source
+    let hasInpaintImages = nodes.values.contains { $0.classType == "ETN_LoadImageCache" }
+
+    if let cn = cropNode, hasInpaintImages {
+      // Inpaint with selection crop: use ImageCrop dimensions
+      width = roundTo16(intValue(cn.inputs["width"]) ?? 1024)
+      height = roundTo16(intValue(cn.inputs["height"]) ?? 1024)
+      batchSize = 1
+    } else if let ln = latentNode {
       // txt2img: dimensions from empty latent node
       width = roundTo16(intValue(ln.inputs["width"]) ?? 1024)
       height = roundTo16(intValue(ln.inputs["height"]) ?? 1024)
       batchSize = intValue(ln.inputs["batch_size"]) ?? 1
-    } else if let cn = cropNode {
-      // Inpaint: dimensions from ImageCrop node (actual selection size)
-      width = roundTo16(intValue(cn.inputs["width"]) ?? 1024)
-      height = roundTo16(intValue(cn.inputs["height"]) ?? 1024)
+    } else if hasInpaintImages {
+      // Inpaint without ImageCrop or EmptyLatentImage — set width/height to 0
+      // to signal downstream code to derive from the actual inpaint image
+      width = 0
+      height = 0
       batchSize = 1
     } else {
       // Fallback
@@ -146,11 +158,24 @@ enum ComfyBridgeWorkflowParser {
 
     // --- Steps ---
     let schedulerNode = nodes.values.first { $0.classType == "BasicScheduler" }
+    // Also check KSampler for denoise (Krita may use KSampler instead of BasicScheduler)
+    let kSamplerNode = nodes.values.first { $0.classType == "KSampler" || $0.classType == "KSamplerAdvanced" }
     let steps = intValue(schedulerNode?.inputs["steps"]) ?? 9
 
     // --- Denoise strength ---
     // BasicScheduler has an optional "denoise" input. Default 1.0 (full denoise for txt2img).
-    let denoise = floatValue(schedulerNode?.inputs["denoise"]) ?? 1.0
+    // Krita AI Diffusion uses SplitSigmas to control effective denoise: it generates the
+    // full sigma schedule (denoise=1.0) then splits at a step, using only the second half.
+    // Effective denoise = 1.0 - (splitStep / totalSteps).
+    let splitNode = nodes.values.first { $0.classType == "SplitSigmas" }
+    let splitStep = intValue(splitNode?.inputs["step"])
+    let baseDenoise = floatValue(schedulerNode?.inputs["denoise"]) ?? floatValue(kSamplerNode?.inputs["denoise"]) ?? 1.0
+    let denoise: Float
+    if let split = splitStep, split > 0 {
+      denoise = 1.0 - (Float(split) / Float(steps))
+    } else {
+      denoise = baseDenoise
+    }
 
     // --- CFG ---
     let cfg: Float
@@ -185,6 +210,12 @@ enum ComfyBridgeWorkflowParser {
     let expandNode = nodes.values.first { $0.classType == "INPAINT_ExpandMask" }
     let maskGrow = intValue(expandNode?.inputs["grow"]) ?? 0
     let maskFeather = intValue(expandNode?.inputs["feather"]) ?? 0
+    let maskCropX = intValue(cropNode?.inputs["x"]) ?? 0
+    let maskCropY = intValue(cropNode?.inputs["y"]) ?? 0
+
+    // Debug: log workflow structure
+    let _nodeTypes = nodes.values.map { $0.classType }.sorted()
+    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise)")
 
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
@@ -202,7 +233,9 @@ enum ComfyBridgeWorkflowParser {
       maskImageId: maskImageId,
       denoise: denoise,
       maskGrow: maskGrow,
-      maskFeather: maskFeather
+      maskFeather: maskFeather,
+      maskCropX: maskCropX,
+      maskCropY: maskCropY
     )
   }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -45,13 +45,30 @@ struct ComfyBridgeGenerateRequest: Sendable {
   /// Each entry is (filename, strength_model scale).
   let loras: [(name: String, scale: Float)]
 
+  // --- Phase 4: ControlNet fields ---
+
+  /// ControlNet model name or path (from ControlNetLoader or ModelPatchLoader node).
+  let controlnetModel: String?
+  /// ControlNet strength (0.0-1.0). Default 0.5.
+  let controlnetStrength: Float
+  /// ControlNet start percent (when to start applying control). Default 0.0.
+  let controlnetStart: Float
+  /// ControlNet end percent (when to stop applying control). Default 1.0.
+  let controlnetEnd: Float
+  /// Image cache ID of the control image (depth map, canny edges, etc.).
+  let controlImageId: String?
+
   /// Whether this is an inpainting request.
   var isInpaint: Bool { inpaintImageId != nil }
+
+  /// Whether this request uses ControlNet.
+  var isControlNet: Bool { controlnetModel != nil }
 
   // Populated by executor before passing to generate handler.
   // Not set by parser — must be filled from image cache.
   var inpaintImageData: Data?
   var maskImageData: Data?
+  var controlImageData: Data?
 }
 
 /// Result of a ComfyUI bridge generation.
@@ -235,10 +252,56 @@ enum ComfyBridgeWorkflowParser {
       loras.append((name: loraName, scale: strengthModel))
     }
 
+    // --- Phase 4: ControlNet extraction ---
+    // Krita sends ZImageFunControlnet nodes for Z-Image native controlnet workflows,
+    // or ControlNetLoader nodes for standard ComfyUI controlnet workflows.
+    // We also check ModelPatchLoader which Krita uses for our custom node.
+    let controlnetModel: String?
+    var controlnetStrength: Float = 0.5
+    var controlnetStart: Float = 0.0
+    var controlnetEnd: Float = 1.0
+    var controlImageId: String?
+
+    // Check for ZImageFunControlnet node first (our custom node)
+    if let funControlNode = nodes.values.first(where: { $0.classType == "ZImageFunControlnet" }) {
+      // The model_patch input links to a ModelPatchLoader node
+      if let patchRef = funControlNode.inputs["model_patch"] as? [Any],
+         let patchNodeId = patchRef.first as? String,
+         let patchNode = nodes[patchNodeId],
+         patchNode.classType == "ModelPatchLoader" {
+        controlnetModel = patchNode.inputs["name"] as? String
+      } else {
+        controlnetModel = nil
+      }
+      controlnetStrength = floatValue(funControlNode.inputs["strength"]) ?? 0.5
+      controlnetStart = floatValue(funControlNode.inputs["start"]) ?? 0.0
+      controlnetEnd = floatValue(funControlNode.inputs["end"]) ?? 1.0
+      // The inpaint_image input links to ETN_LoadImageCache or another image source
+      if let imgRef = funControlNode.inputs["inpaint_image"] as? [Any],
+         let imgNodeId = imgRef.first as? String,
+         let imgNode = nodes[imgNodeId] {
+        if imgNode.classType == "ETN_LoadImageCache" {
+          controlImageId = imgNode.inputs["id"] as? String
+        }
+      }
+    }
+    // Fallback: standard ControlNetLoader node
+    else if let controlNetLoader = nodes.values.first(where: { $0.classType == "ControlNetLoader" }) {
+      controlnetModel = controlNetLoader.inputs["control_net_name"] as? String
+    }
+    // Fallback: standalone ModelPatchLoader node
+    else if let modelPatchLoader = nodes.values.first(where: { $0.classType == "ModelPatchLoader" }) {
+      controlnetModel = modelPatchLoader.inputs["name"] as? String
+    }
+    else {
+      controlnetModel = nil
+    }
+
     // Debug: log workflow structure
     let _nodeTypes = nodes.values.map { $0.classType }.sorted()
     let _loraDesc = loras.isEmpty ? "none" : loras.map { "\($0.name)@\($0.scale)" }.joined(separator: ", ")
-    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise) loras=\(_loraDesc)")
+    let _cnDesc = controlnetModel ?? "none"
+    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise) loras=\(_loraDesc) controlnet=\(_cnDesc)")
 
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
@@ -259,7 +322,12 @@ enum ComfyBridgeWorkflowParser {
       maskFeather: maskFeather,
       maskCropX: maskCropX,
       maskCropY: maskCropY,
-      loras: loras
+      loras: loras,
+      controlnetModel: controlnetModel,
+      controlnetStrength: controlnetStrength,
+      controlnetStart: controlnetStart,
+      controlnetEnd: controlnetEnd,
+      controlImageId: controlImageId
     )
   }
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -594,24 +594,27 @@ private final class ConnectionHandler {
     }
 
     // Check for WebSocket upgrade before entering the async router.
-    if request.path == "/ws",
-       request.method == "GET",
-       let wsResponse = server.comfyBridge.handleWebSocketUpgrade(request: request, connection: connection, queue: queue) {
-      // Send the upgrade response, then keep the connection alive for WebSocket framing.
-      guard !responseSent else { return }
-      responseSent = true
-      connection.send(content: wsResponse, completion: .contentProcessed { [weak self] _ in
-        guard let self, let server = self.server else { return }
-        let clientId = request.queryParameters["clientId"] ?? UUID().uuidString
-        server.comfyBridge.wsManager.registerConnection(
-          clientId: clientId,
-          connection: self.connection,
-          queue: self.queue
-        )
-        // Release the ConnectionHandler — the WS manager now owns the NWConnection.
-        // Do NOT cancel the connection; only release our retain cycle.
-        self.retainSelf = nil
-      })
+    if request.path == "/ws", request.method == "GET" {
+      if let wsResponse = server.comfyBridge.handleWebSocketUpgrade(request: request, connection: connection, queue: queue) {
+        // Send the upgrade response, then keep the connection alive for WebSocket framing.
+        guard !responseSent else { return }
+        responseSent = true
+        connection.send(content: wsResponse, completion: .contentProcessed { [weak self] _ in
+          guard let self, let server = self.server else { return }
+          let clientId = request.queryParameters["clientId"] ?? UUID().uuidString
+          server.comfyBridge.wsManager.registerConnection(
+            clientId: clientId,
+            connection: self.connection,
+            queue: self.queue
+          )
+          // Release the ConnectionHandler — the WS manager now owns the NWConnection.
+          // Do NOT cancel the connection; only release our retain cycle.
+          self.retainSelf = nil
+        })
+      } else {
+        // Invalid WebSocket upgrade request — send 400 and close.
+        finish(with: .error(status: 400, message: "Invalid WebSocket upgrade request"))
+      }
       return
     }
 
@@ -625,7 +628,8 @@ private final class ConnectionHandler {
       case .shutdown(let response):
         self.finish(with: response, shutdownAfterSend: true)
       case .websocketUpgrade:
-        break // Already handled above; should not reach here.
+        // Should not reach here — /ws is handled above before async dispatch.
+        self.finish(with: .error(status: 400, message: "Invalid WebSocket upgrade request"))
       }
     }
   }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -201,11 +201,11 @@ public final class WarmServer {
   private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest) async throws -> ComfyBridgeGenerateResult {
     let payload = GeneratePayload(
       prompt: request.prompt,
-      negativePrompt: request.negativePrompt,
+      negativePrompt: nil,  // Z-Image Turbo: negative prompts cause broadcast_shapes crash
       width: request.width,
       height: request.height,
       steps: request.steps,
-      guidance: request.guidance,
+      guidance: 0.0,  // Z-Image Turbo: designed for cfg=0
       seed: request.seed,
       outputPath: nil
     )

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -198,12 +198,41 @@ public final class WarmServer {
 
   /// Bridge a ComfyUI workflow request to the internal generate pipeline.
   /// Called by ComfyBridgeExecutor via the closure set in init.
+  /// Read PNG dimensions from IHDR chunk (bytes 16-23 of a valid PNG).
+  private func pngDimensions(from data: Data) -> (width: Int, height: Int)? {
+    guard data.count >= 24 else { return nil }
+    let w = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
+    let h = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
+    return (w, h)
+  }
+
+  /// Round up to nearest multiple of 16 (for latent alignment).
+  private func roundTo16(_ n: Int) -> Int {
+    return ((n + 15) / 16) * 16
+  }
+
   private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest, progressCallback: ComfyBridgeProgressHandler?) async throws -> ComfyBridgeGenerateResult {
+    // Derive dimensions from inpaint image if parser returned 0x0
+    // (happens when workflow has no ImageCrop or EmptyLatentImage nodes)
+    var genWidth = request.width
+    var genHeight = request.height
+    if genWidth == 0 || genHeight == 0, let imgData = request.inpaintImageData {
+      if let dims = pngDimensions(from: imgData) {
+        genWidth = roundTo16(dims.width)
+        genHeight = roundTo16(dims.height)
+        logger.info("WarmServer: derived dimensions from inpaint image: \(dims.width)x\(dims.height) -> \(genWidth)x\(genHeight)")
+      } else {
+        genWidth = 1024
+        genHeight = 1024
+        logger.warning("WarmServer: could not read inpaint image dimensions, falling back to 1024x1024")
+      }
+    }
+
     let payload = GeneratePayload(
       prompt: request.prompt,
       negativePrompt: nil,  // Z-Image Turbo: negative prompts cause broadcast_shapes crash
-      width: request.width,
-      height: request.height,
+      width: genWidth,
+      height: genHeight,
       steps: min(request.steps, 9),  // Z-Image Turbo: optimal at 9 steps, clamp plugin defaults
       guidance: 0.0,  // Z-Image Turbo: designed for cfg=0
       seed: request.seed,
@@ -212,7 +241,9 @@ public final class WarmServer {
       maskData: request.maskImageData,
       denoise: request.denoise,
       maskGrow: request.maskGrow,
-      maskFeather: request.maskFeather
+      maskFeather: request.maskFeather,
+      maskCropX: request.maskCropX,
+      maskCropY: request.maskCropY
     )
 
     // Convert bridge progress callback to pipeline progress handler.
@@ -812,6 +843,8 @@ private struct GeneratePayload: Sendable {
   let denoise: Float?
   let maskGrow: Int?
   let maskFeather: Int?
+  let maskCropX: Int?
+  let maskCropY: Int?
 
   /// Default memberwise init for bridge-created payloads.
   init(
@@ -820,7 +853,8 @@ private struct GeneratePayload: Sendable {
     guidance: Float? = nil, seed: UInt64? = nil, outputPath: String? = nil,
     scheduler: String? = nil, sigmaSchedule: String? = nil, eta: Float? = nil,
     dype: String? = nil, inpaintImageData: Data? = nil, maskData: Data? = nil,
-    denoise: Float? = nil, maskGrow: Int? = nil, maskFeather: Int? = nil
+    denoise: Float? = nil, maskGrow: Int? = nil, maskFeather: Int? = nil,
+    maskCropX: Int? = nil, maskCropY: Int? = nil
   ) {
     self.prompt = prompt; self.negativePrompt = negativePrompt
     self.width = width; self.height = height; self.steps = steps
@@ -829,6 +863,7 @@ private struct GeneratePayload: Sendable {
     self.eta = eta; self.dype = dype
     self.inpaintImageData = inpaintImageData; self.maskData = maskData
     self.denoise = denoise; self.maskGrow = maskGrow; self.maskFeather = maskFeather
+    self.maskCropX = maskCropX; self.maskCropY = maskCropY
   }
 }
 
@@ -858,6 +893,8 @@ extension GeneratePayload: Decodable {
     denoise = nil
     maskGrow = nil
     maskFeather = nil
+    maskCropX = nil
+    maskCropY = nil
   }
 
   func makePipelineRequest(
@@ -916,7 +953,9 @@ extension GeneratePayload: Decodable {
       maskData: maskData,
       denoise: denoise ?? 1.0,
       maskGrow: maskGrow ?? 0,
-      maskFeather: maskFeather ?? 0
+      maskFeather: maskFeather ?? 0,
+      maskCropX: maskCropX ?? 0,
+      maskCropY: maskCropY ?? 0
     )
   }
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -211,7 +211,29 @@ public final class WarmServer {
     return ((n + 15) / 16) * 16
   }
 
+  /// Default LoRA directory path — matches ComfyBridgeObjectInfo discovery path.
+  private static let loraDirectoryPath = ("~/bin/zimage/loras" as NSString).expandingTildeInPath
+
   private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest, progressCallback: ComfyBridgeProgressHandler?) async throws -> ComfyBridgeGenerateResult {
+    // --- Phase 4: Dynamic LoRA swap ---
+    // If the workflow contains LoraLoader nodes, swap LoRAs before generating.
+    // The coordinator serializes operations, so swap completes before generate starts.
+    if !request.loras.isEmpty {
+      let loraEntries = request.loras.map { lora -> LoRAEntry in
+        // Resolve bare filenames to full paths in the LoRA directory.
+        let resolvedPath: String
+        if lora.name.contains("/") || lora.name.hasPrefix("~") {
+          resolvedPath = lora.name
+        } else {
+          resolvedPath = Self.loraDirectoryPath + "/" + lora.name
+        }
+        return LoRAEntry(path: resolvedPath, scale: lora.scale)
+      }
+      let swapPayload = LoRASwapPayload(loras: loraEntries)
+      let swapResult = try await coordinator.enqueueSwap(swapPayload)
+      logger.info("WarmServer: bridge LoRA swap complete — \(swapResult.loraCount) LoRA(s) active")
+    }
+
     // Derive dimensions from inpaint image if parser returned 0x0
     // (happens when workflow has no ImageCrop or EmptyLatentImage nodes)
     var genWidth = request.width

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -210,7 +210,9 @@ public final class WarmServer {
       outputPath: nil,
       inpaintImageData: request.inpaintImageData,
       maskData: request.maskImageData,
-      denoise: request.denoise
+      denoise: request.denoise,
+      maskGrow: request.maskGrow,
+      maskFeather: request.maskFeather
     )
 
     // Convert bridge progress callback to pipeline progress handler.
@@ -808,6 +810,8 @@ private struct GeneratePayload: Sendable {
   let inpaintImageData: Data?
   let maskData: Data?
   let denoise: Float?
+  let maskGrow: Int?
+  let maskFeather: Int?
 
   /// Default memberwise init for bridge-created payloads.
   init(
@@ -816,7 +820,7 @@ private struct GeneratePayload: Sendable {
     guidance: Float? = nil, seed: UInt64? = nil, outputPath: String? = nil,
     scheduler: String? = nil, sigmaSchedule: String? = nil, eta: Float? = nil,
     dype: String? = nil, inpaintImageData: Data? = nil, maskData: Data? = nil,
-    denoise: Float? = nil
+    denoise: Float? = nil, maskGrow: Int? = nil, maskFeather: Int? = nil
   ) {
     self.prompt = prompt; self.negativePrompt = negativePrompt
     self.width = width; self.height = height; self.steps = steps
@@ -824,7 +828,7 @@ private struct GeneratePayload: Sendable {
     self.scheduler = scheduler; self.sigmaSchedule = sigmaSchedule
     self.eta = eta; self.dype = dype
     self.inpaintImageData = inpaintImageData; self.maskData = maskData
-    self.denoise = denoise
+    self.denoise = denoise; self.maskGrow = maskGrow; self.maskFeather = maskFeather
   }
 }
 
@@ -852,6 +856,8 @@ extension GeneratePayload: Decodable {
     inpaintImageData = nil
     maskData = nil
     denoise = nil
+    maskGrow = nil
+    maskFeather = nil
   }
 
   func makePipelineRequest(
@@ -908,7 +914,9 @@ extension GeneratePayload: Decodable {
       dyPE: dyPEConfig,
       inpaintImageData: inpaintImageData,
       maskData: maskData,
-      denoise: denoise ?? 1.0
+      denoise: denoise ?? 1.0,
+      maskGrow: maskGrow ?? 0,
+      maskFeather: maskFeather ?? 0
     )
   }
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -47,8 +47,8 @@ public final class WarmServer {
     self.logger = logger
     self.coordinator = WarmServerCoordinator(configuration: configuration, logger: logger)
     self.comfyBridge = ComfyBridge(logger: logger)
-    self.comfyBridge.configureExecutor(generateHandler: { [unowned self] request in
-      try await self.bridgeGenerate(request)
+    self.comfyBridge.configureExecutor(generateHandler: { [unowned self] request, progressCallback in
+      try await self.bridgeGenerate(request, progressCallback: progressCallback)
     })
   }
 
@@ -198,18 +198,28 @@ public final class WarmServer {
 
   /// Bridge a ComfyUI workflow request to the internal generate pipeline.
   /// Called by ComfyBridgeExecutor via the closure set in init.
-  private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest) async throws -> ComfyBridgeGenerateResult {
+  private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest, progressCallback: ComfyBridgeProgressHandler?) async throws -> ComfyBridgeGenerateResult {
     let payload = GeneratePayload(
       prompt: request.prompt,
       negativePrompt: nil,  // Z-Image Turbo: negative prompts cause broadcast_shapes crash
       width: request.width,
       height: request.height,
-      steps: request.steps,
+      steps: min(request.steps, 9),  // Z-Image Turbo: optimal at 9 steps, clamp plugin defaults
       guidance: 0.0,  // Z-Image Turbo: designed for cfg=0
       seed: request.seed,
       outputPath: nil
     )
-    let result = try await coordinator.enqueueGenerate(payload)
+
+    // Convert bridge progress callback to pipeline progress handler.
+    let pipelineProgress: (@Sendable (ZImagePipeline.GenerationProgress) -> Void)? = progressCallback.map { callback in
+      return { progress in
+        if progress.stage == .denoising {
+          callback(progress.stepIndex, progress.totalSteps)
+        }
+      }
+    }
+
+    let result = try await coordinator.enqueueGenerate(payload, progressHandler: pipelineProgress)
     return ComfyBridgeGenerateResult(
       outputPath: result.outputPath,
       durationMs: result.durationMs
@@ -343,7 +353,10 @@ private actor WarmServerCoordinator {
     logger.info("Warm server pipeline ready")
   }
 
-  func enqueueGenerate(_ payload: GeneratePayload) async throws -> GenerateResponse {
+  func enqueueGenerate(
+    _ payload: GeneratePayload,
+    progressHandler: (@Sendable (ZImagePipeline.GenerationProgress) -> Void)? = nil
+  ) async throws -> GenerateResponse {
     if shuttingDown {
       throw ServerError.shuttingDown
     }
@@ -352,7 +365,7 @@ private actor WarmServerCoordinator {
     }
 
     return try await withCheckedThrowingContinuation { continuation in
-      pending.append(.generate(payload, ContinuationBox(continuation)))
+      pending.append(.generate(payload, ContinuationBox(continuation), progressHandler))
       startProcessingIfNeeded()
     }
   }
@@ -424,8 +437,8 @@ private actor WarmServerCoordinator {
 
       let operation = pending.removeFirst()
       switch operation {
-      case .generate(let payload, let continuation):
-        await runGenerate(payload, continuation: continuation)
+      case .generate(let payload, let continuation, let progressHandler):
+        await runGenerate(payload, continuation: continuation, progressHandler: progressHandler)
       case .swap(let payload, let continuation):
         await runSwap(payload, continuation: continuation)
       case .shutdown(let continuation):
@@ -439,7 +452,7 @@ private actor WarmServerCoordinator {
     }
   }
 
-  private func runGenerate(_ payload: GeneratePayload, continuation: ContinuationBox<GenerateResponse>) async {
+  private func runGenerate(_ payload: GeneratePayload, continuation: ContinuationBox<GenerateResponse>, progressHandler: (@Sendable (ZImagePipeline.GenerationProgress) -> Void)? = nil) async {
     activeRenderStartedAt = Date()
     let start = Date()
 
@@ -448,7 +461,7 @@ private actor WarmServerCoordinator {
         configuration: configuration,
         activeLoRAs: activeLoRAs
       )
-      let outputURL = try await pipeline.generateFromRequest(request)
+      let outputURL = try await pipeline.generateFromRequest(request, progressHandler: progressHandler)
       let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
       successfulRenderCount += 1
       lastRenderDurationMs = durationMs
@@ -923,7 +936,7 @@ struct ErrorPayload: Encodable {
 }
 
 private enum QueuedOperation: Sendable {
-  case generate(GeneratePayload, ContinuationBox<GenerateResponse>)
+  case generate(GeneratePayload, ContinuationBox<GenerateResponse>, (@Sendable (ZImagePipeline.GenerationProgress) -> Void)?)
   case swap(LoRASwapPayload, ContinuationBox<LoRASwapResponse>)
   case shutdown(ContinuationBox<ShutdownResponse>)
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -214,6 +214,9 @@ public final class WarmServer {
   /// Default LoRA directory path — matches ComfyBridgeObjectInfo discovery path.
   private static let loraDirectoryPath = ("~/bin/zimage/loras" as NSString).expandingTildeInPath
 
+  /// Default ControlNet directory path — matches ComfyBridgeObjectInfo discovery path.
+  private static let controlnetDirectoryPath = ("~/bin/zimage/controlnet" as NSString).expandingTildeInPath
+
   private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest, progressCallback: ComfyBridgeProgressHandler?) async throws -> ComfyBridgeGenerateResult {
     // --- Phase 4: Dynamic LoRA swap ---
     // If the workflow contains LoraLoader nodes, swap LoRAs before generating.
@@ -248,6 +251,114 @@ public final class WarmServer {
         genHeight = 1024
         logger.warning("WarmServer: could not read inpaint image dimensions, falling back to 1024x1024")
       }
+    }
+
+    // --- Phase 4: ControlNet routing ---
+    // If the workflow contains ControlNet nodes, route to ZImageControlPipeline
+    // instead of the standard ZImagePipeline.
+    if request.isControlNet, let controlnetModel = request.controlnetModel {
+      logger.info("WarmServer: routing to ControlNet pipeline — model=\(controlnetModel), strength=\(request.controlnetStrength)")
+
+      // Resolve controlnet model name to a path or HuggingFace ID
+      let resolvedControlnetWeights: String
+      if controlnetModel.contains("/") || controlnetModel.hasPrefix("~") || controlnetModel.hasPrefix(".") {
+        // Already a path or HuggingFace ID — use as-is
+        resolvedControlnetWeights = controlnetModel
+      } else {
+        // Bare name — check if it's a local directory/file in the controlnet dir
+        let localPath = Self.controlnetDirectoryPath + "/" + controlnetModel
+        if FileManager.default.fileExists(atPath: localPath) {
+          resolvedControlnetWeights = localPath
+        } else {
+          // Treat as HuggingFace ID
+          resolvedControlnetWeights = controlnetModel
+        }
+      }
+
+      // Write control image data to a temp file if we have it
+      var controlImageURL: URL? = nil
+      if let controlData = request.controlImageData {
+        let tempPath = NSTemporaryDirectory() + "zimage-control-\(UUID().uuidString).png"
+        try controlData.write(to: URL(fileURLWithPath: tempPath))
+        controlImageURL = URL(fileURLWithPath: tempPath)
+        logger.info("WarmServer: wrote control image to \(tempPath) (\(controlData.count) bytes)")
+      }
+
+      // Write inpaint image to temp file if present
+      var inpaintImageURL: URL? = nil
+      if let inpaintData = request.inpaintImageData {
+        let tempPath = NSTemporaryDirectory() + "zimage-inpaint-\(UUID().uuidString).png"
+        try inpaintData.write(to: URL(fileURLWithPath: tempPath))
+        inpaintImageURL = URL(fileURLWithPath: tempPath)
+      }
+
+      // Write mask to temp file if present
+      var maskImageURL: URL? = nil
+      if let maskData = request.maskImageData {
+        let tempPath = NSTemporaryDirectory() + "zimage-mask-\(UUID().uuidString).png"
+        try maskData.write(to: URL(fileURLWithPath: tempPath))
+        maskImageURL = URL(fileURLWithPath: tempPath)
+      }
+
+      let outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("zimage-\(UUID().uuidString).png")
+
+      // Build LoRA configurations for the control pipeline
+      let controlLoRAs: [LoRAConfiguration] = request.loras.map { lora in
+        let resolvedPath: String
+        if lora.name.contains("/") || lora.name.hasPrefix("~") {
+          resolvedPath = lora.name
+        } else {
+          resolvedPath = Self.loraDirectoryPath + "/" + lora.name
+        }
+        return .local(resolvedPath, scale: lora.scale)
+      }
+
+      let controlRequest = ZImageControlGenerationRequest(
+        prompt: request.prompt,
+        negativePrompt: nil,
+        controlImage: controlImageURL,
+        inpaintImage: inpaintImageURL,
+        maskImage: maskImageURL,
+        controlContextScale: request.controlnetStrength,
+        width: genWidth,
+        height: genHeight,
+        steps: request.steps,
+        guidanceScale: 0.0,
+        seed: request.seed,
+        outputPath: outputURL,
+        model: nil,
+        textEncoderPath: configuration.textEncoderPath,
+        controlnetWeights: resolvedControlnetWeights,
+        // For HuggingFace repos with multiple safetensors, specify the 8-step variant
+        controlnetWeightsFile: resolvedControlnetWeights.contains("alibaba-pai")
+          ? "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors" : nil,
+        maxSequenceLength: configuration.maxSequenceLength,
+        loras: controlLoRAs,
+        progressCallback: progressCallback.map { callback in
+          return { progress in
+            if progress.stage == "Denoising" {
+              callback(progress.stepIndex, progress.totalSteps)
+            }
+          }
+        },
+        enhancePrompt: false,
+        enhanceMaxTokens: 512
+      )
+
+      let start = Date()
+      let result = try await coordinator.enqueueControlGenerate(controlRequest)
+      let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
+
+      // Clean up temp files
+      if let url = controlImageURL { try? FileManager.default.removeItem(at: url) }
+      if let url = inpaintImageURL { try? FileManager.default.removeItem(at: url) }
+      if let url = maskImageURL { try? FileManager.default.removeItem(at: url) }
+
+      return ComfyBridgeGenerateResult(
+        outputPath: result.outputPath,
+        durationMs: result.durationMs
+      )
     }
 
     let payload = GeneratePayload(
@@ -380,6 +491,8 @@ private actor WarmServerCoordinator {
   private let configuration: WarmServerConfiguration
   private let logger: Logger
   private let pipeline: ZImagePipeline
+  /// Lazy-initialized ControlNet pipeline — only created when first ControlNet request arrives.
+  private var controlPipeline: ZImageControlPipeline?
   private let startTime = Date()
   private var activeLoRAs: [LoRAConfiguration]
   private var pending: [QueuedOperation] = []
@@ -442,6 +555,20 @@ private actor WarmServerCoordinator {
     }
   }
 
+  func enqueueControlGenerate(_ request: ZImageControlGenerationRequest) async throws -> GenerateResponse {
+    if shuttingDown {
+      throw ServerError.shuttingDown
+    }
+    if pending.count >= configuration.maxPendingRequests {
+      throw ServerError.queueFull(maxPending: configuration.maxPendingRequests)
+    }
+
+    return try await withCheckedThrowingContinuation { continuation in
+      pending.append(.controlGenerate(request, ContinuationBox(continuation)))
+      startProcessingIfNeeded()
+    }
+  }
+
   func enqueueShutdown() async throws -> ShutdownResponse {
     if shuttingDown {
       throw ServerError.shuttingDown
@@ -497,6 +624,8 @@ private actor WarmServerCoordinator {
       switch operation {
       case .generate(let payload, let continuation, let progressHandler):
         await runGenerate(payload, continuation: continuation, progressHandler: progressHandler)
+      case .controlGenerate(let request, let continuation):
+        await runControlGenerate(request, continuation: continuation)
       case .swap(let payload, let continuation):
         await runSwap(payload, continuation: continuation)
       case .shutdown(let continuation):
@@ -520,6 +649,39 @@ private actor WarmServerCoordinator {
         activeLoRAs: activeLoRAs
       )
       let outputURL = try await pipeline.generateFromRequest(request, progressHandler: progressHandler)
+      let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
+      successfulRenderCount += 1
+      lastRenderDurationMs = durationMs
+      lastError = nil
+      activeRenderStartedAt = nil
+
+      continuation.resume(
+        returning: GenerateResponse(
+          success: true,
+          outputPath: outputURL.path,
+          durationMs: durationMs
+        )
+      )
+    } catch {
+      failedRenderCount += 1
+      lastError = error.localizedDescription
+      activeRenderStartedAt = nil
+      continuation.resume(throwing: error)
+    }
+  }
+
+  private func runControlGenerate(_ request: ZImageControlGenerationRequest, continuation: ContinuationBox<GenerateResponse>) async {
+    activeRenderStartedAt = Date()
+    let start = Date()
+
+    do {
+      // Lazy-init the control pipeline on first ControlNet request
+      if controlPipeline == nil {
+        logger.info("Initializing ControlNet pipeline (first use)...")
+        controlPipeline = ZImageControlPipeline(logger: logger)
+      }
+
+      let outputURL = try await controlPipeline!.generate(request)
       let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
       successfulRenderCount += 1
       lastRenderDurationMs = durationMs
@@ -1061,6 +1223,7 @@ struct ErrorPayload: Encodable {
 
 private enum QueuedOperation: Sendable {
   case generate(GeneratePayload, ContinuationBox<GenerateResponse>, (@Sendable (ZImagePipeline.GenerationProgress) -> Void)?)
+  case controlGenerate(ZImageControlGenerationRequest, ContinuationBox<GenerateResponse>)
   case swap(LoRASwapPayload, ContinuationBox<LoRASwapResponse>)
   case shutdown(ContinuationBox<ShutdownResponse>)
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -207,7 +207,10 @@ public final class WarmServer {
       steps: min(request.steps, 9),  // Z-Image Turbo: optimal at 9 steps, clamp plugin defaults
       guidance: 0.0,  // Z-Image Turbo: designed for cfg=0
       seed: request.seed,
-      outputPath: nil
+      outputPath: nil,
+      inpaintImageData: request.inpaintImageData,
+      maskData: request.maskImageData,
+      denoise: request.denoise
     )
 
     // Convert bridge progress callback to pipeline progress handler.
@@ -788,7 +791,7 @@ enum RoutedResponse {
   }
 }
 
-private struct GeneratePayload: Decodable, Sendable {
+private struct GeneratePayload: Sendable {
   let prompt: String
   let negativePrompt: String?
   let width: Int?
@@ -801,6 +804,55 @@ private struct GeneratePayload: Decodable, Sendable {
   let sigmaSchedule: String?
   let eta: Float?
   let dype: String?
+  // Phase 3: Inpainting data (set by bridge, not by HTTP API)
+  let inpaintImageData: Data?
+  let maskData: Data?
+  let denoise: Float?
+
+  /// Default memberwise init for bridge-created payloads.
+  init(
+    prompt: String, negativePrompt: String? = nil,
+    width: Int? = nil, height: Int? = nil, steps: Int? = nil,
+    guidance: Float? = nil, seed: UInt64? = nil, outputPath: String? = nil,
+    scheduler: String? = nil, sigmaSchedule: String? = nil, eta: Float? = nil,
+    dype: String? = nil, inpaintImageData: Data? = nil, maskData: Data? = nil,
+    denoise: Float? = nil
+  ) {
+    self.prompt = prompt; self.negativePrompt = negativePrompt
+    self.width = width; self.height = height; self.steps = steps
+    self.guidance = guidance; self.seed = seed; self.outputPath = outputPath
+    self.scheduler = scheduler; self.sigmaSchedule = sigmaSchedule
+    self.eta = eta; self.dype = dype
+    self.inpaintImageData = inpaintImageData; self.maskData = maskData
+    self.denoise = denoise
+  }
+}
+
+extension GeneratePayload: Decodable {
+  private enum CodingKeys: String, CodingKey {
+    case prompt, negativePrompt, width, height, steps, guidance, seed
+    case outputPath, scheduler, sigmaSchedule, eta, dype
+    // inpaintImageData, maskData, denoise are excluded from JSON decoding
+  }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    prompt = try c.decode(String.self, forKey: .prompt)
+    negativePrompt = try c.decodeIfPresent(String.self, forKey: .negativePrompt)
+    width = try c.decodeIfPresent(Int.self, forKey: .width)
+    height = try c.decodeIfPresent(Int.self, forKey: .height)
+    steps = try c.decodeIfPresent(Int.self, forKey: .steps)
+    guidance = try c.decodeIfPresent(Float.self, forKey: .guidance)
+    seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
+    outputPath = try c.decodeIfPresent(String.self, forKey: .outputPath)
+    scheduler = try c.decodeIfPresent(String.self, forKey: .scheduler)
+    sigmaSchedule = try c.decodeIfPresent(String.self, forKey: .sigmaSchedule)
+    eta = try c.decodeIfPresent(Float.self, forKey: .eta)
+    dype = try c.decodeIfPresent(String.self, forKey: .dype)
+    inpaintImageData = nil
+    maskData = nil
+    denoise = nil
+  }
 
   func makePipelineRequest(
     configuration: WarmServerConfiguration,
@@ -853,7 +905,10 @@ private struct GeneratePayload: Decodable, Sendable {
       schedulerKind: schedulerKind,
       sigmaSchedule: sigmaScheduleKind,
       eta: eta,
-      dyPE: dyPEConfig
+      dyPE: dyPEConfig,
+      inpaintImageData: inpaintImageData,
+      maskData: maskData,
+      denoise: denoise ?? 1.0
     )
   }
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -47,6 +47,9 @@ public final class WarmServer {
     self.logger = logger
     self.coordinator = WarmServerCoordinator(configuration: configuration, logger: logger)
     self.comfyBridge = ComfyBridge(logger: logger)
+    self.comfyBridge.configureExecutor(generateHandler: { [unowned self] request in
+      try await self.bridgeGenerate(request)
+    })
   }
 
   public func run() throws {
@@ -190,6 +193,27 @@ public final class WarmServer {
       }
       return .error(.error(status: 404, message: "Not found"))
     }
+  }
+
+
+  /// Bridge a ComfyUI workflow request to the internal generate pipeline.
+  /// Called by ComfyBridgeExecutor via the closure set in init.
+  private func bridgeGenerate(_ request: ComfyBridgeGenerateRequest) async throws -> ComfyBridgeGenerateResult {
+    let payload = GeneratePayload(
+      prompt: request.prompt,
+      negativePrompt: request.negativePrompt,
+      width: request.width,
+      height: request.height,
+      steps: request.steps,
+      guidance: request.guidance,
+      seed: request.seed,
+      outputPath: nil
+    )
+    let result = try await coordinator.enqueueGenerate(payload)
+    return ComfyBridgeGenerateResult(
+      outputPath: result.outputPath,
+      durationMs: result.durationMs
+    )
   }
 
   fileprivate func requestShutdownAfterResponse() {

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -36,6 +36,7 @@ public final class WarmServer {
   private let configuration: WarmServerConfiguration
   private let logger: Logger
   private let coordinator: WarmServerCoordinator
+  let comfyBridge: ComfyBridge
   private let listenerQueue = DispatchQueue(label: "z-image.warm-server.listener")
   private let lifecycleLock = NSLock()
   private var listener: NWListener?
@@ -45,6 +46,7 @@ public final class WarmServer {
     self.configuration = configuration
     self.logger = logger
     self.coordinator = WarmServerCoordinator(configuration: configuration, logger: logger)
+    self.comfyBridge = ComfyBridge(logger: logger)
   }
 
   public func run() throws {
@@ -145,6 +147,11 @@ public final class WarmServer {
   }
 
   fileprivate func respond(to request: HTTPRequest) async -> RoutedResponse {
+    // Try ComfyUI bridge routes first.
+    if let bridgeResponse = comfyBridge.route(request) {
+      return bridgeResponse
+    }
+
     switch (request.method, request.path) {
     case ("GET", "/health"):
       let memoryBytes = Self.currentMemoryFootprintBytes()
@@ -462,7 +469,8 @@ private actor WarmServerCoordinator {
 
 private final class ConnectionHandler {
   private static let headerDelimiter = Data("\r\n\r\n".utf8)
-  private static let maximumRequestBytes = 1_048_576
+  /// 10 MB — raised from 1 MB to support ComfyUI image uploads via PUT /api/etn/image/.
+  private static let maximumRequestBytes = 10_485_760
 
   private let connection: NWConnection
   private let queue: DispatchQueue
@@ -564,12 +572,15 @@ private final class ConnectionHandler {
 
     let body = buffer.subdata(in: bodyStart..<totalLength)
     let rawPath = String(requestParts[1])
-    let path = rawPath.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? rawPath
+    let pathAndQuery = rawPath.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+    let path = pathAndQuery.first.map(String.init) ?? rawPath
+    let queryString: String? = pathAndQuery.count > 1 ? String(pathAndQuery[1]) : nil
 
     return .request(
       HTTPRequest(
         method: String(requestParts[0]).uppercased(),
         path: path,
+        queryString: queryString,
         headers: headers,
         body: body
       )
@@ -582,6 +593,28 @@ private final class ConnectionHandler {
       return
     }
 
+    // Check for WebSocket upgrade before entering the async router.
+    if request.path == "/ws",
+       request.method == "GET",
+       let wsResponse = server.comfyBridge.handleWebSocketUpgrade(request: request, connection: connection, queue: queue) {
+      // Send the upgrade response, then keep the connection alive for WebSocket framing.
+      guard !responseSent else { return }
+      responseSent = true
+      connection.send(content: wsResponse, completion: .contentProcessed { [weak self] _ in
+        guard let self, let server = self.server else { return }
+        let clientId = request.queryParameters["clientId"] ?? UUID().uuidString
+        server.comfyBridge.wsManager.registerConnection(
+          clientId: clientId,
+          connection: self.connection,
+          queue: self.queue
+        )
+        // Release the ConnectionHandler — the WS manager now owns the NWConnection.
+        // Do NOT cancel the connection; only release our retain cycle.
+        self.retainSelf = nil
+      })
+      return
+    }
+
     Task {
       let routed = await server.respond(to: request)
       switch routed {
@@ -591,6 +624,8 @@ private final class ConnectionHandler {
         self.finish(with: response)
       case .shutdown(let response):
         self.finish(with: response, shutdownAfterSend: true)
+      case .websocketUpgrade:
+        break // Already handled above; should not reach here.
       }
     }
   }
@@ -610,29 +645,56 @@ private final class ConnectionHandler {
   }
 }
 
-private struct HTTPRequest {
+struct HTTPRequest {
   let method: String
   let path: String
+  let queryString: String?
   let headers: [String: String]
   let body: Data
+
+  /// Parse query parameters from the query string.
+  var queryParameters: [String: String] {
+    guard let qs = queryString, !qs.isEmpty else { return [:] }
+    var params: [String: String] = [:]
+    for pair in qs.split(separator: "&") {
+      let parts = pair.split(separator: "=", maxSplits: 1)
+      if parts.count == 2 {
+        params[String(parts[0])] = String(parts[1])
+      } else if parts.count == 1 {
+        params[String(parts[0])] = ""
+      }
+    }
+    return params
+  }
 }
 
-private enum HTTPParseResult {
+enum HTTPParseResult {
   case incomplete
   case request(HTTPRequest)
   case error(HTTPResponse)
 }
 
-private struct HTTPResponse {
+struct HTTPResponse {
   let status: Int
   let reasonPhrase: String
+  let contentType: String
   let body: Data
 
   static func json<T: Encodable>(status: Int, payload: T) -> HTTPResponse {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let body = (try? encoder.encode(payload)) ?? Data("{\"success\":false,\"error\":\"encoding failure\"}".utf8)
-    return HTTPResponse(status: status, reasonPhrase: reasonPhrase(for: status), body: body)
+    return HTTPResponse(status: status, reasonPhrase: reasonPhrase(for: status), contentType: "application/json", body: body)
+  }
+
+  /// Create a JSON response from pre-encoded Data (no snake_case conversion).
+  static func rawJSON(status: Int, data: Data) -> HTTPResponse {
+    HTTPResponse(status: status, reasonPhrase: reasonPhrase(for: status), contentType: "application/json", body: data)
+  }
+
+  /// Create a binary response with a specified content type.
+  static func binary(status: Int, contentType: String, data: Data) -> HTTPResponse {
+    HTTPResponse(status: status, reasonPhrase: reasonPhrase(for: status), contentType: contentType, body: data)
   }
 
   static func error(status: Int, message: String) -> HTTPResponse {
@@ -643,7 +705,7 @@ private struct HTTPResponse {
     var data = Data()
     let header = [
       "HTTP/1.1 \(status) \(reasonPhrase)",
-      "Content-Type: application/json",
+      "Content-Type: \(contentType)",
       "Content-Length: \(body.count)",
       "Connection: close",
       "",
@@ -654,7 +716,7 @@ private struct HTTPResponse {
     return data
   }
 
-  private static func reasonPhrase(for status: Int) -> String {
+  static func reasonPhrase(for status: Int) -> String {
     switch status {
     case 200: return "OK"
     case 400: return "Bad Request"
@@ -669,10 +731,12 @@ private struct HTTPResponse {
   }
 }
 
-private enum RoutedResponse {
+enum RoutedResponse {
   case json(HTTPResponse)
   case shutdown(HTTPResponse)
   case error(HTTPResponse)
+  /// WebSocket upgrade — the bridge takes ownership of the connection.
+  case websocketUpgrade
 
   static func json<T: Encodable>(status: Int, payload: T) -> RoutedResponse {
     .json(.json(status: status, payload: payload))
@@ -825,7 +889,7 @@ private struct LoRAState: Encodable, Sendable {
   }
 }
 
-private struct ErrorPayload: Encodable {
+struct ErrorPayload: Encodable {
   let success: Bool
   let error: String
 }

--- a/Sources/ZImage/Upscale/SeedVR2/Common/CausalConv3d.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/CausalConv3d.swift
@@ -1,0 +1,135 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// A 3D convolution with causal temporal padding for the SeedVR2 video VAE.
+///
+/// In video autoencoders, temporal causality ensures that the encoding of frame `t`
+/// depends only on frames `<= t`. This is achieved by replicating the first frame
+/// to fill the temporal receptive field, rather than using symmetric zero-padding.
+///
+/// ## Weight Layout
+///
+/// Weights are stored as `(C_out, K_t, K_h, K_w, C_in)` — the MLX channels-last
+/// layout for 3D convolution kernels.
+///
+/// ## Input Layout
+///
+/// The Python reference uses BCTHW (batch, channels, time, height, width) as the
+/// external interface. Internally, the convolution operates on BTHWC (channels-last)
+/// because MLX `convGeneral` expects `(N, ..., C_in)` inputs. This module handles
+/// the necessary transposes.
+///
+/// ## Padding Modes
+///
+/// - `causalTemporal = true` (default): Replicates the first temporal frame
+///   `(kernel_t - 1)` times and prepends them, with zero temporal padding in the
+///   convolution itself. Spatial padding is applied normally.
+/// - `causalTemporal = true, usePaddingCausal = true`: Uses `2 * padding_t` replicated
+///   frames instead of `kernel_t - 1`.
+/// - `causalTemporal = false`: Standard symmetric temporal padding (no replication).
+public final class CausalConv3d: Module {
+
+  /// Convolution kernel weights: shape `(C_out, K_t, K_h, K_w, C_in)`.
+  public var weight: MLXArray
+
+  /// Bias vector: shape `(C_out,)`.
+  public var bias: MLXArray
+
+  /// Kernel size as `(temporal, height, width)`.
+  public let kernelSize: (Int, Int, Int)
+
+  /// Stride as `(temporal, height, width)`.
+  public let stride: (Int, Int, Int)
+
+  /// Nominal padding as `(temporal, height, width)`.
+  /// When ``causalTemporal`` is true, the temporal component drives the causal
+  /// pad size but is not passed to the convolution.
+  public let padding: (Int, Int, Int)
+
+  /// Whether to apply causal temporal padding via frame replication.
+  public let causalTemporal: Bool
+
+  /// When true and ``causalTemporal`` is true, uses `2 * padding.temporal`
+  /// replicated frames instead of `kernel_t - 1`.
+  public let usePaddingCausal: Bool
+
+  /// Creates a causal 3D convolution layer.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - kernelSize: Convolution kernel size as `(t, h, w)`.
+  ///   - stride: Convolution stride as `(t, h, w)`. Default `(1, 1, 1)`.
+  ///   - padding: Nominal padding as `(t, h, w)`. Default `(1, 1, 1)`.
+  ///   - causalTemporal: Whether to replicate the first frame for causal padding.
+  ///     Default `true`.
+  ///   - usePaddingCausal: If true, the causal pad count is `2 * padding.t` instead
+  ///     of `kernelSize.t - 1`. Default `false`.
+  public init(
+    inChannels: Int,
+    outChannels: Int,
+    kernelSize: (Int, Int, Int) = (3, 3, 3),
+    stride: (Int, Int, Int) = (1, 1, 1),
+    padding: (Int, Int, Int) = (1, 1, 1),
+    causalTemporal: Bool = true,
+    usePaddingCausal: Bool = false
+  ) {
+    self.kernelSize = kernelSize
+    self.stride = stride
+    self.padding = padding
+    self.causalTemporal = causalTemporal
+    self.usePaddingCausal = usePaddingCausal
+
+    let (kt, kh, kw) = kernelSize
+    self.weight = MLXArray.zeros([outChannels, kt, kh, kw, inChannels])
+    self.bias = MLXArray.zeros([outChannels])
+
+    super.init()
+  }
+
+  /// Applies the causal 3D convolution.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)` (channels-first,
+  ///   matching the Python SeedVR2 VAE convention).
+  /// - Returns: Output tensor of shape `(B, C_out, T_out, H_out, W_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var input = x
+    let (kt, _, _) = kernelSize
+    let (pt, ph, pw) = padding
+
+    // --- Temporal padding ---
+    let temporalPadding: Int
+    if causalTemporal && kt > 1 {
+      let causalPad = usePaddingCausal ? (2 * pt) : (kt - 1)
+      if causalPad > 0 {
+        // Replicate the first frame along the temporal axis.
+        // Input shape: (B, C, T, H, W) — temporal is axis 2.
+        let firstFrame = input[0..., 0..., ..<1, 0..., 0...]
+        let padFrames = MLX.repeated(firstFrame, count: causalPad, axis: 2)
+        input = MLX.concatenated([padFrames, input], axis: 2)
+      }
+      temporalPadding = 0
+    } else {
+      temporalPadding = pt
+    }
+
+    // --- Transpose BCTHW -> BTHWC for convGeneral ---
+    input = input.transposed(0, 2, 3, 4, 1)
+
+    // --- 3D convolution ---
+    var out = convGeneral(
+      input, weight,
+      strides: IntOrArray([stride.0, stride.1, stride.2]),
+      padding: IntOrArray([temporalPadding, ph, pw])
+    )
+
+    // --- Add bias ---
+    out = out + bias
+
+    // --- Transpose BTHWC -> BCTHW ---
+    out = out.transposed(0, 4, 1, 2, 3)
+
+    return out
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2EulerScheduler.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2EulerScheduler.swift
@@ -1,0 +1,110 @@
+import Foundation
+import MLX
+
+/// Flow-matching Euler scheduler for SeedVR2 super-resolution inference.
+///
+/// SeedVR2 uses a continuous-time flow-matching formulation where the model
+/// predicts the velocity field between the noisy input and the clean output.
+/// This scheduler implements the Euler discretization of that flow.
+///
+/// ## Timestep Computation
+///
+/// Given N inference steps and T training timesteps (default 1000):
+///
+///     step_size = T / N
+///     timesteps = [T, T - step_size, ..., 0]    (N+1 values)
+///     sigmas    = timesteps / T                  (normalized to [0, 1])
+///
+/// Each denoising step uses a pair (t, s) of consecutive timesteps.
+///
+/// ## Step Formula
+///
+///     pred_x_0    = sample - (t/T) * model_output
+///     pred_noise  = sample + (1 - t/T) * model_output
+///
+///     if s == 0 (final step):
+///         return pred_x_0
+///     else:
+///         return (1 - s/T) * pred_x_0 + (s/T) * pred_noise
+///
+/// For a single-step schedule (the default), one model evaluation suffices.
+public struct SeedVR2EulerScheduler {
+
+  /// Number of training timesteps the model was trained with.
+  public let numTrainTimesteps: Int
+
+  /// Number of inference steps to run.
+  public let numInferenceSteps: Int
+
+  /// Classifier-free guidance scale (unused in the step formula but stored for callers).
+  public let guidance: Float
+
+  /// The training timestep ceiling as a float for arithmetic.
+  private let T: Float
+
+  /// Timestep values: N+1 elements from T down to 0.
+  public let timesteps: MLXArray
+
+  /// Sigma values: timesteps / T, normalized to [0, 1].
+  public let sigmas: MLXArray
+
+  /// Creates a SeedVR2 Euler scheduler.
+  ///
+  /// - Parameters:
+  ///   - numTrainTimesteps: Number of timesteps used during training. Default 1000.
+  ///   - numInferenceSteps: Number of denoising steps at inference. Default 1.
+  ///   - guidance: Classifier-free guidance scale. Default 1.0.
+  public init(
+    numTrainTimesteps: Int = 1000,
+    numInferenceSteps: Int = 1,
+    guidance: Float = 1.0
+  ) {
+    self.numTrainTimesteps = numTrainTimesteps
+    self.numInferenceSteps = numInferenceSteps
+    self.guidance = guidance
+    self.T = Float(numTrainTimesteps)
+
+    let stepSize = self.T / Float(numInferenceSteps)
+    var values: [Float] = []
+    for i in 0...numInferenceSteps {
+      let t = self.T - Float(i) * stepSize
+      values.append(max(t, 0.0))
+    }
+
+    self.timesteps = MLXArray(values)
+    self.sigmas = MLXArray(values.map { v in v / Float(numTrainTimesteps) })
+  }
+
+  /// Performs a single Euler step.
+  ///
+  /// - Parameters:
+  ///   - modelOutput: The model predicted velocity (same shape as sample).
+  ///   - timestepIndex: Index into the timesteps array for the current step.
+  ///     The next timestep is timesteps[timestepIndex + 1].
+  ///   - sample: The current noisy latent.
+  /// - Returns: The denoised (or partially denoised) latent.
+  public func step(
+    modelOutput: MLXArray,
+    timestepIndex: Int,
+    sample: MLXArray
+  ) -> MLXArray {
+    let t = timesteps[timestepIndex]
+    let s = timesteps[timestepIndex + 1]
+
+    let tNorm = t / T
+    let sNorm = s / T
+
+    // Predicted clean sample and noise from flow matching.
+    let predX0 = sample - tNorm * modelOutput
+    let predNoise = sample + (1 - tNorm) * modelOutput
+
+    // If this is the final step (s == 0), return the clean prediction directly.
+    // Otherwise, interpolate between clean and noise at the next sigma level.
+    let sValue = s.item(Float.self)
+    if sValue > 0 {
+      return (1 - sNorm) * predX0 + sNorm * predNoise
+    } else {
+      return predX0
+    }
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2LatentCreator.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2LatentCreator.swift
@@ -1,0 +1,75 @@
+import Foundation
+import MLX
+import MLXRandom
+
+/// Creates noise latents and conditioning tensors for SeedVR2 upscale inference.
+///
+/// The latent creator produces two components needed by the diffusion loop:
+///
+/// 1. **Noise latents**: Random normal noise in the latent space, shaped for the
+///    SeedVR2 transformer. These serve as the starting point for denoising.
+///
+/// 2. **Condition tensor**: The VAE-encoded input image concatenated with a
+///    spatial mask of ones. This conditions the transformer on the low-resolution
+///    input during each denoising step.
+///
+/// ## Tensor Shapes
+///
+/// All tensors use the SeedVR2 5D video format: `(B, C, T, H, W)`.
+///
+/// - Noise latents:  `(B, 16, 1, H_lat, W_lat)`
+/// - Encoded image:  `(B, 16, 1, H_lat, W_lat)`
+/// - Condition mask:  `(1, 1, 1, H_lat, W_lat)` — broadcast across batch and channels
+/// - Full condition: `(B, 17, 1, H_lat, W_lat)` — 16 latent channels + 1 mask channel
+public enum SeedVR2LatentCreator {
+
+  /// Creates random normal noise latents for the diffusion process.
+  ///
+  /// - Parameters:
+  ///   - seed: Random seed for reproducible generation.
+  ///   - height: Latent height (input height / 8).
+  ///   - width: Latent width (input width / 8).
+  ///   - batchSize: Number of samples in the batch. Default `1`.
+  ///   - latentChannels: Number of latent channels. Default `16`.
+  /// - Returns: An MLXArray of shape `(batchSize, latentChannels, 1, height, width)`.
+  public static func createNoiseLatents(
+    seed: Int,
+    height: Int,
+    width: Int,
+    batchSize: Int = 1,
+    latentChannels: Int = 16
+  ) -> MLXArray {
+    let key = MLXRandom.key(UInt64(seed))
+    return MLXRandom.normal(
+      [batchSize, latentChannels, 1, height, width],
+      key: key
+    )
+  }
+
+  /// Creates the conditioning tensor from a VAE-encoded latent.
+  ///
+  /// The condition concatenates the encoded image latent with a spatial mask
+  /// of ones along the channel dimension. The mask indicates valid conditioning
+  /// regions (the entire image, for upscaling).
+  ///
+  /// - Parameter encodedLatent: The VAE-encoded input image. Accepts either
+  ///   4D `(B, C, H, W)` or 5D `(B, C, T, H, W)` input. If 4D, a temporal
+  ///   dimension of 1 is inserted at axis 2.
+  /// - Returns: An MLXArray of shape `(B, C+1, T, H, W)`.
+  public static func createCondition(encodedLatent: MLXArray) -> MLXArray {
+    // Ensure 5D: (B, C, T, H, W)
+    var latent = encodedLatent
+    if latent.ndim == 4 {
+      latent = latent.expandedDimensions(axis: 2)
+    }
+
+    let height = latent.dim(3)
+    let width = latent.dim(4)
+
+    // Create a mask of ones: (1, 1, 1, H, W) — broadcasts across batch
+    let mask = MLXArray.ones([1, 1, 1, height, width])
+
+    // Concatenate along channel axis: (B, C, T, H, W) + (1, 1, 1, H, W) -> (B, C+1, T, H, W)
+    return MLX.concatenated([latent, mask], axis: 1)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2ModelConfig.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2ModelConfig.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Configuration for SeedVR2 model variants (3B and 7B).
+///
+/// The 3B and 7B variants have different architectures:
+///
+/// | Parameter | 3B | 7B |
+/// |-----------|----|----|
+/// | vidDim | 2560 | 3072 |
+/// | heads | 20 | 24 |
+/// | numLayers | 32 | 36 |
+/// | mmLayers | 10 | 36 (all separate) |
+/// | mlpType | SwiGLU | GELU |
+/// | hasOutputNorm | true | false |
+///
+/// The model variant is auto-detected from the weights directory by checking
+/// which transformer weight file is present.
+public struct SeedVR2ModelConfig: Equatable {
+
+  /// Video/text feature dimension.
+  public let vidDim: Int
+
+  /// Text encoder input dimension (always 5120).
+  public let txtInDim: Int
+
+  /// Number of attention heads.
+  public let heads: Int
+
+  /// Dimension per attention head (always 128).
+  public let headDim: Int
+
+  /// RoPE dimension. 3B uses 128 (full head_dim), 7B uses 64 (head_dim/2).
+  public let ropeDim: Int
+
+  /// MLP expansion ratio (always 4).
+  public let expandRatio: Int
+
+  /// Total number of transformer blocks.
+  public let numLayers: Int
+
+  /// Number of multi-modal (separate weight) layers. Blocks >= mmLayers share weights.
+  public let mmLayers: Int
+
+  /// MLP type used in transformer blocks.
+  public let mlpType: SeedVR2MLPType
+
+  /// Whether the transformer has output normalization and adaptive shift/scale.
+  /// True for 3B (uses vid_out_norm + out_shift + out_scale), false for 7B.
+  public let hasOutputNorm: Bool
+
+  /// Whether the last block freezes text (vid-only). True for 3B, false for 7B.
+  public let hasLastLayerFreeze: Bool
+
+  /// Transformer weight file name (without path).
+  public let transformerWeightFile: String
+
+  /// FP8 transformer weight file name (without path).
+  public let transformerWeightFileFP8: String
+
+  /// 3B model configuration preset.
+  public static let preset3B = SeedVR2ModelConfig(
+    vidDim: 2560,
+    txtInDim: 5120,
+    heads: 20,
+    headDim: 128,
+    ropeDim: 128,
+    expandRatio: 4,
+    numLayers: 32,
+    mmLayers: 10,
+    mlpType: .swiglu,
+    hasOutputNorm: true,
+    hasLastLayerFreeze: true,
+    transformerWeightFile: "seedvr2_ema_3b_fp16.safetensors",
+    transformerWeightFileFP8: "seedvr2_ema_3b_fp8.safetensors"
+  )
+
+  /// 7B model configuration preset.
+  public static let preset7B = SeedVR2ModelConfig(
+    vidDim: 3072,
+    txtInDim: 5120,
+    heads: 24,
+    headDim: 128,
+    ropeDim: 64,
+    expandRatio: 4,
+    numLayers: 36,
+    mmLayers: 36,
+    mlpType: .gelu,
+    hasOutputNorm: false,
+    hasLastLayerFreeze: false,
+    transformerWeightFile: "seedvr2_ema_7b_fp16.safetensors",
+    transformerWeightFileFP8: "seedvr2_ema_7b_fp8.safetensors"
+  )
+
+  /// Auto-detects the model variant from the weights directory.
+  ///
+  /// Checks for the presence of 7B or 3B weight files and returns the corresponding config.
+  /// Prefers 7B if both are present.
+  ///
+  /// - Parameter directory: The weights directory URL.
+  /// - Returns: The detected model config, or nil if no recognized weight file is found.
+  public static func detect(from directory: URL) -> SeedVR2ModelConfig? {
+    let fm = FileManager.default
+
+    // Check for 7B files first
+    if fm.fileExists(atPath: directory.appendingPathComponent(preset7B.transformerWeightFile).path)
+      || fm.fileExists(atPath: directory.appendingPathComponent(preset7B.transformerWeightFileFP8).path)
+    {
+      return .preset7B
+    }
+
+    // Check for 3B files
+    if fm.fileExists(atPath: directory.appendingPathComponent(preset3B.transformerWeightFile).path)
+      || fm.fileExists(atPath: directory.appendingPathComponent(preset3B.transformerWeightFileFP8).path)
+    {
+      return .preset3B
+    }
+
+    return nil
+  }
+}
+
+/// MLP type variants used in SeedVR2 transformer blocks.
+public enum SeedVR2MLPType: Equatable {
+  /// SwiGLU MLP (3B): gate = SiLU(proj_in_gate(x)) * proj_in(x), out = proj_out(gate). No bias.
+  case swiglu
+  /// Standard GELU MLP (7B): out = proj_out(GELU(proj_in(x))). Has bias.
+  case gelu
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2RMSNorm.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2RMSNorm.swift
@@ -1,0 +1,42 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Root mean square layer normalization utilities for SeedVR2.
+///
+/// SeedVR2 uses RMSNorm in two ways:
+///
+/// 1. **As a learnable module** -- via MLXNN's built-in RMSNorm (used in attention
+///    qk-norms and the top-level transformer norms). These are stored with a learnable
+///    weight vector and map naturally to the checkpoint key paths.
+///
+/// 2. **As a weight-free operation** -- the transformer block applies inline RMSNorm
+///    using a ones vector (no learned parameters). This is the static helper below.
+///
+/// For learnable norms, use MLXNN's RMSNorm directly (matching existing ZImage style):
+///
+///     @ModuleInfo(key: "norm_q_vid") var normQVid: RMSNorm
+///
+/// For the weight-free norm used inside transformer block forward passes, use:
+///
+///     SeedVR2RMSNorm.apply(x, eps: normEps)
+///
+public enum SeedVR2RMSNorm {
+
+  /// Applies weight-free RMS normalization using a unit weight vector.
+  ///
+  /// This matches the Python SeedVR2 transformer block's inline norm:
+  ///
+  ///     mx.fast.rms_norm(x, mx.ones(x.shape[-1]), eps)
+  ///
+  /// - Parameters:
+  ///   - x: Input array of arbitrary shape.
+  ///   - eps: Numerical stability constant. Default 1e-5.
+  /// - Returns: The RMS-normalized array with the same shape and dtype.
+  public static func apply(_ x: MLXArray, eps: Float = 1e-5) -> MLXArray {
+    let dim = x.dim(-1)
+    let ones = MLXArray.ones([dim])
+    return MLXFast.rmsNorm(x, weight: ones, eps: eps)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2TextEmbeddings.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2TextEmbeddings.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MLX
+
+/// Loads pre-computed positive text embeddings for SeedVR2 upscaling.
+///
+/// SeedVR2 uses fixed text embeddings rather than running a text encoder at inference
+/// time. The embeddings are stored in a safetensors file (pos_emb.safetensors, ~594 KB)
+/// that ships alongside the model weights.
+///
+/// The embedding tensor has shape (58, 5120) and represents a tokenized positive
+/// prompt pre-encoded through the SeedVR2 text encoder.
+///
+/// ## Usage
+///
+///     let embeddings = try SeedVR2TextEmbeddings.loadPositive(
+///         from: modelDirectory,
+///         batchSize: 1
+///     )
+///     // embeddings.shape == [1, 58, 5120]
+///
+public enum SeedVR2TextEmbeddings {
+
+  /// Expected shape of the raw embedding tensor (before batch dimension).
+  public static let embeddingShape = (sequenceLength: 58, hiddenSize: 5120)
+
+  /// Name of the safetensors file containing the pre-computed embeddings.
+  public static let fileName = "pos_emb.safetensors"
+
+  /// Key used to store the embedding tensor within the safetensors file.
+  private static let tensorKey = "embedding"
+
+  /// Errors that can occur when loading text embeddings.
+  public enum LoadError: Error, CustomStringConvertible {
+    /// The safetensors file was not found at the expected path.
+    case fileNotFound(URL)
+    /// The expected tensor key was not present in the safetensors file.
+    case missingTensor(String)
+    /// The loaded tensor has an unexpected shape.
+    case unexpectedShape(expected: [Int], actual: [Int])
+
+    public var description: String {
+      switch self {
+      case .fileNotFound(let url):
+        return "SeedVR2 text embeddings file not found at \(url.path)"
+      case .missingTensor(let key):
+        return "SeedVR2 text embeddings missing tensor key: \(key)"
+      case .unexpectedShape(let expected, let actual):
+        return "SeedVR2 text embedding shape mismatch: expected \(expected), got \(actual)"
+      }
+    }
+  }
+
+  /// Loads the positive text embeddings from a safetensors file.
+  ///
+  /// - Parameters:
+  ///   - directory: Directory containing the pos_emb.safetensors file. This is
+  ///     typically the SeedVR2 text encoder weights directory.
+  ///   - batchSize: Number of times to repeat the embeddings along the batch axis.
+  ///     Default 1.
+  /// - Returns: An MLXArray of shape (batchSize, 58, 5120).
+  /// - Throws: A LoadError if the file is missing or the tensor has an unexpected format.
+  public static func loadPositive(
+    from directory: URL,
+    batchSize: Int = 1
+  ) throws -> MLXArray {
+    let fileURL = directory.appendingPathComponent(fileName)
+
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      throw LoadError.fileNotFound(fileURL)
+    }
+
+    let arrays = try MLX.loadArrays(url: fileURL)
+
+    guard var embedding = arrays[tensorKey] else {
+      throw LoadError.missingTensor(tensorKey)
+    }
+
+    // The raw tensor is either (58, 5120) or (1, 58, 5120).
+    // Ensure it has a batch dimension.
+    if embedding.ndim == 2 {
+      embedding = embedding.expandedDimensions(axis: 0)
+    }
+
+    // Validate the sequence and hidden dimensions.
+    let seqLen = embedding.dim(1)
+    let hiddenSize = embedding.dim(2)
+    guard seqLen == embeddingShape.sequenceLength && hiddenSize == embeddingShape.hiddenSize else {
+      throw LoadError.unexpectedShape(
+        expected: [1, embeddingShape.sequenceLength, embeddingShape.hiddenSize],
+        actual: Array(embedding.shape)
+      )
+    }
+
+    // Tile for larger batch sizes.
+    if batchSize > 1 {
+      embedding = MLX.repeated(embedding, count: batchSize, axis: 0)
+    }
+
+    return embedding
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2Util.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2Util.swift
@@ -1,0 +1,584 @@
+import Foundation
+import MLX
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+
+/// Image preprocessing and post-processing utilities for the SeedVR2 upscaler.
+///
+/// ## Preprocessing Pipeline
+///
+/// Prepares an input image for VAE encoding:
+///
+/// ```
+/// Load CGImage
+///   -> Compute scale: targetResolution / min(width, height)
+///   -> Resize to (trueW, trueH), both even
+///   -> Optional softness: downscale then upscale via bicubic
+///   -> Pad to multiples of 16
+///   -> Normalize: [0,255] -> [0,1] -> [-1,1]
+///   -> CHW layout, add batch dim
+///   -> Output: (1, 3, H_pad, W_pad)
+/// ```
+///
+/// ## Color Correction
+///
+/// After the diffusion model produces an upscaled image, the colors may drift from
+/// the input. Color correction addresses this through two stages:
+///
+/// 1. **Wavelet reconstruction**: Extracts high-frequency detail from the upscaled
+///    result and low-frequency color structure from the original, then combines them.
+///
+/// 2. **LAB color transfer**: Converts both images to CIE LAB space, histogram-matches
+///    the chrominance (a, b) channels, and blends luminance. This preserves the
+///    fine detail of the upscaled result while matching the color palette of the input.
+public enum SeedVR2Util {
+
+  /// Result of image preprocessing.
+  public struct PreprocessResult {
+    /// The preprocessed image tensor: `(1, 3, H_padded, W_padded)`, values in [-1, 1].
+    public let tensor: MLXArray
+    /// True (unpadded) height after scaling.
+    public let trueHeight: Int
+    /// True (unpadded) width after scaling.
+    public let trueWidth: Int
+  }
+
+  /// Preprocesses an image for VAE encoding.
+  ///
+  /// - Parameters:
+  ///   - image: The input CGImage to upscale.
+  ///   - targetResolution: Target resolution for the shortest side. Default `2048`.
+  ///   - softness: Preprocessing softness in range `[0.0, 1.0]`. Maps to a blur factor
+  ///     of `1.0` (no softening) to `8.0` (maximum softening). Default `0.0`.
+  /// - Returns: A `PreprocessResult` containing the tensor and true dimensions.
+  /// - Throws: `QwenImageIOError` if image processing fails.
+  public static func preprocessImage(
+    _ image: CGImage,
+    targetResolution: Int = 2048,
+    softness: Float = 0.0
+  ) throws -> PreprocessResult {
+    let w = image.width
+    let h = image.height
+
+    // Compute scale to bring the shortest side to targetResolution.
+    let scale = Float(targetResolution) / Float(min(w, h))
+    var trueW = Int(Float(w) * scale)
+    var trueH = Int(Float(h) * scale)
+
+    // Ensure both dimensions are even.
+    trueW = (trueW / 2) * 2
+    trueH = (trueH / 2) * 2
+
+    // Map normalized softness [0, 1] to blur factor [1, 8].
+    let clampedSoftness = max(0.0, min(1.0, softness))
+    let factor = 1.0 + clampedSoftness * 7.0
+
+    // Resize with optional softness (downscale then upscale).
+    let resizedImage: CGImage
+    if factor > 1.0 {
+      let downW = max(2, Int(Float(trueW) / factor))
+      let downH = max(2, Int(Float(trueH) / factor))
+      let downscaled = try QwenImageIO.resizedCGImage(
+        from: image, width: downW, height: downH,
+        interpolation: .high
+      )
+      resizedImage = try QwenImageIO.resizedCGImage(
+        from: downscaled, width: trueW, height: trueH,
+        interpolation: .high
+      )
+    } else {
+      resizedImage = try QwenImageIO.resizedCGImage(
+        from: image, width: trueW, height: trueH,
+        interpolation: .high
+      )
+    }
+
+    // Pad to multiples of 16.
+    let padW = (16 - (trueW % 16)) % 16
+    let padH = (16 - (trueH % 16)) % 16
+    let paddedW = trueW + padW
+    let paddedH = trueH + padH
+
+    let finalImage: CGImage
+    if padW > 0 || padH > 0 {
+      finalImage = try padImage(resizedImage, toWidth: paddedW, height: paddedH)
+    } else {
+      finalImage = resizedImage
+    }
+
+    // Convert to MLXArray: CHW layout, [0, 1] range, batch dim.
+    var tensor = try QwenImageIO.array(
+      from: finalImage, addBatchDimension: true, dtype: .float32
+    )
+    // tensor is now (1, 3, H, W) in [0, 1] from QwenImageIO.array
+
+    // Normalize to [-1, 1].
+    tensor = MLX.clip(tensor, min: 0, max: 1)
+    tensor = tensor * 2.0 - 1.0
+
+    return PreprocessResult(tensor: tensor, trueHeight: trueH, trueWidth: trueW)
+  }
+
+  /// Loads a CGImage from a file path.
+  ///
+  /// - Parameter path: Absolute path to an image file (PNG, JPEG, etc.).
+  /// - Returns: The loaded CGImage.
+  /// - Throws: If the file cannot be read or decoded.
+  public static func loadImage(from path: String) throws -> CGImage {
+    let url = URL(fileURLWithPath: path)
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+      throw SeedVR2UtilError.imageLoadFailed(path)
+    }
+    return cgImage
+  }
+
+  // MARK: - Color Correction
+
+  /// Applies wavelet reconstruction and LAB color transfer to correct color drift.
+  ///
+  /// - Parameters:
+  ///   - content: The upscaled (diffusion output) tensor, shape `(B, 3, H, W)`, values in [-1, 1].
+  ///   - style: The preprocessed input (style reference) tensor, same shape and range.
+  ///   - luminanceWeight: How much of the content luminance to preserve (0.0-1.0).
+  ///     Default `0.8` (80% content luminance, 20% style-matched luminance).
+  /// - Returns: Color-corrected tensor, same shape and range.
+  public static func applyColorCorrection(
+    content: MLXArray,
+    style: MLXArray,
+    luminanceWeight: Float = 0.8
+  ) -> MLXArray {
+    // Convert MLXArray to Float arrays for CPU-side processing.
+    let contentF32 = content.asType(.float32)
+    let styleF32 = style.asType(.float32)
+    MLX.eval(contentF32)
+    MLX.eval(styleF32)
+
+    let shape = contentF32.shape  // [B, 3, H, W]
+    let B = shape[0]
+    let C = shape[1]
+    let H = shape[2]
+    let W = shape[3]
+
+    guard C == 3 else { return content }
+
+    var contentArr = contentF32.asArray(Float.self)
+    let styleArr = styleF32.asArray(Float.self)
+
+    // Wavelet reconstruction: high-freq from content + low-freq from style.
+    waveletReconstruction(
+      content: &contentArr, style: styleArr,
+      B: B, C: C, H: H, W: W
+    )
+
+    // Denormalize from [-1,1] to [0,1] for LAB conversion.
+    let pixelCount = B * H * W
+    var contentRGB = [Float](repeating: 0, count: pixelCount * 3)
+    var styleRGB = [Float](repeating: 0, count: pixelCount * 3)
+
+    bchwToBhwc(contentArr, out: &contentRGB, B: B, C: C, H: H, W: W, denormalize: true)
+    bchwToBhwc(styleArr, out: &styleRGB, B: B, C: C, H: H, W: W, denormalize: true)
+
+    // Convert to LAB.
+    var contentLAB = rgbToLAB(contentRGB, count: pixelCount)
+    let styleLAB = rgbToLAB(styleRGB, count: pixelCount)
+
+    // Histogram-match a and b channels per batch.
+    for b in 0..<B {
+      let offset = b * H * W
+      let count = H * W
+
+      // Match 'a' channel (index 1).
+      histogramMatch(
+        source: &contentLAB, sourceOffset: offset, sourceStride: 3, channel: 1,
+        reference: styleLAB, refOffset: offset, refStride: 3, refChannel: 1,
+        count: count
+      )
+
+      // Match 'b' channel (index 2).
+      histogramMatch(
+        source: &contentLAB, sourceOffset: offset, sourceStride: 3, channel: 2,
+        reference: styleLAB, refOffset: offset, refStride: 3, refChannel: 2,
+        count: count
+      )
+
+      // Blend luminance.
+      if luminanceWeight < 1.0 {
+        var srcL = [Float](repeating: 0, count: count)
+        var refL = [Float](repeating: 0, count: count)
+        var matchedL = [Float](repeating: 0, count: count)
+        for i in 0..<count {
+          srcL[i] = contentLAB[(offset + i) * 3]
+          refL[i] = styleLAB[(offset + i) * 3]
+        }
+        histogramMatchChannel(source: &srcL, reference: refL, output: &matchedL, count: count)
+        for i in 0..<count {
+          let idx = (offset + i) * 3
+          contentLAB[idx] = luminanceWeight * contentLAB[idx]
+            + (1.0 - luminanceWeight) * matchedL[i]
+        }
+      }
+    }
+
+    // Convert back to RGB.
+    let resultRGB = labToRGB(contentLAB, count: pixelCount)
+
+    // Re-normalize to [-1, 1] and convert back to BCHW.
+    var resultArr = [Float](repeating: 0, count: B * C * H * W)
+    bhwcToBchw(resultRGB, out: &resultArr, B: B, C: C, H: H, W: W, renormalize: true)
+
+    return MLXArray(resultArr, shape).asType(content.dtype)
+  }
+
+  // MARK: - Layout Conversion Helpers
+
+  /// BCHW -> BHWC with optional [-1,1] -> [0,1] denormalization.
+  private static func bchwToBhwc(
+    _ src: [Float], out: inout [Float],
+    B: Int, C: Int, H: Int, W: Int,
+    denormalize: Bool
+  ) {
+    for b in 0..<B {
+      for h in 0..<H {
+        for w in 0..<W {
+          for c in 0..<C {
+            let bchwIdx = b * (C * H * W) + c * (H * W) + h * W + w
+            let bhwcIdx = b * (H * W * C) + h * (W * C) + w * C + c
+            var val = src[bchwIdx]
+            if denormalize {
+              val = max(0, min(1, (val + 1.0) * 0.5))
+            }
+            out[bhwcIdx] = val
+          }
+        }
+      }
+    }
+  }
+
+  /// BHWC -> BCHW with optional [0,1] -> [-1,1] renormalization.
+  private static func bhwcToBchw(
+    _ src: [Float], out: inout [Float],
+    B: Int, C: Int, H: Int, W: Int,
+    renormalize: Bool
+  ) {
+    for b in 0..<B {
+      for h in 0..<H {
+        for w in 0..<W {
+          for c in 0..<C {
+            let bhwcIdx = b * (H * W * C) + h * (W * C) + w * C + c
+            let bchwIdx = b * (C * H * W) + c * (H * W) + h * W + w
+            var val = src[bhwcIdx]
+            if renormalize {
+              val = max(0, min(1, val)) * 2.0 - 1.0
+            }
+            out[bchwIdx] = val
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Wavelet Decomposition
+
+  /// Applies a blur at the given radius using a 3x3 binomial kernel with edge-replicated padding.
+  private static func waveletBlurChannel(
+    _ channel: [Float], H: Int, W: Int, radius: Int
+  ) -> [Float] {
+    let r = max(1, min(radius, max(1, min(H, W) / 8)))
+    var output = [Float](repeating: 0, count: H * W)
+
+    let offsets: [(Int, Int, Float)] = [
+      (-1, -1, 0.0625), ( 0, -1, 0.125), ( 1, -1, 0.0625),
+      (-1,  0, 0.125),  ( 0,  0, 0.25),  ( 1,  0, 0.125),
+      (-1,  1, 0.0625), ( 0,  1, 0.125), ( 1,  1, 0.0625)
+    ]
+
+    for y in 0..<H {
+      for x in 0..<W {
+        var sum: Float = 0
+        for (dx, dy, wt) in offsets {
+          let sy = max(0, min(H - 1, y + dy * r))
+          let sx = max(0, min(W - 1, x + dx * r))
+          sum += wt * channel[sy * W + sx]
+        }
+        output[y * W + x] = sum
+      }
+    }
+
+    return output
+  }
+
+  /// Performs 5-level wavelet decomposition and reconstruction.
+  private static func waveletReconstruction(
+    content: inout [Float], style: [Float],
+    B: Int, C: Int, H: Int, W: Int,
+    levels: Int = 5
+  ) {
+    guard content.count == style.count else { return }
+    let planeSize = H * W
+
+    for b in 0..<B {
+      for c in 0..<C {
+        let baseOffset = b * (C * H * W) + c * planeSize
+
+        // Extract content channel.
+        var contentHigh = [Float](repeating: 0, count: planeSize)
+        var contentCur = [Float](repeating: 0, count: planeSize)
+        for i in 0..<planeSize {
+          contentCur[i] = content[baseOffset + i]
+        }
+
+        for level in 0..<levels {
+          let radius = 1 << level
+          let blurred = waveletBlurChannel(contentCur, H: H, W: W, radius: radius)
+          for i in 0..<planeSize {
+            contentHigh[i] += contentCur[i] - blurred[i]
+            contentCur[i] = blurred[i]
+          }
+        }
+
+        // Extract style channel and decompose for low frequencies.
+        var styleCur = [Float](repeating: 0, count: planeSize)
+        for i in 0..<planeSize {
+          styleCur[i] = style[baseOffset + i]
+        }
+        for level in 0..<levels {
+          let radius = 1 << level
+          styleCur = waveletBlurChannel(styleCur, H: H, W: W, radius: radius)
+        }
+
+        // Reconstruct: high-freq content + low-freq style.
+        for i in 0..<planeSize {
+          content[baseOffset + i] = max(-1, min(1, contentHigh[i] + styleCur[i]))
+        }
+      }
+    }
+  }
+
+  // MARK: - Color Space Conversion
+
+  @inline(__always)
+  private static func srgbToLinear(_ x: Float) -> Float {
+    x > 0.04045 ? powf((x + 0.055) / 1.055, 2.4) : x / 12.92
+  }
+
+  @inline(__always)
+  private static func linearToSRGB(_ x: Float) -> Float {
+    x > 0.0031308 ? 1.055 * powf(max(x, 0), 1.0 / 2.4) - 0.055 : 12.92 * x
+  }
+
+  /// Converts RGB pixels (interleaved, [0,1]) to LAB (interleaved).
+  private static func rgbToLAB(_ rgb: [Float], count: Int) -> [Float] {
+    var lab = [Float](repeating: 0, count: count * 3)
+
+    let m00: Float = 0.4124564, m01: Float = 0.3575761, m02: Float = 0.1804375
+    let m10: Float = 0.2126729, m11: Float = 0.7151522, m12: Float = 0.0721750
+    let m20: Float = 0.0193339, m21: Float = 0.1191920, m22: Float = 0.9503041
+
+    let eps: Float = 6.0 / 29.0
+    let eps3: Float = eps * eps * eps
+    let kappa: Float = (29.0 / 3.0) * (29.0 / 3.0) * (29.0 / 3.0)
+
+    for i in 0..<count {
+      let idx = i * 3
+      let r = srgbToLinear(rgb[idx])
+      let g = srgbToLinear(rgb[idx + 1])
+      let b = srgbToLinear(rgb[idx + 2])
+
+      var x = m00 * r + m01 * g + m02 * b
+      var y = m10 * r + m11 * g + m12 * b
+      var z = m20 * r + m21 * g + m22 * b
+
+      x /= 0.95047
+      z /= 1.08883
+
+      let fx = x > eps3 ? cbrtf(x) : (kappa * x + 16.0) / 116.0
+      let fy = y > eps3 ? cbrtf(y) : (kappa * y + 16.0) / 116.0
+      let fz = z > eps3 ? cbrtf(z) : (kappa * z + 16.0) / 116.0
+
+      lab[idx]     = 116.0 * fy - 16.0
+      lab[idx + 1] = 500.0 * (fx - fy)
+      lab[idx + 2] = 200.0 * (fy - fz)
+    }
+
+    return lab
+  }
+
+  /// Converts LAB pixels (interleaved) to RGB ([0,1], interleaved).
+  private static func labToRGB(_ lab: [Float], count: Int) -> [Float] {
+    var rgb = [Float](repeating: 0, count: count * 3)
+
+    let eps: Float = 6.0 / 29.0
+    let kappa: Float = (29.0 / 3.0) * (29.0 / 3.0) * (29.0 / 3.0)
+
+    let m00: Float =  3.2404542, m01: Float = -1.5371385, m02: Float = -0.4985314
+    let m10: Float = -0.9692660, m11: Float =  1.8760108, m12: Float =  0.0415560
+    let m20: Float =  0.0556434, m21: Float = -0.2040259, m22: Float =  1.0572252
+
+    for i in 0..<count {
+      let idx = i * 3
+      let L = lab[idx]
+      let a = lab[idx + 1]
+      let b = lab[idx + 2]
+
+      let fy = (L + 16.0) / 116.0
+      let fx = a / 500.0 + fy
+      let fz = fy - b / 200.0
+
+      var x = fx > eps ? fx * fx * fx : (116.0 * fx - 16.0) / kappa
+      var y = fy > eps ? fy * fy * fy : (116.0 * fy - 16.0) / kappa
+      var z = fz > eps ? fz * fz * fz : (116.0 * fz - 16.0) / kappa
+
+      x *= 0.95047
+      z *= 1.08883
+
+      let rLin = m00 * x + m01 * y + m02 * z
+      let gLin = m10 * x + m11 * y + m12 * z
+      let bLin = m20 * x + m21 * y + m22 * z
+
+      rgb[idx]     = linearToSRGB(rLin)
+      rgb[idx + 1] = linearToSRGB(gLin)
+      rgb[idx + 2] = linearToSRGB(bLin)
+    }
+
+    return rgb
+  }
+
+  // MARK: - Histogram Matching
+
+  /// In-place histogram matching of a single channel within interleaved LAB data.
+  private static func histogramMatch(
+    source: inout [Float], sourceOffset: Int, sourceStride: Int, channel: Int,
+    reference: [Float], refOffset: Int, refStride: Int, refChannel: Int,
+    count: Int
+  ) {
+    var srcValues = [Float](repeating: 0, count: count)
+    var refValues = [Float](repeating: 0, count: count)
+    for i in 0..<count {
+      srcValues[i] = source[(sourceOffset + i) * sourceStride + channel]
+      refValues[i] = reference[(refOffset + i) * refStride + refChannel]
+    }
+
+    var matched = [Float](repeating: 0, count: count)
+    histogramMatchChannel(source: &srcValues, reference: refValues, output: &matched, count: count)
+
+    for i in 0..<count {
+      source[(sourceOffset + i) * sourceStride + channel] = matched[i]
+    }
+  }
+
+  /// Histogram matching via sort-rank transfer for a single channel.
+  private static func histogramMatchChannel(
+    source: inout [Float], reference: [Float], output: inout [Float], count: Int
+  ) {
+    var srcIndices = Array(0..<count)
+    srcIndices.sort { source[$0] < source[$1] }
+
+    var refSorted = reference
+    refSorted.sort()
+
+    var invPerm = [Int](repeating: 0, count: count)
+    for i in 0..<count {
+      invPerm[srcIndices[i]] = i
+    }
+
+    for i in 0..<count {
+      output[i] = refSorted[invPerm[i]]
+    }
+  }
+
+  // MARK: - Image Padding
+
+  private static func padImage(_ image: CGImage, toWidth width: Int, height: Int) throws -> CGImage {
+    guard let colorSpace = image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) else {
+      throw SeedVR2UtilError.paddingFailed
+    }
+    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+    guard let context = CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo
+    ) else {
+      throw SeedVR2UtilError.paddingFailed
+    }
+
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+    let drawY = height - image.height
+    context.draw(image, in: CGRect(x: 0, y: drawY, width: image.width, height: image.height))
+
+    guard let padded = context.makeImage() else {
+      throw SeedVR2UtilError.paddingFailed
+    }
+    return padded
+  }
+
+  /// Converts an MLXArray in [-1,1] to a CGImage.
+  ///
+  /// - Parameters:
+  ///   - tensor: The image tensor, shape `(B, 3, H, W)`, `(B, 3, T, H, W)`, or `(3, H, W)`.
+  ///   - cropHeight: If provided, crop to this height before converting.
+  ///   - cropWidth: If provided, crop to this width before converting.
+  /// - Returns: The resulting CGImage.
+  /// - Throws: If the tensor has an unexpected shape.
+  public static func tensorToImage(
+    _ tensor: MLXArray,
+    cropHeight: Int? = nil,
+    cropWidth: Int? = nil
+  ) throws -> CGImage {
+    var t = tensor.asType(.float32)
+
+    // Handle 5D: (B, C, T, H, W) -> take first batch, squeeze T
+    if t.ndim == 5 {
+      t = t[0]  // (C, T, H, W)
+      if t.dim(1) == 1 {
+        t = t[0..., 0, 0..., 0...]  // (C, H, W)
+      }
+    }
+
+    // Handle 4D: (B, C, H, W) -> take first batch
+    if t.ndim == 4 {
+      t = t[0]
+    }
+
+    guard t.ndim == 3 && t.dim(0) == 3 else {
+      throw SeedVR2UtilError.invalidTensorShape(Array(t.shape))
+    }
+
+    // Crop if requested.
+    if let ch = cropHeight, let cw = cropWidth {
+      t = t[0..., ..<ch, ..<cw]
+    }
+
+    // Denormalize [-1, 1] -> [0, 1].
+    t = (t + 1.0) / 2.0
+
+    return try QwenImageIO.image(from: t)
+  }
+}
+
+/// Errors specific to SeedVR2 utility operations.
+public enum SeedVR2UtilError: Error, CustomStringConvertible {
+  case imageLoadFailed(String)
+  case paddingFailed
+  case invalidTensorShape([Int])
+
+  public var description: String {
+    switch self {
+    case .imageLoadFailed(let path):
+      return "Failed to load image from \(path)"
+    case .paddingFailed:
+      return "Failed to pad image to target dimensions"
+    case .invalidTensorShape(let shape):
+      return "Invalid tensor shape for image conversion: \(shape)"
+    }
+  }
+}
+#endif

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2WeightLoader.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2WeightLoader.swift
@@ -237,13 +237,10 @@ public enum SeedVR2WeightLoader {
       }
     }
 
-    // MLP shared weight duplication for blocks with .all. pattern (3B blocks 10-31)
-    if key.contains(".mlp.all.") {
-      return [
-        key.replacingOccurrences(of: ".mlp.all.", with: ".mlp.vid."),
-        key.replacingOccurrences(of: ".mlp.all.", with: ".mlp.txt."),
-      ]
-    }
+    // MLP shared weights: pass through unchanged.
+    // SeedVR2MMSwiGLU registers shared MLP as @ModuleInfo(key: "all"),
+    // so .mlp.all. keys map directly to the module tree.
+    // (Unlike attention, which always creates both vid/txt modules.)
 
     // Default: key passes through unchanged.
     return [key]

--- a/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2WeightLoader.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Common/SeedVR2WeightLoader.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+/// Loads and applies weights from safetensors files to SeedVR2 transformer and VAE modules.
+///
+/// Supports both 3B and 7B model variants with automatic weight file detection.
+public enum SeedVR2WeightLoader {
+
+  /// Default 3B transformer weight file names.
+  public static let transformerWeightFile3B = "seedvr2_ema_3b_fp16.safetensors"
+  public static let transformerWeightFile3BFP8 = "seedvr2_ema_3b_fp8.safetensors"
+
+  /// 7B transformer weight file names.
+  public static let transformerWeightFile7B = "seedvr2_ema_7b_fp16.safetensors"
+  public static let transformerWeightFile7BFP8 = "seedvr2_ema_7b_fp8.safetensors"
+
+  /// Legacy aliases for backward compatibility.
+  public static let transformerWeightFile = transformerWeightFile3B
+  public static let transformerWeightFileFP8 = transformerWeightFile3BFP8
+
+  /// Default VAE weight file name.
+  public static let vaeWeightFile = "ema_vae_fp16.safetensors"
+
+  /// Text embedding file name.
+  public static let textEmbeddingFile = SeedVR2TextEmbeddings.fileName
+
+  /// Errors that can occur during weight loading.
+  public enum LoadError: Error, CustomStringConvertible {
+    case fileNotFound(String)
+    case weightApplicationFailed(String, Error)
+    case safetensorsReadFailed(String, Error)
+    case noTransformerWeightsFound(String)
+
+    public var description: String {
+      switch self {
+      case .fileNotFound(let path):
+        return "Weight file not found: \(path)"
+      case .weightApplicationFailed(let component, let error):
+        return "Failed to apply \(component) weights: \(error)"
+      case .safetensorsReadFailed(let path, let error):
+        return "Failed to read safetensors file \(path): \(error)"
+      case .noTransformerWeightsFound(let dir):
+        return "No SeedVR2 transformer weights (3B or 7B) found in: \(dir)"
+      }
+    }
+  }
+
+  // MARK: - Public API
+
+  /// Detects which transformer weight file is available in the directory.
+  ///
+  /// Returns the file name and detected model config. Prefers fp16 over fp8.
+  /// Prefers 7B over 3B if both are present.
+  public static func detectTransformerWeights(
+    in directory: URL
+  ) -> (fileName: String, config: SeedVR2ModelConfig)? {
+    let fm = FileManager.default
+
+    // Check 7B first
+    if fm.fileExists(atPath: directory.appendingPathComponent(transformerWeightFile7B).path) {
+      return (transformerWeightFile7B, .preset7B)
+    }
+    if fm.fileExists(atPath: directory.appendingPathComponent(transformerWeightFile7BFP8).path) {
+      return (transformerWeightFile7BFP8, .preset7B)
+    }
+
+    // Then 3B
+    if fm.fileExists(atPath: directory.appendingPathComponent(transformerWeightFile3B).path) {
+      return (transformerWeightFile3B, .preset3B)
+    }
+    if fm.fileExists(atPath: directory.appendingPathComponent(transformerWeightFile3BFP8).path) {
+      return (transformerWeightFile3BFP8, .preset3B)
+    }
+
+    return nil
+  }
+
+  /// Loads transformer weights from a safetensors file and applies them to the model.
+  public static func loadTransformerWeights(
+    into transformer: SeedVR2Transformer,
+    from directory: URL,
+    fileName: String,
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws {
+    let fileURL = directory.appendingPathComponent(fileName)
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      throw LoadError.fileNotFound(fileURL.path)
+    }
+
+    logger.info("Loading SeedVR2 transformer weights from \(fileName)")
+
+    let rawTensors: [String: MLXArray]
+    do {
+      let reader = try SafeTensorsReader(fileURL: fileURL)
+      rawTensors = try reader.loadAllTensors(as: dtype)
+    } catch {
+      throw LoadError.safetensorsReadFailed(fileURL.path, error)
+    }
+
+    logger.info("Read \(rawTensors.count) tensors from \(fileName)")
+
+    // Apply key remapping.
+    let remapped = remapTransformerKeys(rawTensors, hasOutputNorm: transformer.hasOutputNorm)
+    logger.info("Remapped to \(remapped.count) transformer weight keys")
+
+    // Apply to the module.
+    do {
+      let params = ModuleParameters.unflattened(remapped)
+      try transformer.update(parameters: params, verify: [.shapeMismatch])
+    } catch {
+      logger.error("Transformer weight application error: \(error)")
+      throw LoadError.weightApplicationFailed("transformer", error)
+    }
+
+    logger.info("Applied transformer weights successfully")
+  }
+
+  /// Loads VAE weights from a safetensors file and applies them to the model.
+  public static func loadVAEWeights(
+    into vae: SeedVR2VAE,
+    from directory: URL,
+    fileName: String = vaeWeightFile,
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws {
+    let fileURL = directory.appendingPathComponent(fileName)
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      throw LoadError.fileNotFound(fileURL.path)
+    }
+
+    logger.info("Loading SeedVR2 VAE weights from \(fileName)")
+
+    let rawTensors: [String: MLXArray]
+    do {
+      let reader = try SafeTensorsReader(fileURL: fileURL)
+      rawTensors = try reader.loadAllTensors(as: dtype)
+    } catch {
+      throw LoadError.safetensorsReadFailed(fileURL.path, error)
+    }
+
+    logger.info("Read \(rawTensors.count) tensors from \(fileName)")
+
+    let transposed = transposeVAEWeights(rawTensors)
+    logger.info("Processed \(transposed.count) VAE weight keys")
+
+    do {
+      let params = ModuleParameters.unflattened(transposed)
+      try vae.update(parameters: params, verify: [.shapeMismatch])
+    } catch {
+      throw LoadError.weightApplicationFailed("vae", error)
+    }
+
+    logger.info("Applied VAE weights successfully")
+  }
+
+  // MARK: - Transformer Key Remapping
+
+  private static func remapTransformerKeys(
+    _ tensors: [String: MLXArray],
+    hasOutputNorm: Bool
+  ) -> [(String, MLXArray)] {
+    var result: [(String, MLXArray)] = []
+
+    for (key, value) in tensors {
+      let remappedKeys = remapSingleTransformerKey(key, hasOutputNorm: hasOutputNorm)
+      for rk in remappedKeys {
+        result.append((rk, value))
+      }
+    }
+
+    return result
+  }
+
+  private static func remapSingleTransformerKey(
+    _ key: String,
+    hasOutputNorm: Bool
+  ) -> [String] {
+    // Top-level output adaptive norm renames (3B only).
+    if key == "vid_out_ada.out_shift" {
+      return hasOutputNorm ? ["out_shift"] : []
+    }
+    if key == "vid_out_ada.out_scale" {
+      return hasOutputNorm ? ["out_scale"] : []
+    }
+
+    // RoPE frequency rename
+    if key.contains(".attn.rope.rope.freqs") {
+      return [key.replacingOccurrences(of: ".attn.rope.rope.freqs", with: ".attn.rope.freqs")]
+    }
+
+    // AdaLN parameter renames
+    if key.contains(".ada.vid.") {
+      return [key.replacingOccurrences(of: ".ada.vid.", with: ".ada.params_vid.")]
+    }
+    if key.contains(".ada.txt.") {
+      return [key.replacingOccurrences(of: ".ada.txt.", with: ".ada.params_txt.")]
+    }
+    if key.contains(".ada.all.") {
+      return [key.replacingOccurrences(of: ".ada.all.", with: ".ada.params_all.")]
+    }
+
+    // Attention weight sharing for blocks with .all. pattern (3B blocks 10-31)
+    let sharedAttnPatterns = [
+      ".attn.proj_qkv.all.": (".attn.proj_qkv_vid.", ".attn.proj_qkv_txt."),
+      ".attn.norm_q.all.": (".attn.norm_q_vid.", ".attn.norm_q_txt."),
+      ".attn.norm_k.all.": (".attn.norm_k_vid.", ".attn.norm_k_txt."),
+      ".attn.proj_out.all.": (".attn.proj_out_vid.", ".attn.proj_out_txt."),
+    ]
+
+    for (pattern, (vidReplace, txtReplace)) in sharedAttnPatterns {
+      if key.contains(pattern) {
+        return [
+          key.replacingOccurrences(of: pattern, with: vidReplace),
+          key.replacingOccurrences(of: pattern, with: txtReplace),
+        ]
+      }
+    }
+
+    // Non-shared attention renames
+    let singleAttnPatterns = [
+      ".attn.proj_qkv.vid.": ".attn.proj_qkv_vid.",
+      ".attn.proj_qkv.txt.": ".attn.proj_qkv_txt.",
+      ".attn.norm_q.vid.": ".attn.norm_q_vid.",
+      ".attn.norm_q.txt.": ".attn.norm_q_txt.",
+      ".attn.norm_k.vid.": ".attn.norm_k_vid.",
+      ".attn.norm_k.txt.": ".attn.norm_k_txt.",
+      ".attn.proj_out.vid.": ".attn.proj_out_vid.",
+      ".attn.proj_out.txt.": ".attn.proj_out_txt.",
+    ]
+
+    for (pattern, replacement) in singleAttnPatterns {
+      if key.contains(pattern) {
+        return [key.replacingOccurrences(of: pattern, with: replacement)]
+      }
+    }
+
+    // MLP shared weight duplication for blocks with .all. pattern (3B blocks 10-31)
+    if key.contains(".mlp.all.") {
+      return [
+        key.replacingOccurrences(of: ".mlp.all.", with: ".mlp.vid."),
+        key.replacingOccurrences(of: ".mlp.all.", with: ".mlp.txt."),
+      ]
+    }
+
+    // Default: key passes through unchanged.
+    return [key]
+  }
+
+  // MARK: - VAE Weight Transposition
+
+  private static func transposeVAEWeights(_ tensors: [String: MLXArray]) -> [(String, MLXArray)] {
+    var result: [(String, MLXArray)] = []
+
+    for (key, value) in tensors {
+      if value.ndim == 5 && isConvWeightKey(key) {
+        let transposed = value.transposed(0, 2, 3, 4, 1)
+        result.append((key, transposed))
+      } else {
+        result.append((key, value))
+      }
+    }
+
+    return result
+  }
+
+  private static func isConvWeightKey(_ key: String) -> Bool {
+    key.contains("conv") && key.hasSuffix(".weight")
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/SeedVR2Pipeline.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/SeedVR2Pipeline.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+/// End-to-end SeedVR2 super-resolution pipeline.
+///
+/// Supports both 3B and 7B model variants with automatic detection.
+/// The variant is determined by which transformer weight file is present.
+public final class SeedVR2Pipeline {
+
+  public let transformer: SeedVR2Transformer
+  public let vae: SeedVR2VAE
+  public let scheduler: SeedVR2EulerScheduler
+  public let logger: Logger
+  public let weightsDirectory: URL
+  public let modelConfig: SeedVR2ModelConfig
+
+  public enum PipelineError: Error, CustomStringConvertible {
+    case weightsDirectoryNotFound(String)
+    case noTransformerWeightsFound(String)
+    case imageLoadFailed(String)
+    case preprocessFailed(Error)
+    case encodeFailed(Error)
+    case decodeFailed(Error)
+    case saveFailed(String)
+
+    public var description: String {
+      switch self {
+      case .weightsDirectoryNotFound(let path):
+        return "Weights directory not found: \(path)"
+      case .noTransformerWeightsFound(let path):
+        return "No SeedVR2 transformer weights (3B or 7B) found in: \(path)"
+      case .imageLoadFailed(let path):
+        return "Failed to load input image: \(path)"
+      case .preprocessFailed(let error):
+        return "Image preprocessing failed: \(error)"
+      case .encodeFailed(let error):
+        return "VAE encoding failed: \(error)"
+      case .decodeFailed(let error):
+        return "VAE decoding failed: \(error)"
+      case .saveFailed(let path):
+        return "Failed to save output image to: \(path)"
+      }
+    }
+  }
+
+  /// Creates a SeedVR2 pipeline, auto-detecting the model variant.
+  public init(
+    weightsPath: String,
+    steps: Int = 1,
+    logger: Logger = Logger(label: "seedvr2.pipeline")
+  ) throws {
+    let directory = URL(fileURLWithPath: weightsPath)
+    guard FileManager.default.fileExists(atPath: directory.path) else {
+      throw PipelineError.weightsDirectoryNotFound(weightsPath)
+    }
+
+    self.weightsDirectory = directory
+    self.logger = logger
+
+    // Auto-detect model variant
+    guard let detected = SeedVR2WeightLoader.detectTransformerWeights(in: directory) else {
+      throw PipelineError.noTransformerWeightsFound(weightsPath)
+    }
+
+    let config = detected.config
+    self.modelConfig = config
+    logger.info("Detected SeedVR2 model: \(config == .preset7B ? "7B" : "3B")")
+    logger.info("  vid_dim=\(config.vidDim), heads=\(config.heads), layers=\(config.numLayers), mlp=\(config.mlpType == .swiglu ? "SwiGLU" : "GELU")")
+
+    // Initialize models with detected config
+    logger.info("Initializing SeedVR2 transformer...")
+    self.transformer = SeedVR2Transformer(config: config)
+
+    logger.info("Initializing SeedVR2 VAE...")
+    self.vae = SeedVR2VAE()
+
+    self.scheduler = SeedVR2EulerScheduler(
+      numTrainTimesteps: 1000,
+      numInferenceSteps: steps,
+      guidance: 1.0
+    )
+
+    // Load weights
+    logger.info("Loading weights...")
+    try SeedVR2WeightLoader.loadTransformerWeights(
+      into: transformer,
+      from: directory,
+      fileName: detected.fileName,
+      logger: logger
+    )
+
+    try SeedVR2WeightLoader.loadVAEWeights(
+      into: vae,
+      from: directory,
+      logger: logger
+    )
+
+    logger.info("SeedVR2 pipeline ready (\(config == .preset7B ? "7B" : "3B"))")
+  }
+
+  /// Upscales an image to the target resolution.
+  public func upscale(
+    imagePath: String,
+    targetResolution: Int = 2048,
+    seed: Int? = nil,
+    softness: Float = 0.0
+  ) throws -> CGImage {
+    let actualSeed = seed ?? Int.random(in: 0..<Int(Int32.max))
+    logger.info("Upscaling \(imagePath) to \(targetResolution)px, seed=\(actualSeed), softness=\(softness)")
+
+    // 1. Load and preprocess
+    logger.info("Step 1: Loading and preprocessing image...")
+    let inputImage: CGImage
+    do {
+      inputImage = try SeedVR2Util.loadImage(from: imagePath)
+    } catch {
+      throw PipelineError.imageLoadFailed(imagePath)
+    }
+
+    let preprocessed: SeedVR2Util.PreprocessResult
+    do {
+      preprocessed = try SeedVR2Util.preprocessImage(
+        inputImage,
+        targetResolution: targetResolution,
+        softness: softness
+      )
+    } catch {
+      throw PipelineError.preprocessFailed(error)
+    }
+
+    let trueH = preprocessed.trueHeight
+    let trueW = preprocessed.trueWidth
+    logger.info("Preprocessed: \(inputImage.width)x\(inputImage.height) -> \(trueW)x\(trueH)")
+
+    // 2. VAE encode
+    logger.info("Step 2: VAE encoding...")
+    let encodedLatent = vae.encode(preprocessed.tensor)
+    MLX.eval(encodedLatent)
+    logger.info("Encoded latent shape: \(encodedLatent.shape)")
+
+    // 3. Create conditioning
+    logger.info("Step 3: Creating condition...")
+    let condition = SeedVR2LatentCreator.createCondition(encodedLatent: encodedLatent)
+
+    // 4. Create noise latents
+    logger.info("Step 4: Creating noise latents...")
+    let latentH = encodedLatent.dim(3)
+    let latentW = encodedLatent.dim(4)
+    var latents = SeedVR2LatentCreator.createNoiseLatents(
+      seed: actualSeed, height: latentH, width: latentW
+    )
+    MLX.eval(latents)
+
+    // 5. Load text embeddings
+    logger.info("Step 5: Loading text embeddings...")
+    let txtPos = try SeedVR2TextEmbeddings.loadPositive(from: weightsDirectory)
+    MLX.eval(txtPos)
+
+    // 6. Denoising loop
+    let numSteps = scheduler.numInferenceSteps
+    logger.info("Step 6: Denoising (\(numSteps) step\(numSteps == 1 ? "" : "s"))...")
+
+    for t in 0..<numSteps {
+      let modelInput = MLX.concatenated([latents, condition], axis: 1)
+      let timestep = scheduler.timesteps[t]
+      let noise = transformer(vid: modelInput, txt: txtPos, timestep: timestep)
+      latents = scheduler.step(modelOutput: noise, timestepIndex: t, sample: latents)
+      MLX.eval(latents)
+      logger.info("  Step \(t + 1)/\(numSteps) complete")
+    }
+
+    // 7. VAE decode
+    logger.info("Step 7: VAE decoding...")
+    var decoded = vae.decode(latents)
+    MLX.eval(decoded)
+
+    // 8. Crop to true dimensions
+    if decoded.ndim == 5 {
+      decoded = decoded[0..., 0..., 0..., ..<trueH, ..<trueW]
+    } else if decoded.ndim == 4 {
+      decoded = decoded[0..., 0..., ..<trueH, ..<trueW]
+    }
+
+    var styleRef = preprocessed.tensor
+    if styleRef.ndim == 4 {
+      styleRef = styleRef[0..., 0..., ..<trueH, ..<trueW]
+    }
+
+    // 9. Color correction
+    logger.info("Step 8: Applying color correction...")
+    var decodedForCC = decoded
+    if decodedForCC.ndim == 5 && decodedForCC.dim(2) == 1 {
+      decodedForCC = decodedForCC[0..., 0..., 0, 0..., 0...]
+    }
+    let corrected = SeedVR2Util.applyColorCorrection(content: decodedForCC, style: styleRef)
+    MLX.eval(corrected)
+
+    // 10. Convert to CGImage
+    logger.info("Step 9: Converting to CGImage...")
+    let result = try SeedVR2Util.tensorToImage(corrected)
+
+    logger.info("Upscale complete: \(result.width)x\(result.height)")
+    return result
+  }
+
+  /// Upscales an image and saves the result to a file.
+  @discardableResult
+  public func upscaleAndSave(
+    imagePath: String,
+    outputPath: String? = nil,
+    targetResolution: Int = 2048,
+    seed: Int? = nil,
+    softness: Float = 0.0
+  ) throws -> String {
+    let result = try upscale(
+      imagePath: imagePath,
+      targetResolution: targetResolution,
+      seed: seed,
+      softness: softness
+    )
+
+    let outPath: String
+    if let provided = outputPath {
+      outPath = provided
+    } else {
+      let inputURL = URL(fileURLWithPath: imagePath)
+      let baseName = inputURL.deletingPathExtension().lastPathComponent
+      let ext = inputURL.pathExtension.isEmpty ? "png" : inputURL.pathExtension
+      outPath = inputURL.deletingLastPathComponent()
+        .appendingPathComponent("\(baseName)-upscaled.\(ext)").path
+    }
+
+    let outURL = URL(fileURLWithPath: outPath)
+    guard let destination = CGImageDestinationCreateWithURL(
+      outURL as CFURL,
+      UTType.png.identifier as CFString,
+      1,
+      nil
+    ) else {
+      throw PipelineError.saveFailed(outPath)
+    }
+
+    CGImageDestinationAddImage(destination, result, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      throw PipelineError.saveFailed(outPath)
+    }
+
+    logger.info("Saved upscaled image to \(outPath)")
+    return outPath
+  }
+}
+#endif

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2AdaModulation.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2AdaModulation.swift
@@ -1,0 +1,154 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// A group of six learnable modulation parameters for one modality.
+///
+/// Stored as individual `MLXArray` parameters so that the weight loader can
+/// match key paths like `params_vid.attn_shift`, `params_vid.mlp_gate`, etc.
+public final class SeedVR2AdaParams: Module {
+
+  @ParameterInfo(key: "attn_shift") var attnShift: MLXArray
+  @ParameterInfo(key: "attn_scale") var attnScale: MLXArray
+  @ParameterInfo(key: "attn_gate") var attnGate: MLXArray
+  @ParameterInfo(key: "mlp_shift") var mlpShift: MLXArray
+  @ParameterInfo(key: "mlp_scale") var mlpScale: MLXArray
+  @ParameterInfo(key: "mlp_gate") var mlpGate: MLXArray
+
+  public init(dim: Int) {
+    self._attnShift.wrappedValue = MLXArray.zeros([dim])
+    self._attnScale.wrappedValue = MLXArray.ones([dim])
+    self._attnGate.wrappedValue = MLXArray.zeros([dim])
+    self._mlpShift.wrappedValue = MLXArray.zeros([dim])
+    self._mlpScale.wrappedValue = MLXArray.ones([dim])
+    self._mlpGate.wrappedValue = MLXArray.zeros([dim])
+    super.init()
+  }
+
+  /// Returns the (shift, scale, gate) tuple for the requested layer.
+  func params(for layer: String) -> (shift: MLXArray, scale: MLXArray, gate: MLXArray) {
+    if layer == "attn" {
+      return (attnShift, attnScale, attnGate)
+    } else {
+      return (mlpShift, mlpScale, mlpGate)
+    }
+  }
+}
+
+/// Adaptive layer normalization with learned bias parameters for the SeedVR2 transformer.
+///
+/// Each parameter set contains six learnable vectors (dim-sized):
+///
+///     attn_shift, attn_scale, attn_gate, mlp_shift, mlp_scale, mlp_gate
+///
+/// Three configurations are supported:
+///
+/// - **Separate** (`sharedWeights=false, isLastLayer=false`): Independent `params_vid`
+///   and `params_txt` parameter sets (blocks 0--9).
+/// - **Shared** (`sharedWeights=true, isLastLayer=false`): Single `params_all` set
+///   used for both video and text (blocks 10--30).
+/// - **Last layer** (`sharedWeights=true, isLastLayer=true`): `params_all` but text
+///   modulation returns identity (block 31).
+///
+/// ## Modulation Formulas
+///
+/// The time embedding `emb` has shape `(B, vid_dim, 2, 3)`:
+/// - axis 2: `[0]=attention, [1]=mlp`
+/// - axis 3: `[0]=shift, [1]=scale, [2]=gate`
+///
+/// **In-modulation**: `output = hidden * (scale + emb_scale) + (shift + emb_shift)`
+///
+/// **Out-modulation**: `output = hidden * (gate + emb_gate)`
+///
+/// ## Weight Key Paths
+///
+/// - `ada.params_vid.{attn_shift,...}` or `ada.params_all.{...}` or `ada.params_txt.{...}`
+public final class SeedVR2AdaModulation: Module {
+
+  public let sharedWeights: Bool
+  public let isLastLayer: Bool
+
+  @ModuleInfo(key: "params_all") var paramsAll: SeedVR2AdaParams?
+  @ModuleInfo(key: "params_vid") var paramsVid: SeedVR2AdaParams?
+  @ModuleInfo(key: "params_txt") var paramsTxt: SeedVR2AdaParams?
+
+  /// Creates an adaptive modulation module.
+  ///
+  /// - Parameters:
+  ///   - dim: Feature dimension (2560 for SeedVR2).
+  ///   - sharedWeights: If true, a single parameter set serves both modalities.
+  ///   - isLastLayer: If true, text modulation is identity (no txt params).
+  public init(dim: Int, sharedWeights: Bool = false, isLastLayer: Bool = false) {
+    self.sharedWeights = sharedWeights
+    self.isLastLayer = isLastLayer
+
+    if sharedWeights {
+      self._paramsAll.wrappedValue = SeedVR2AdaParams(dim: dim)
+    } else {
+      self._paramsVid.wrappedValue = SeedVR2AdaParams(dim: dim)
+      if !isLastLayer {
+        self._paramsTxt.wrappedValue = SeedVR2AdaParams(dim: dim)
+      }
+    }
+
+    super.init()
+  }
+
+  /// Modulates the video stream.
+  public func modulateVid(
+    _ hidden: MLXArray,
+    emb: MLXArray,
+    layer: String,
+    mode: String
+  ) -> MLXArray {
+    let p = sharedWeights ? paramsAll! : paramsVid!
+    return SeedVR2AdaModulation.applyModulation(hidden, emb: emb, params: p, layer: layer, mode: mode)
+  }
+
+  /// Modulates the text stream. Returns `hidden` unchanged if last layer.
+  public func modulateTxt(
+    _ hidden: MLXArray,
+    emb: MLXArray,
+    layer: String,
+    mode: String
+  ) -> MLXArray {
+    if isLastLayer { return hidden }
+    let p = sharedWeights ? paramsAll! : paramsTxt!
+    return SeedVR2AdaModulation.applyModulation(hidden, emb: emb, params: p, layer: layer, mode: mode)
+  }
+
+  // MARK: - Private
+
+  /// Core modulation logic.
+  ///
+  /// `emb` shape: `(B, dim, 2, 3)`.
+  /// `layer_idx`: 0 for attn, 1 for mlp.
+  /// `mod = emb[:, :, layer_idx, :]` -> `(B, dim, 3)`.
+  ///
+  /// In-mode: `hidden * (scale + mod[..., 1][:, None, :]) + (shift + mod[..., 0][:, None, :])`
+  /// Out-mode: `hidden * (gate + mod[..., 2][:, None, :])`
+  private static func applyModulation(
+    _ hidden: MLXArray,
+    emb: MLXArray,
+    params: SeedVR2AdaParams,
+    layer: String,
+    mode: String
+  ) -> MLXArray {
+    let layerIdx = layer == "attn" ? 0 : 1
+    let p = params.params(for: layer)
+
+    // mod = emb[:, :, layerIdx, :] → (B, dim, 3)
+    let mod = emb[0..., 0..., layerIdx, 0...]
+
+    if mode == "in" {
+      // shift = mod[..., 0][:, None, :] + param_shift
+      // scale = mod[..., 1][:, None, :] + param_scale
+      let embShift = mod[.ellipsis, 0].expandedDimensions(axis: 1)
+      let embScale = mod[.ellipsis, 1].expandedDimensions(axis: 1)
+      return hidden * (p.scale + embScale) + (p.shift + embShift)
+    } else {
+      let embGate = mod[.ellipsis, 2].expandedDimensions(axis: 1)
+      return hidden * (p.gate + embGate)
+    }
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMAttention.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMAttention.swift
@@ -1,0 +1,400 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Multi-modal windowed attention for the SeedVR2 transformer.
+///
+/// ## Forward Pass
+///
+/// 1. Project vid and txt to fused QKV (`dim -> 3 * heads * head_dim`)
+/// 2. Window partition vid tokens via ``SeedVR2WindowPartitioner``
+/// 3. QK-normalize (per-head RMSNorm)
+/// 4. Repeat text tokens for each window
+/// 5. Apply 3D RoPE to vid, 1D to txt
+/// 6. Concatenate vid+txt per window
+/// 7. Scaled dot-product attention per window
+/// 8. Split vid and txt from attention output
+/// 9. Coalesce text (mean across window copies)
+/// 10. Reverse window partition for vid
+/// 11. Project out
+///
+/// ## Shared Mode (blocks 10--31)
+///
+/// When `sharedWeights=true`, the vid projections are used for BOTH modalities
+/// during forward. Separate txt modules still exist for weight loading compatibility,
+/// but are not called.
+///
+/// ## Weight Key Paths
+///
+/// - `attn.proj_qkv_vid.weight`, `attn.proj_qkv_txt.weight`
+/// - `attn.proj_out_vid.{weight,bias}`, `attn.proj_out_txt.{weight,bias}`
+/// - `attn.norm_q_vid.weight`, `attn.norm_k_vid.weight`
+/// - `attn.norm_q_txt.weight`, `attn.norm_k_txt.weight`
+/// - `attn.rope.freqs`
+public final class SeedVR2MMAttention: Module {
+
+  public let sharedWeights: Bool
+  public let heads: Int
+  public let headDim: Int
+  public let scale: Float
+  public let window: (Int, Int, Int)
+  public let shift: Bool
+
+  // Video projections (always present)
+  @ModuleInfo(key: "proj_qkv_vid") var projQkvVid: Linear
+  @ModuleInfo(key: "proj_out_vid") var projOutVid: Linear
+  @ModuleInfo(key: "norm_q_vid") var normQVid: RMSNorm
+  @ModuleInfo(key: "norm_k_vid") var normKVid: RMSNorm
+
+  // Text projections (always present for weight loading; aliased to vid in shared mode forward)
+  @ModuleInfo(key: "proj_qkv_txt") var projQkvTxt: Linear
+  @ModuleInfo(key: "proj_out_txt") var projOutTxt: Linear
+  @ModuleInfo(key: "norm_q_txt") var normQTxt: RMSNorm
+  @ModuleInfo(key: "norm_k_txt") var normKTxt: RMSNorm
+
+  // 3D RoPE
+  @ModuleInfo(key: "rope") var rope: SeedVR2RoPE
+
+  /// Creates a multi-modal attention module.
+  ///
+  /// - Parameters:
+  ///   - vidDim: Video feature dimension. Default `2560`.
+  ///   - txtDim: Text feature dimension. Default `2560`.
+  ///   - heads: Number of attention heads. Default `20`.
+  ///   - headDim: Dimension per head. Default `128`.
+  ///   - qkBias: Whether QKV projections have bias. Default `false`.
+  ///   - qkNormEps: Epsilon for QK normalization. Default `1e-5`.
+  ///   - ropeDim: RoPE dimension. Default `128`.
+  ///   - sharedWeights: If true, vid projections serve both modalities. Default `false`.
+  ///   - window: Number of windows per axis. Default `(4, 3, 3)`.
+  ///   - shift: Whether to shift windows. Default `false`.
+  public init(
+    vidDim: Int = 2560,
+    txtDim: Int = 2560,
+    heads: Int = 20,
+    headDim: Int = 128,
+    qkBias: Bool = false,
+    qkNormEps: Float = 1e-5,
+    ropeDim: Int = 128,
+    sharedWeights: Bool = false,
+    window: (Int, Int, Int) = (4, 3, 3),
+    shift: Bool = false
+  ) {
+    self.sharedWeights = sharedWeights
+    self.heads = heads
+    self.headDim = headDim
+    self.scale = pow(Float(headDim), -0.5)
+    self.window = window
+    self.shift = shift
+
+    let innerDim = heads * headDim
+
+    // Video modules
+    self._projQkvVid.wrappedValue = Linear(vidDim, 3 * innerDim, bias: qkBias)
+    self._projOutVid.wrappedValue = Linear(innerDim, vidDim, bias: true)
+    self._normQVid.wrappedValue = RMSNorm(dimensions: headDim, eps: qkNormEps)
+    self._normKVid.wrappedValue = RMSNorm(dimensions: headDim, eps: qkNormEps)
+
+    // Text modules (always created for checkpoint compatibility)
+    self._projQkvTxt.wrappedValue = Linear(txtDim, 3 * innerDim, bias: qkBias)
+    self._projOutTxt.wrappedValue = Linear(innerDim, txtDim, bias: true)
+    self._normQTxt.wrappedValue = RMSNorm(dimensions: headDim, eps: qkNormEps)
+    self._normKTxt.wrappedValue = RMSNorm(dimensions: headDim, eps: qkNormEps)
+
+    // RoPE
+    self._rope.wrappedValue = SeedVR2RoPE(dim: ropeDim)
+
+    super.init()
+  }
+
+  /// Applies multi-modal windowed attention.
+  ///
+  /// - Parameters:
+  ///   - vid: Video tokens, shape `(B, L_vid, vid_dim)`.
+  ///   - txt: Text tokens, shape `(B, L_txt, txt_dim)`.
+  ///   - vidShape: Video spatial shape, `(B, 3)`.
+  ///   - txtShape: Text length, `(B, 1)`.
+  /// - Returns: Tuple of (vid_out, txt_out) with same shapes as input.
+  public func callAsFunction(
+    _ vid: MLXArray,
+    _ txt: MLXArray,
+    _ vidShape: MLXArray,
+    _ txtShape: MLXArray
+  ) -> (MLXArray, MLXArray) {
+    let bSize = vid.dim(0)
+    let lVid = vid.dim(1)
+    let lTxt = txt.dim(1)
+
+    // Select projections: in shared mode, use vid projections for both
+    let qkvProjVid = projQkvVid
+    let qkvProjTxt = sharedWeights ? projQkvVid : projQkvTxt
+    let outProjVid = projOutVid
+    let outProjTxt = sharedWeights ? projOutVid : projOutTxt
+    let nqVid = normQVid
+    let nkVid = normKVid
+    let nqTxt = sharedWeights ? normQVid : normQTxt
+    let nkTxt = sharedWeights ? normKVid : normKTxt
+
+    // 1. Project to QKV
+    // vid: (B, L, D) → flatten → (B*L, D) → proj → (B*L, 3*heads*head_dim) → (B*L, 3, heads, head_dim)
+    let vidFlat = vid.reshaped(-1, vid.dim(-1))
+    var qkvVid = qkvProjVid(vidFlat).reshaped(-1, 3, heads, headDim)
+
+    let txtFlat = txt.reshaped(-1, txt.dim(-1))
+    let qkvTxt = qkvProjTxt(txtFlat).reshaped(-1, 3, heads, headDim)
+
+    // 2. Window partition vid tokens
+    let partitioner = SeedVR2WindowPartitioner(shape: vidShape, windowSize: window, shift: shift)
+    qkvVid = partitioner.partition(qkvVid)
+
+    // 3. Split Q/K/V and normalize Q,K
+    // qkvVid shape: (N_vid_windowed, 3, heads, head_dim)
+    let qVid = nqVid(qkvVid[0..., 0])   // (N, heads, head_dim)
+    let kVid = nkVid(qkvVid[0..., 1])
+    let vVid = qkvVid[0..., 2]
+
+    let qTxt = nqTxt(qkvTxt[0..., 0])
+    let kTxt = nkTxt(qkvTxt[0..., 1])
+    let vTxt = qkvTxt[0..., 2]
+
+    // 4. Repeat text for each window
+    let counts = partitioner.windowCounts
+    let txtLen = txtShape[0..., 0]  // (B,) text lengths
+
+    // Stack Q/K/V for text: (N_txt, 3, heads, head_dim)
+    let qkvTxtStacked = MLX.stacked([qTxt, kTxt, vTxt], axis: 1)
+
+    // Repeat text per window: reshape to (B, L_txt, 3, heads, head_dim) then repeat along batch
+    let qkvTxtRepeated = SeedVR2MMAttention.repeatTextForWindows(
+      qkvTxtStacked, txtLen: txtLen, counts: counts
+    )
+    let qTxtRep = qkvTxtRepeated[0..., 0]
+    let kTxtRep = qkvTxtRepeated[0..., 1]
+    let vTxtRep = qkvTxtRepeated[0..., 2]
+
+    // 5. Apply RoPE
+    let txtShapeRepeated = SeedVR2MMAttention.perElementRepeat(txtShape, counts: counts)
+    let (rqVid, rkVid, rqTxt, rkTxt) = rope(
+      vidQ: qVid, vidK: kVid, vidShape: partitioner.windowShapes,
+      txtQ: qTxtRep, txtK: kTxtRep, txtShape: txtShapeRepeated
+    )
+
+    // 6 & 7. Per-window attention
+    let vidLens = partitioner.windowShapes.product(axis: 1)  // (num_windows,)
+    let winToBatch = SeedVR2MMAttention.repeatIndices(counts: counts)
+    let txtLens = txtLen[winToBatch]  // text length per window
+
+    // Concatenate vid+txt per window, run attention, split back
+    let vidQKV = MLX.stacked([rqVid, rkVid, vVid], axis: 1)
+    let txtQKV = MLX.stacked([rqTxt, rkTxt, vTxtRep], axis: 1)
+
+    let combined = SeedVR2MMAttention.concatWithText(
+      vid: vidQKV, txt: txtQKV, vidLens: vidLens, txtLens: txtLens, counts: counts
+    )
+
+    let winLens = vidLens + txtLens
+    let attnOut = SeedVR2MMAttention.perWindowAttention(
+      combined: combined, winLens: winLens, heads: heads, headDim: headDim, scale: scale
+    )
+
+    // 8 & 9. Split vid/txt and coalesce text
+    let (vidOut, txtOut) = SeedVR2MMAttention.unconcatAndCoalesce(
+      combined: attnOut, vidLens: vidLens, txtLens: txtLens, counts: counts
+    )
+
+    // 10. Reverse window partition and project out
+    let vidResult = outProjVid(partitioner.reverse(vidOut)).reshaped(bSize, lVid, -1)
+    let txtResult = outProjTxt(txtOut).reshaped(bSize, lTxt, -1)
+
+    return (vidResult, txtResult)
+  }
+
+  // MARK: - Static Helpers
+
+  /// Repeats text tokens for each window.
+  ///
+  /// Input: (N_txt_total, 3, heads, head_dim), where N_txt_total = sum(B * L_txt)
+  /// Output: (sum(counts * L_txt), 3, heads, head_dim)
+  private static func repeatTextForWindows(
+    _ txt: MLXArray,
+    txtLen: MLXArray,
+    counts: [Int]
+  ) -> MLXArray {
+    let batchSize = counts.count
+    let lTxt = Int(txtLen[0].item(Int32.self))
+    let restShape = Array(txt.shape[1...])
+
+    // Reshape to (B, L_txt, ...)
+    let reshaped = txt.reshaped([batchSize, lTxt] + restShape)
+
+    // Per-batch repeat: repeat batch element b by counts[b] times
+    var parts: [MLXArray] = []
+    for b in 0 ..< batchSize {
+      let batchSlice = reshaped[b].expandedDimensions(axis: 0)
+      let rep = MLX.repeated(batchSlice, count: counts[b], axis: 0)
+      parts.append(rep)
+    }
+    let joined = MLX.concatenated(parts, axis: 0)
+
+    // Flatten: (sum_counts, L_txt, ...) -> (sum_counts * L_txt, ...)
+    let totalWindows = counts.reduce(0, +)
+    return joined.reshaped([totalWindows * lTxt] + restShape)
+  }
+
+  /// Creates an index array that maps each window to its batch element.
+  /// e.g., counts=[3, 2] → [0, 0, 0, 1, 1]
+  private static func repeatIndices(counts: [Int]) -> MLXArray {
+    var indices: [Int32] = []
+    for (batchIdx, count) in counts.enumerated() {
+      indices.append(contentsOf: [Int32](repeating: Int32(batchIdx), count: count))
+    }
+    return MLXArray(indices)
+  }
+
+  /// Interleaves vid and txt tokens per window.
+  ///
+  /// Result: [vid_win0, txt_win0, vid_win1, txt_win1, ...]
+  private static func concatWithText(
+    vid: MLXArray,
+    txt: MLXArray,
+    vidLens: MLXArray,
+    txtLens: MLXArray,
+    counts: [Int]
+  ) -> MLXArray {
+    let numWindows = counts.reduce(0, +)
+    var parts: [MLXArray] = []
+
+    var vidOffset = 0
+    var txtOffset = 0
+
+    for w in 0 ..< numWindows {
+      let vLen = Int(vidLens[w].item(Int32.self))
+      let tLen = Int(txtLens[w].item(Int32.self))
+
+      parts.append(vid[vidOffset ..< (vidOffset + vLen)])
+      parts.append(txt[txtOffset ..< (txtOffset + tLen)])
+
+      vidOffset += vLen
+      txtOffset += tLen
+    }
+
+    return MLX.concatenated(parts, axis: 0)
+  }
+
+  /// Runs scaled dot-product attention independently per window.
+  ///
+  /// Input `combined`: concatenated (vid+txt) tokens per window with shape
+  /// `(total_tokens, 3, heads, head_dim)`, where the `3` axis is [Q, K, V].
+  private static func perWindowAttention(
+    combined: MLXArray,
+    winLens: MLXArray,
+    heads: Int,
+    headDim: Int,
+    scale: Float
+  ) -> MLXArray {
+    let numWindows = winLens.dim(0)
+
+    // Compute cumulative split indices
+    var splitIndices: [Int] = []
+    var cumLen = 0
+    for w in 0 ..< numWindows - 1 {
+      cumLen += Int(winLens[w].item(Int32.self))
+      splitIndices.append(cumLen)
+    }
+
+    let windows = combined.split(indices: splitIndices, axis: 0)
+    var outputs: [MLXArray] = []
+
+    for w in windows {
+      // w shape: (winLen, 3, heads, head_dim)
+      // Extract Q, K, V and reshape for SDPA: (1, heads, winLen, head_dim)
+      let q = w[0..., 0].expandedDimensions(axis: 0).transposed(0, 2, 1, 3)
+      let k = w[0..., 1].expandedDimensions(axis: 0).transposed(0, 2, 1, 3)
+      let v = w[0..., 2].expandedDimensions(axis: 0).transposed(0, 2, 1, 3)
+
+      // SDPA: (1, heads, winLen, head_dim) → squeeze → (winLen, heads, head_dim)
+      var o = MLXFast.scaledDotProductAttention(
+        queries: q, keys: k, values: v, scale: scale, mask: nil
+      )
+      o = o.transposed(0, 2, 1, 3).squeezed(axis: 0)
+
+      outputs.append(o)
+    }
+
+    // Concatenate all windows: (total_tokens, heads, head_dim)
+    return MLX.concatenated(outputs, axis: 0)
+  }
+
+  /// Splits combined attention output into vid and txt, coalescing text across windows.
+  ///
+  /// Text tokens appear in every window. We average them across all windows that
+  /// contain the same batch element.
+  private static func unconcatAndCoalesce(
+    combined: MLXArray,
+    vidLens: MLXArray,
+    txtLens: MLXArray,
+    counts: [Int]
+  ) -> (MLXArray, MLXArray) {
+    // Flatten to (total, heads*head_dim) for output
+    let combinedFlat = combined.reshaped(-1, combined.dim(-2) * combined.dim(-1))
+
+    let numWindows = counts.reduce(0, +)
+
+    // Build alternating split indices: [vLen0, tLen0, vLen1, tLen1, ...]
+    var splitLens: [Int] = []
+    for w in 0 ..< numWindows {
+      splitLens.append(Int(vidLens[w].item(Int32.self)))
+      splitLens.append(Int(txtLens[w].item(Int32.self)))
+    }
+
+    // Compute cumulative split indices
+    var splitIndices: [Int] = []
+    var cumLen = 0
+    for i in 0 ..< (splitLens.count - 1) {
+      cumLen += splitLens[i]
+      splitIndices.append(cumLen)
+    }
+
+    let parts = combinedFlat.split(indices: splitIndices, axis: 0)
+
+    // Even indices are vid, odd are txt
+    var vidParts: [MLXArray] = []
+    var txtParts: [MLXArray] = []
+    for (i, part) in parts.enumerated() {
+      if i % 2 == 0 {
+        vidParts.append(part)
+      } else {
+        txtParts.append(part)
+      }
+    }
+
+    let vidOut = MLX.concatenated(vidParts, axis: 0)
+
+    // Coalesce text: average across windows per batch element
+    var coalescedTxt: [MLXArray] = []
+    var windowOffset = 0
+    for count in counts {
+      // Stack the text from `count` windows and take mean
+      let windowTxts = Array(txtParts[windowOffset ..< (windowOffset + count)])
+      let stacked = MLX.stacked(windowTxts, axis: 0)  // (count, L_txt, D)
+      let averaged = stacked.mean(axis: 0)  // (L_txt, D)
+      coalescedTxt.append(averaged)
+      windowOffset += count
+    }
+
+    let txtOut = MLX.concatenated(coalescedTxt, axis: 0)
+
+    return (vidOut, txtOut)
+  }
+
+  /// Repeats rows of an array with per-element counts along axis 0.
+  private static func perElementRepeat(_ array: MLXArray, counts: [Int]) -> MLXArray {
+    var parts: [MLXArray] = []
+    for (i, count) in counts.enumerated() {
+      let slice = array[i].expandedDimensions(axis: 0)
+      parts.append(MLX.repeated(slice, count: count, axis: 0))
+    }
+    return MLX.concatenated(parts, axis: 0)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMSwiGLU.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMSwiGLU.swift
@@ -1,0 +1,52 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Multi-modal feed-forward wrapper for the SeedVR2 transformer.
+///
+/// Supports both SwiGLU (3B) and GELU (7B) MLP variants.
+/// The SeedVR2SwiGLUMLP class handles both modes internally.
+public final class SeedVR2MMSwiGLU: Module {
+
+  public let sharedWeights: Bool
+  public let isLastLayer: Bool
+
+  @ModuleInfo(key: "all") var mlpAll: SeedVR2SwiGLUMLP?
+  @ModuleInfo(key: "vid") var mlpVid: SeedVR2SwiGLUMLP?
+  @ModuleInfo(key: "txt") var mlpTxt: SeedVR2SwiGLUMLP?
+
+  public init(
+    vidDim: Int = 2560,
+    txtDim: Int = 2560,
+    expandRatio: Int = 4,
+    sharedWeights: Bool = false,
+    isLastLayer: Bool = false,
+    mlpType: SeedVR2MLPType = .swiglu
+  ) {
+    self.sharedWeights = sharedWeights
+    self.isLastLayer = isLastLayer
+
+    if sharedWeights {
+      self._mlpAll.wrappedValue = SeedVR2SwiGLUMLP(dim: vidDim, expandRatio: expandRatio, mlpType: mlpType)
+    } else {
+      self._mlpVid.wrappedValue = SeedVR2SwiGLUMLP(dim: vidDim, expandRatio: expandRatio, mlpType: mlpType)
+      if !isLastLayer {
+        self._mlpTxt.wrappedValue = SeedVR2SwiGLUMLP(dim: txtDim, expandRatio: expandRatio, mlpType: mlpType)
+      }
+    }
+
+    super.init()
+  }
+
+  public func callAsFunction(_ vid: MLXArray, _ txt: MLXArray) -> (MLXArray, MLXArray) {
+    if sharedWeights {
+      let vidOut = mlpAll!(vid)
+      let txtOut = isLastLayer ? txt : mlpAll!(txt)
+      return (vidOut, txtOut)
+    } else {
+      let vidOut = mlpVid!(vid)
+      let txtOut = isLastLayer ? txt : mlpTxt!(txt)
+      return (vidOut, txtOut)
+    }
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMSwiGLU.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2MMSwiGLU.swift
@@ -41,7 +41,7 @@ public final class SeedVR2MMSwiGLU: Module {
   public func callAsFunction(_ vid: MLXArray, _ txt: MLXArray) -> (MLXArray, MLXArray) {
     if sharedWeights {
       let vidOut = mlpAll!(vid)
-      let txtOut = isLastLayer ? txt : mlpAll!(txt)
+      let txtOut = mlpAll!(txt)  // Shared mode always processes text (matches Python)
       return (vidOut, txtOut)
     } else {
       let vidOut = mlpVid!(vid)

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchIn.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchIn.swift
@@ -1,0 +1,85 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Patchifies 5D video tensors into a flat token sequence for the SeedVR2 transformer.
+///
+/// ## Architecture
+///
+/// ```
+/// Input: (B, C=33, T, H, W)
+///   → reshape to (B, C, T/pt, pt, H/ph, ph, W/pw, pw)
+///   → transpose to (B, T/pt, H/ph, W/pw, C*pt*ph*pw)
+///   → Linear(C*pt*ph*pw, dim)
+///   → reshape to (B, T'*H'*W', dim)
+///   → output tokens (B, L, dim) and vid_shape (B, 3) = [T', H', W']
+/// ```
+///
+/// With default parameters (C=33, patch_size=(1,2,2), dim=2560):
+///   - Patch volume: 1*2*2 = 4
+///   - Input features per patch: 33 * 4 = 132
+///   - Linear: 132 -> 2560
+///
+/// ## Weight Key Paths
+///
+/// - `vid_in.proj.weight`, `vid_in.proj.bias`
+public final class SeedVR2PatchIn: Module {
+
+  /// Spatial/temporal patch size (pt, ph, pw).
+  public let patchSize: (Int, Int, Int)
+
+  /// Linear projection from flattened patch to model dim.
+  @ModuleInfo(key: "proj") var proj: Linear
+
+  /// Creates a patch-in module.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels. Default `33`.
+  ///   - patchSize: (temporal, height, width) patch size. Default `(1, 2, 2)`.
+  ///   - dim: Output feature dimension. Default `2560`.
+  public init(inChannels: Int = 33, patchSize: (Int, Int, Int) = (1, 2, 2), dim: Int = 2560) {
+    self.patchSize = patchSize
+    let (pt, ph, pw) = patchSize
+    self._proj.wrappedValue = Linear(inChannels * pt * ph * pw, dim)
+    super.init()
+  }
+
+  /// Patchifies a 5D video tensor into a token sequence.
+  ///
+  /// - Parameter vid: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Tuple of (tokens, vid_shape) where tokens is `(B, L, dim)` and
+  ///   vid_shape is `(B, 3)` containing `[T/pt, H/ph, W/pw]` per batch element.
+  public func callAsFunction(_ vid: MLXArray) -> (MLXArray, MLXArray) {
+    let (pt, ph, pw) = patchSize
+    let bSize = vid.dim(0)
+    let channels = vid.dim(1)
+    let tSize = vid.dim(2)
+    let hSize = vid.dim(3)
+    let wSize = vid.dim(4)
+
+    let tPatches = tSize / pt
+    let hPatches = hSize / ph
+    let wPatches = wSize / pw
+
+    // (B, C, T, H, W) → (B, C, T/pt, pt, H/ph, ph, W/pw, pw)
+    var x = vid.reshaped(bSize, channels, tPatches, pt, hPatches, ph, wPatches, pw)
+
+    // → (B, T/pt, H/ph, W/pw, pt, ph, pw, C)
+    x = x.transposed(0, 2, 4, 6, 3, 5, 7, 1)
+
+    // → (B, T/pt, H/ph, W/pw, pt*ph*pw*C)
+    x = x.reshaped(bSize, tPatches, hPatches, wPatches, pt * ph * pw * channels)
+
+    // Linear projection
+    x = proj(x)
+
+    // Flatten spatial dims: (B, T*H*W, dim)
+    x = x.reshaped(bSize, -1, x.dim(-1))
+
+    // vid_shape: (B, 3) = broadcast [tPatches, hPatches, wPatches]
+    let shape = MLXArray([Int32(tPatches), Int32(hPatches), Int32(wPatches)])
+    let vidShape = MLX.broadcast(shape.reshaped(1, 3), to: [bSize, 3])
+
+    return (x, vidShape)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchOut.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchOut.swift
@@ -1,0 +1,77 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Reverse patchification: maps transformer tokens back to a 5D video tensor.
+///
+/// ## Architecture
+///
+/// ```
+/// Input: (B, L, dim), vid_shape (B, 3) = [T', H', W']
+///   → Linear(dim, out_channels * pt * ph * pw)
+///   → reshape to (B, T', H', W', out_channels, pt, ph, pw)
+///   → transpose to (B, out_channels, T'*pt, H'*ph, W'*pw)
+///   → output (B, out_channels, T, H, W)
+/// ```
+///
+/// With default parameters (out_channels=16, patch_size=(1,2,2), dim=2560):
+///   - Output features per patch: 16 * 1 * 2 * 2 = 64
+///   - Linear: 2560 -> 64
+///
+/// ## Weight Key Paths
+///
+/// - `vid_out.proj.weight`, `vid_out.proj.bias`
+public final class SeedVR2PatchOut: Module {
+
+  /// Spatial/temporal patch size (pt, ph, pw).
+  public let patchSize: (Int, Int, Int)
+
+  /// Number of output channels per voxel.
+  public let outChannels: Int
+
+  /// Linear projection from model dim to flattened patch.
+  @ModuleInfo(key: "proj") var proj: Linear
+
+  /// Creates a patch-out module.
+  ///
+  /// - Parameters:
+  ///   - outChannels: Number of output channels per voxel. Default `16`.
+  ///   - patchSize: (temporal, height, width) patch size. Default `(1, 2, 2)`.
+  ///   - dim: Input feature dimension. Default `2560`.
+  public init(outChannels: Int = 16, patchSize: (Int, Int, Int) = (1, 2, 2), dim: Int = 2560) {
+    self.outChannels = outChannels
+    self.patchSize = patchSize
+    let (pt, ph, pw) = patchSize
+    self._proj.wrappedValue = Linear(dim, outChannels * pt * ph * pw)
+    super.init()
+  }
+
+  /// Converts tokens back to a 5D video tensor.
+  ///
+  /// - Parameters:
+  ///   - vid: Token tensor of shape `(B, L, dim)`.
+  ///   - vidShape: Patch grid shape, `(B, 3)` containing `[T', H', W']`.
+  /// - Returns: Tuple of (video, vidShape) where video is `(B, C, T, H, W)`.
+  public func callAsFunction(_ vid: MLXArray, _ vidShape: MLXArray) -> (MLXArray, MLXArray) {
+    let (pt, ph, pw) = patchSize
+
+    // Linear projection: (B, L, dim) → (B, L, outChannels * pt * ph * pw)
+    var x = proj(vid)
+
+    let bSize = x.dim(0)
+    let tPatches = Int(vidShape[0, 0].item(Int32.self))
+    let hPatches = Int(vidShape[0, 1].item(Int32.self))
+    let wPatches = Int(vidShape[0, 2].item(Int32.self))
+
+    // (B, T', H', W', outChannels, pt, ph, pw)
+    x = x.reshaped(bSize, tPatches, hPatches, wPatches, outChannels, pt, ph, pw)
+
+    // → (B, outChannels, T', pt, H', ph, W', pw)
+    x = x.transposed(0, 4, 1, 5, 2, 6, 3, 7)
+
+    // → (B, outChannels, T'*pt, H'*ph, W'*pw)
+    x = x.reshaped(bSize, outChannels, tPatches * pt, hPatches * ph, wPatches * pw)
+
+    return (x, vidShape)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchOut.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2PatchOut.swift
@@ -9,7 +9,7 @@ import MLXNN
 /// ```
 /// Input: (B, L, dim), vid_shape (B, 3) = [T', H', W']
 ///   → Linear(dim, out_channels * pt * ph * pw)
-///   → reshape to (B, T', H', W', out_channels, pt, ph, pw)
+///   → reshape to (B, T', H', W', pt, ph, pw, out_channels)
 ///   → transpose to (B, out_channels, T'*pt, H'*ph, W'*pw)
 ///   → output (B, out_channels, T, H, W)
 /// ```
@@ -63,11 +63,11 @@ public final class SeedVR2PatchOut: Module {
     let hPatches = Int(vidShape[0, 1].item(Int32.self))
     let wPatches = Int(vidShape[0, 2].item(Int32.self))
 
-    // (B, T', H', W', outChannels, pt, ph, pw)
-    x = x.reshaped(bSize, tPatches, hPatches, wPatches, outChannels, pt, ph, pw)
+    // (B, T', H', W', pt, ph, pw, outChannels) — channel LAST, matching Python
+    x = x.reshaped(bSize, tPatches, hPatches, wPatches, pt, ph, pw, outChannels)
 
-    // → (B, outChannels, T', pt, H', ph, W', pw)
-    x = x.transposed(0, 4, 1, 5, 2, 6, 3, 7)
+    // → (B, outChannels, T'*pt, H'*ph, W'*pw) via transpose
+    x = x.transposed(0, 7, 1, 4, 2, 5, 3, 6)
 
     // → (B, outChannels, T'*pt, H'*ph, W'*pw)
     x = x.reshaped(bSize, outChannels, tPatches * pt, hPatches * ph, wPatches * pw)

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2RoPE.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2RoPE.swift
@@ -1,0 +1,233 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// 3D axial rotary position embeddings for the SeedVR2 transformer.
+///
+/// Applies learned-frequency RoPE along temporal, height, and width axes independently.
+/// For video tokens, the three axes produce separate frequency grids that are concatenated.
+/// For text tokens, a 1D frequency grid is tiled across all three axes.
+///
+/// ## Key Dimensions
+///
+/// - `dim = 128` (head_dim)
+/// - `freq_dim = dim / 3 = 42` (frequencies per axis)
+/// - `freqs` parameter: shape `(freq_dim / 2,)` = `(21,)` — shared across axes
+/// - Rotation covers first `3 * 42 = 126` dims; remaining 2 pass through
+///
+/// ## Text Temporal Offset
+///
+/// Video temporal positions are offset by the text sequence length, so that
+/// text occupies positions `[0, txt_len)` and video occupies `[txt_len, txt_len+T)`.
+///
+/// ## Weight Key Paths
+///
+/// - `rope.freqs` — shape `(21,)`
+public final class SeedVR2RoPE: Module {
+
+  /// Feature dimension (128 = head_dim).
+  public let dim: Int
+
+  /// Number of spatial axes for RoPE (3: temporal, height, width).
+  public let ropeDim: Int
+
+  /// Features per axis: dim / ropeDim = 42.
+  public let freqDim: Int
+
+  /// Learned base frequencies, shape `(freqDim / 2,)` = `(21,)`.
+  @ParameterInfo(key: "freqs") var freqs: MLXArray
+
+  /// Creates a 3D RoPE module.
+  ///
+  /// - Parameter dim: Head dimension. Default `128`.
+  public init(dim: Int = 128) {
+    self.dim = dim
+    self.ropeDim = 3
+    self.freqDim = dim / 3  // 42
+
+    // Initialize with standard geometric frequencies:
+    // freqs = 1 / (theta^(arange(0, freq_dim, 2)[:freq_dim//2] / freq_dim))
+    // where theta = 10000
+    let theta: Float = 10000.0
+    let halfFreqDim = freqDim / 2  // 21
+    // arange(0, freq_dim, 2)[:halfFreqDim] as float
+    var idxArray: [Float] = []
+    for i in stride(from: 0, to: freqDim, by: 2).prefix(halfFreqDim) {
+      idxArray.append(Float(i))
+    }
+    let indices = MLXArray(idxArray)
+    let exponents = indices / Float(freqDim)
+    self._freqs.wrappedValue = MLXArray(1.0) / MLXArray(theta).pow(exponents)
+
+    super.init()
+  }
+
+  /// Applies 3D axial RoPE to video and text Q/K tensors.
+  ///
+  /// - Parameters:
+  ///   - vidQ: Video queries, shape `(N_vid, heads, head_dim)`.
+  ///   - vidK: Video keys, shape `(N_vid, heads, head_dim)`.
+  ///   - vidShape: Window shapes, `(num_windows, 3)` containing `[T, H, W]`.
+  ///   - txtQ: Text queries, shape `(N_txt, heads, head_dim)`.
+  ///   - txtK: Text keys, shape `(N_txt, heads, head_dim)`.
+  ///   - txtShape: Text shapes, `(num_windows, 1)` containing text length per window.
+  /// - Returns: Tuple of rotated (vidQ, vidK, txtQ, txtK).
+  public func callAsFunction(
+    vidQ: MLXArray,
+    vidK: MLXArray,
+    vidShape: MLXArray,
+    txtQ: MLXArray,
+    txtK: MLXArray,
+    txtShape: MLXArray
+  ) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    return SeedVR2RoPE.applyMMRoPE3D(
+      vidQ: vidQ, vidK: vidK, vidShape: vidShape,
+      txtQ: txtQ, txtK: txtK, txtShape: txtShape,
+      freqs: freqs, ropeDim: ropeDim
+    )
+  }
+
+  // MARK: - Static Helpers
+
+  /// Rotates the second half of each pair: `[-x2, x1]` interleaved.
+  private static func rotateHalf(_ x: MLXArray) -> MLXArray {
+    // Reshape last dim into pairs: (..., dim/2, 2)
+    var shape = x.shape
+    let lastDim = shape[shape.count - 1]
+    shape[shape.count - 1] = lastDim / 2
+    shape.append(2)
+
+    let paired = x.reshaped(shape)
+    let x1 = paired[.ellipsis, 0]
+    let x2 = paired[.ellipsis, 1]
+
+    // Stack [-x2, x1] and flatten back
+    let rotated = MLX.stacked([-x2, x1], axis: -1)
+
+    var outShape = x.shape
+    return rotated.reshaped(outShape)
+  }
+
+  /// Computes axial frequency grids for N-dimensional positions.
+  ///
+  /// For 3D (T, H, W): produces a `(T, H, W, 3*freq_dim)` frequency tensor.
+  /// For 1D (L): produces a `(L, freq_dim)` frequency tensor.
+  ///
+  /// Each axis contributes `freq_dim` features (half-cos, half-sin alternating pairs).
+  private static func getAxialFreqs(freqs: MLXArray, dims: [Int]) -> MLXArray {
+    let freqDimPerAxis = freqs.dim(0) * 2  // 42
+    var targetShape = dims + [freqDimPerAxis]
+
+    var allFreqs: [MLXArray] = []
+
+    for (ind, dimSize) in dims.enumerated() {
+      // pos = arange(dimSize, float32)
+      let pos = MLXArray(Int32(0) ..< Int32(dimSize)).asType(.float32)
+
+      // axis_freqs = outer(pos, freqs) → (dimSize, freqDim/2)
+      let axisFreqsRaw = MLX.outer(pos, freqs.asType(.float32))
+
+      // Repeat each freq value → (dimSize, freqDim) = interleaved cos/sin positions
+      let axisFreqs = MLX.repeated(axisFreqsRaw, count: 2, axis: 1)
+
+      // Reshape to broadcast shape: [1, ..., dimSize, ..., 1, freqDimPerAxis]
+      var shape = [Int](repeating: 1, count: dims.count) + [freqDimPerAxis]
+      shape[ind] = dimSize
+      let reshaped = axisFreqs.reshaped(shape)
+
+      allFreqs.append(reshaped)
+    }
+
+    // Broadcast all to target shape and concatenate along last axis
+    let broadcasted = allFreqs.map { MLX.broadcast($0, to: targetShape) }
+    return MLX.concatenated(broadcasted, axis: -1)
+  }
+
+  /// Applies rotary embedding to a tensor using precomputed frequencies.
+  ///
+  /// Rotates the first `rot_dim` features, passes the rest through unchanged.
+  private static func applyRotaryEmb(freqs: MLXArray, t: MLXArray) -> MLXArray {
+    let rotDim = freqs.dim(-1)
+    let tRotate = t[.ellipsis, 0 ..< rotDim]
+    let tPass = t[.ellipsis, rotDim...]
+
+    let freqsF = freqs.asType(.float32)
+    let tF = tRotate.asType(.float32)
+
+    let cosFreqs = freqsF.cos()
+    let sinFreqs = freqsF.sin()
+    var transformed = (tF * cosFreqs) + (rotateHalf(tF) * sinFreqs)
+    transformed = transformed.asType(t.dtype)
+
+    if tPass.dim(-1) > 0 {
+      return MLX.concatenated([transformed, tPass], axis: -1)
+    }
+    return transformed
+  }
+
+  /// Full multi-modal 3D RoPE application.
+  ///
+  /// Computes separate 3D frequency grids for video (with text offset on temporal axis)
+  /// and 1D grids for text, then applies rotary embeddings per window.
+  private static func applyMMRoPE3D(
+    vidQ: MLXArray, vidK: MLXArray, vidShape: MLXArray,
+    txtQ: MLXArray, txtK: MLXArray, txtShape: MLXArray,
+    freqs: MLXArray, ropeDim: Int
+  ) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    // Compute max dimensions for the precomputed grid
+    let maxTemporal = Int(MLX.max(vidShape[0..., 0] + txtShape[0..., 0]).item(Int32.self))
+    let maxHeight = Int(MLX.max(vidShape[0..., 1]).item(Int32.self))
+    let maxWidth = Int(MLX.max(vidShape[0..., 2]).item(Int32.self))
+    let maxTxtLen = Int(MLX.max(txtShape[0..., 0]).item(Int32.self))
+
+    // Clamp with safety margin
+    let clampTemporal = min(maxTemporal + 16, 1024)
+    let clampHeight = min(maxHeight + 4, 128)
+    let clampWidth = min(maxWidth + 4, 128)
+
+    // Precompute full 3D freq grid: (clampT, clampH, clampW, 3*freqDim)
+    let vidFreqsFull = getAxialFreqs(freqs: freqs, dims: [clampTemporal, clampHeight, clampWidth])
+
+    // Precompute 1D freq grid for text: (maxTxtLen+margin, freqDim)
+    let txtFreqs1D = getAxialFreqs(freqs: freqs, dims: [min(maxTxtLen + 16, 1024)])
+
+    let numWindows = vidShape.dim(0)
+    var vidFreqList: [MLXArray] = []
+    var txtFreqList: [MLXArray] = []
+
+    for b in 0 ..< numWindows {
+      let f = Int(vidShape[b, 0].item(Int32.self))
+      let h = Int(vidShape[b, 1].item(Int32.self))
+      let w = Int(vidShape[b, 2].item(Int32.self))
+      let txtLen = Int(txtShape[b, 0].item(Int32.self))
+
+      // Video: offset temporal by txtLen to avoid position collision
+      // vid_freq = vid_freqs_full[txtLen:txtLen+f, :h, :w].reshape(-1, D)
+      let vidFreq = vidFreqsFull[txtLen ..< (txtLen + f), 0 ..< h, 0 ..< w]
+        .reshaped(-1, vidFreqsFull.dim(-1))
+
+      // Text: tile 1D freqs ropeDim times → (txtLen, ropeDim * freqDim)
+      let txtFreqSlice = txtFreqs1D[0 ..< txtLen]
+      let txtFreq = MLX.tiled(txtFreqSlice, repetitions: [1, ropeDim])
+
+      vidFreqList.append(vidFreq)
+      txtFreqList.append(txtFreq)
+    }
+
+    // Concatenate all windows
+    let vidFreqsAll = MLX.concatenated(vidFreqList, axis: 0)
+    let txtFreqsAll = MLX.concatenated(txtFreqList, axis: 0)
+
+    // Apply rotary embeddings: freqs[:, None, :] broadcasts over heads
+    let vidFreqsExpanded = vidFreqsAll.expandedDimensions(axis: 1)
+    let txtFreqsExpanded = txtFreqsAll.expandedDimensions(axis: 1)
+
+    let rotVidQ = applyRotaryEmb(freqs: vidFreqsExpanded, t: vidQ)
+    let rotVidK = applyRotaryEmb(freqs: vidFreqsExpanded, t: vidK)
+    let rotTxtQ = applyRotaryEmb(freqs: txtFreqsExpanded, t: txtQ)
+    let rotTxtK = applyRotaryEmb(freqs: txtFreqsExpanded, t: txtK)
+
+    return (rotVidQ, rotVidK, rotTxtQ, rotTxtK)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2SwiGLUMLP.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2SwiGLUMLP.swift
@@ -1,0 +1,78 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Unified feed-forward network for the SeedVR2 transformer.
+///
+/// Supports both SwiGLU (3B) and standard GELU (7B) modes:
+///
+/// SwiGLU mode (3B):
+///     gate  = SiLU(proj_in_gate(x))
+///     value = proj_in(x)
+///     out   = proj_out(gate * value)
+///     Hidden dim = multiple_of * ceil(2 * dim * expand_ratio / 3 / multiple_of)
+///     No bias on any projection.
+///
+/// GELU mode (7B):
+///     out = proj_out(GELU(proj_in(x)))
+///     Hidden dim = dim * expand_ratio
+///     Bias on both projections.
+///
+/// All projections are registered via ModuleInfo so weight keys map correctly.
+public final class SeedVR2SwiGLUMLP: Module {
+
+  @ModuleInfo(key: "proj_in") var projIn: Linear
+  @ModuleInfo(key: "proj_in_gate") var projInGate: Linear?
+  @ModuleInfo(key: "proj_out") var projOut: Linear
+
+  public let dim: Int
+  public let hiddenDim: Int
+  public let mlpType: SeedVR2MLPType
+
+  /// Creates a feed-forward layer.
+  ///
+  /// - Parameters:
+  ///   - dim: Input and output feature dimension.
+  ///   - expandRatio: Expansion factor for the hidden dimension. Default 4.
+  ///   - multipleOf: Alignment for SwiGLU hidden dim. Default 256.
+  ///   - mlpType: .swiglu for 3B, .gelu for 7B. Default .swiglu.
+  public init(dim: Int, expandRatio: Int = 4, multipleOf: Int = 256, mlpType: SeedVR2MLPType = .swiglu) {
+    self.dim = dim
+    self.mlpType = mlpType
+
+    switch mlpType {
+    case .swiglu:
+      let raw = 2 * dim * expandRatio / 3
+      let aligned = multipleOf * ((raw + multipleOf - 1) / multipleOf)
+      self.hiddenDim = aligned
+      self._projIn.wrappedValue = Linear(dim, aligned, bias: false)
+      self._projInGate.wrappedValue = Linear(dim, aligned, bias: false)
+      self._projOut.wrappedValue = Linear(aligned, dim, bias: false)
+
+    case .gelu:
+      self.hiddenDim = dim * expandRatio
+      self._projIn.wrappedValue = Linear(dim, dim * expandRatio, bias: true)
+      self._projInGate.wrappedValue = nil
+      self._projOut.wrappedValue = Linear(dim * expandRatio, dim, bias: true)
+    }
+
+    super.init()
+  }
+
+  /// Applies the feed-forward to the input.
+  ///
+  /// - Parameter x: Input array of shape (..., dim).
+  /// - Returns: Output array of shape (..., dim).
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    switch mlpType {
+    case .swiglu:
+      let gate = MLXNN.silu(projInGate!(x))
+      let value = projIn(x)
+      return projOut(gate * value)
+    case .gelu:
+      var h = projIn(x)
+      h = MLXNN.gelu(h)
+      return projOut(h)
+    }
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2TimeEmbedding.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2TimeEmbedding.swift
@@ -1,0 +1,104 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Sinusoidal timestep embedding followed by a three-layer MLP for the SeedVR2 transformer.
+///
+/// ## Architecture
+///
+/// ```
+/// timestep (scalar or [B])
+///   → sinusoidal embedding (B, sinusoidal_dim=256)
+///   → Linear(256, 2560) → SiLU
+///   → Linear(2560, 2560) → SiLU
+///   → Linear(2560, 15360)
+///   → output (B, 15360)
+/// ```
+///
+/// The output is later reshaped to `(B, vid_dim, 2, 3)` in the top-level transformer,
+/// where the `2` axis separates attention vs MLP modulation parameters, and the `3` axis
+/// holds (shift, scale, gate) for each.
+///
+/// ## Weight Key Paths
+///
+/// - `proj_in.weight`, `proj_in.bias`
+/// - `proj_hid.weight`, `proj_hid.bias`
+/// - `proj_out.weight`, `proj_out.bias`
+public final class SeedVR2TimeEmbedding: Module {
+
+  /// Dimension of the sinusoidal positional embedding.
+  public let sinusoidalDim: Int
+
+  /// First linear: sinusoidal_dim -> hidden_dim.
+  @ModuleInfo(key: "proj_in") var projIn: Linear
+
+  /// Second linear: hidden_dim -> hidden_dim.
+  @ModuleInfo(key: "proj_hid") var projHid: Linear
+
+  /// Third linear: hidden_dim -> output_dim.
+  @ModuleInfo(key: "proj_out") var projOut: Linear
+
+  /// Creates a timestep embedding module.
+  ///
+  /// - Parameters:
+  ///   - sinusoidalDim: Dimension of the sinusoidal embedding. Default `256`.
+  ///   - hiddenDim: Hidden dimension of the MLP. Default `2560`.
+  ///   - outputDim: Output dimension. Default `15360` (= 6 * 2560).
+  public init(sinusoidalDim: Int = 256, hiddenDim: Int = 2560, outputDim: Int = 15360) {
+    self.sinusoidalDim = sinusoidalDim
+    self._projIn.wrappedValue = Linear(sinusoidalDim, hiddenDim)
+    self._projHid.wrappedValue = Linear(hiddenDim, hiddenDim)
+    self._projOut.wrappedValue = Linear(hiddenDim, outputDim)
+    super.init()
+  }
+
+  /// Computes the timestep embedding.
+  ///
+  /// - Parameter timestep: Scalar or 1D array of timestep values.
+  /// - Returns: Embedding array of shape `(B, outputDim)`.
+  public func callAsFunction(_ timestep: MLXArray) -> MLXArray {
+    // Ensure at least 1D
+    var t = timestep
+    if t.ndim == 0 {
+      t = t.expandedDimensions(axis: 0)
+    }
+
+    // Sinusoidal embedding
+    var emb = SeedVR2TimeEmbedding.sinusoidalEmbedding(timesteps: t, dim: sinusoidalDim)
+
+    // MLP: Linear -> SiLU -> Linear -> SiLU -> Linear
+    emb = projIn(emb)
+    emb = MLXNN.silu(emb)
+    emb = projHid(emb)
+    emb = MLXNN.silu(emb)
+    emb = projOut(emb)
+
+    return emb
+  }
+
+  /// Creates sinusoidal positional embeddings from timestep values.
+  ///
+  /// Matches the Python `_get_timestep_embedding` implementation:
+  ///
+  ///     half_dim = dim // 2
+  ///     freqs = exp(arange(half_dim) * (-log(10000) / half_dim))
+  ///     args = timesteps[:, None] * freqs
+  ///     return concat([sin(args), cos(args)], axis=-1)
+  ///
+  /// - Parameters:
+  ///   - timesteps: 1D array of timestep values, shape `(B,)`.
+  ///   - dim: Embedding dimension.
+  /// - Returns: Sinusoidal embeddings of shape `(B, dim)`.
+  public static func sinusoidalEmbedding(timesteps: MLXArray, dim: Int) -> MLXArray {
+    let halfDim = dim / 2
+    // freqs = exp(arange(halfDim, float32) * (-log(10000) / halfDim))
+    let indices = MLXArray(Int32(0) ..< Int32(halfDim)).asType(.float32)
+    let freqs = (indices * Float(-Foundation.log(10000.0) / Float(halfDim))).exp()
+
+    // args = timesteps[:, None] * freqs[None, :]
+    let args = timesteps.expandedDimensions(axis: 1).asType(.float32) * freqs
+
+    // concat([sin, cos], axis=-1)
+    return MLX.concatenated([args.sin(), args.cos()], axis: -1)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2Transformer.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2Transformer.swift
@@ -1,0 +1,180 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Top-level NaDiT (Neighborhood-Aware DiT) transformer for SeedVR2 upscaling.
+///
+/// Supports both 3B and 7B model variants:
+///
+/// 3B: vid_out_norm + out_shift/out_scale applied after blocks, before vid_out.
+/// 7B: No output norm/shift/scale. Blocks output goes directly to vid_out.
+public final class SeedVR2Transformer: Module {
+
+  public let vidDim: Int
+  public let embDim: Int
+  public let mmLayers: Int
+  public let numLayers: Int
+  public let hasOutputNorm: Bool
+
+  // Input modules
+  @ModuleInfo(key: "vid_in") var vidIn: SeedVR2PatchIn
+  @ModuleInfo(key: "txt_in") var txtIn: Linear
+  @ModuleInfo(key: "emb_in") var embIn: SeedVR2TimeEmbedding
+
+  // Transformer blocks
+  @ModuleInfo(key: "blocks") var blocks: [SeedVR2TransformerBlock]
+
+  // Output modules (always present for weight loading; may not be used for 7B)
+  @ModuleInfo(key: "vid_out_norm") var vidOutNorm: RMSNorm?
+
+  @ParameterInfo(key: "out_shift") var outShift: MLXArray?
+  @ParameterInfo(key: "out_scale") var outScale: MLXArray?
+
+  @ModuleInfo(key: "vid_out") var vidOut: SeedVR2PatchOut
+
+  /// Creates the SeedVR2 transformer from a model config.
+  public convenience init(config: SeedVR2ModelConfig) {
+    self.init(
+      vidDim: config.vidDim,
+      txtInDim: config.txtInDim,
+      heads: config.heads,
+      headDim: config.headDim,
+      expandRatio: config.expandRatio,
+      numLayers: config.numLayers,
+      mmLayers: config.mmLayers,
+      ropeDim: config.ropeDim,
+      mlpType: config.mlpType,
+      hasOutputNorm: config.hasOutputNorm,
+      hasLastLayerFreeze: config.hasLastLayerFreeze
+    )
+  }
+
+  /// Creates the SeedVR2 transformer with 3B defaults.
+  public override convenience init() {
+    self.init(config: .preset3B)
+  }
+
+  public init(
+    vidInChannels: Int = 33,
+    vidOutChannels: Int = 16,
+    vidDim: Int = 2560,
+    txtInDim: Int = 5120,
+    txtDim: Int? = nil,
+    embDim: Int? = nil,
+    heads: Int = 20,
+    headDim: Int = 128,
+    expandRatio: Int = 4,
+    normEps: Float = 1e-5,
+    patchSize: (Int, Int, Int) = (1, 2, 2),
+    numLayers: Int = 32,
+    mmLayers: Int = 10,
+    ropeDim: Int = 128,
+    window: (Int, Int, Int) = (4, 3, 3),
+    mlpType: SeedVR2MLPType = .swiglu,
+    hasOutputNorm: Bool = true,
+    hasLastLayerFreeze: Bool = true
+  ) {
+    let resolvedTxtDim = txtDim ?? vidDim
+    let resolvedEmbDim = embDim ?? (6 * vidDim)
+    self.vidDim = vidDim
+    self.embDim = resolvedEmbDim
+    self.mmLayers = mmLayers
+    self.numLayers = numLayers
+    self.hasOutputNorm = hasOutputNorm
+
+    // Input modules
+    self._vidIn.wrappedValue = SeedVR2PatchIn(
+      inChannels: vidInChannels, patchSize: patchSize, dim: vidDim
+    )
+    self._txtIn.wrappedValue = Linear(txtInDim, resolvedTxtDim)
+    self._embIn.wrappedValue = SeedVR2TimeEmbedding(
+      sinusoidalDim: 256,
+      hiddenDim: max(vidDim, resolvedTxtDim),
+      outputDim: resolvedEmbDim
+    )
+
+    // Transformer blocks
+    var blockList: [SeedVR2TransformerBlock] = []
+    for i in 0 ..< numLayers {
+      let shared = i >= mmLayers
+      let isLast = hasLastLayerFreeze && (i == numLayers - 1)
+      let shifted = i % 2 == 1
+
+      blockList.append(SeedVR2TransformerBlock(
+        vidDim: vidDim, txtDim: resolvedTxtDim,
+        heads: heads, headDim: headDim, expandRatio: expandRatio,
+        normEps: normEps, qkBias: false, ropeDim: ropeDim,
+        sharedWeights: shared, isLastLayer: isLast,
+        window: window, shift: shifted,
+        mlpType: mlpType
+      ))
+    }
+    self._blocks.wrappedValue = blockList
+
+    // Output modules
+    if hasOutputNorm {
+      self._vidOutNorm.wrappedValue = RMSNorm(dimensions: vidDim, eps: normEps)
+      self._outShift.wrappedValue = MLXArray.zeros([vidDim])
+      self._outScale.wrappedValue = MLXArray.ones([vidDim])
+    } else {
+      self._vidOutNorm.wrappedValue = nil
+      self._outShift.wrappedValue = nil
+      self._outScale.wrappedValue = nil
+    }
+
+    self._vidOut.wrappedValue = SeedVR2PatchOut(
+      outChannels: vidOutChannels, patchSize: patchSize, dim: vidDim
+    )
+
+    super.init()
+  }
+
+  /// Runs the full transformer forward pass.
+  public func callAsFunction(
+    vid: MLXArray,
+    txt: MLXArray,
+    timestep: MLXArray
+  ) -> MLXArray {
+    // Project text embeddings
+    let txtProjected = txtIn(txt)
+    let txtShape = MLXArray(
+      [Int32](repeating: Int32(txtProjected.dim(1)), count: txtProjected.dim(0))
+    ).reshaped(-1, 1)
+
+    // Patchify video
+    let (vidTokens, vidShape) = vidIn(vid)
+
+    // Timestep embedding -> modulation parameters
+    let embFlat = embIn(timestep)
+    let emb = embFlat.reshaped(-1, vidDim, 2, 3)
+
+    // Run through all transformer blocks
+    var vidStream = vidTokens
+    var txtStream = txtProjected
+    for block in blocks {
+      let result = block(vid: vidStream, txt: txtStream, emb: emb, vidShape: vidShape, txtShape: txtShape)
+      vidStream = result.0
+      txtStream = result.1
+    }
+
+    // Output head
+    if hasOutputNorm {
+      // 3B: RMSNorm + adaptive shift/scale
+      vidStream = vidOutNorm!(vidStream)
+      vidStream = applyOutAda(vidStream, emb: emb)
+    }
+    // 7B: no output norm, go straight to unpatchify
+
+    // Un-patchify
+    let (vidResult, _) = vidOut(vidStream, vidShape)
+    return vidResult
+  }
+
+  /// Applies the final output adaptive modulation (3B only).
+  private func applyOutAda(_ hidden: MLXArray, emb: MLXArray) -> MLXArray {
+    let shiftA = emb[0..., 0..., 0, 0].expandedDimensions(axis: 1)
+    let scaleA = emb[0..., 0..., 0, 1].expandedDimensions(axis: 1)
+    return hidden * (outScale! + scaleA) + (outShift! + shiftA)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2TransformerBlock.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2TransformerBlock.swift
@@ -1,0 +1,125 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// A single transformer block in the SeedVR2 architecture.
+///
+/// Each block processes both video and text streams through attention and MLP
+/// with adaptive layer normalization.
+public final class SeedVR2TransformerBlock: Module {
+
+  public let sharedWeights: Bool
+  public let isLastLayer: Bool
+  public let normEps: Float
+
+  @ModuleInfo(key: "attn") var attn: SeedVR2MMAttention
+  @ModuleInfo(key: "mlp") var mlp: SeedVR2MMSwiGLU
+  @ModuleInfo(key: "ada") var ada: SeedVR2AdaModulation
+
+  public init(
+    vidDim: Int = 2560,
+    txtDim: Int = 2560,
+    heads: Int = 20,
+    headDim: Int = 128,
+    expandRatio: Int = 4,
+    normEps: Float = 1e-5,
+    qkBias: Bool = false,
+    ropeDim: Int = 128,
+    sharedWeights: Bool = false,
+    isLastLayer: Bool = false,
+    window: (Int, Int, Int) = (4, 3, 3),
+    shift: Bool = false,
+    mlpType: SeedVR2MLPType = .swiglu
+  ) {
+    self.sharedWeights = sharedWeights
+    self.isLastLayer = isLastLayer
+    self.normEps = normEps
+
+    self._attn.wrappedValue = SeedVR2MMAttention(
+      vidDim: vidDim, txtDim: txtDim, heads: heads, headDim: headDim,
+      qkBias: qkBias, qkNormEps: normEps, ropeDim: ropeDim,
+      sharedWeights: sharedWeights, window: window, shift: shift
+    )
+
+    self._mlp.wrappedValue = SeedVR2MMSwiGLU(
+      vidDim: vidDim, txtDim: txtDim, expandRatio: expandRatio,
+      sharedWeights: sharedWeights, isLastLayer: isLastLayer,
+      mlpType: mlpType
+    )
+
+    self._ada.wrappedValue = SeedVR2AdaModulation(
+      dim: vidDim, sharedWeights: sharedWeights, isLastLayer: isLastLayer
+    )
+
+    super.init()
+  }
+
+  public func callAsFunction(
+    vid: MLXArray,
+    txt: MLXArray,
+    emb: MLXArray,
+    vidShape: MLXArray,
+    txtShape: MLXArray
+  ) -> (MLXArray, MLXArray) {
+    var vidStream = vid
+    var txtStream = txt
+
+    // ---- Attention ----
+
+    // Pre-norm (weight-free RMSNorm)
+    var vidAttn = SeedVR2RMSNorm.apply(vidStream, eps: normEps)
+    var txtAttn = SeedVR2RMSNorm.apply(txtStream, eps: normEps)
+
+    // In-modulation (shift + scale)
+    vidAttn = ada.modulateVid(vidAttn, emb: emb, layer: "attn", mode: "in")
+    txtAttn = ada.modulateTxt(txtAttn, emb: emb, layer: "attn", mode: "in")
+
+    // Multi-modal attention
+    let attnResult = attn(vidAttn, txtAttn, vidShape, txtShape)
+    vidAttn = attnResult.0
+    txtAttn = attnResult.1
+
+    // Out-modulation (gate)
+    vidAttn = ada.modulateVid(vidAttn, emb: emb, layer: "attn", mode: "out")
+    txtAttn = ada.modulateTxt(txtAttn, emb: emb, layer: "attn", mode: "out")
+
+    // Residual
+    vidStream = vidStream + vidAttn
+    if !isLastLayer {
+      txtStream = txtStream + txtAttn
+    }
+
+    // ---- MLP ----
+
+    // Pre-norm
+    var vidMlp = SeedVR2RMSNorm.apply(vidStream, eps: normEps)
+    var txtMlp: MLXArray
+    if isLastLayer {
+      txtMlp = txtStream
+    } else {
+      txtMlp = SeedVR2RMSNorm.apply(txtStream, eps: normEps)
+    }
+
+    // In-modulation
+    vidMlp = ada.modulateVid(vidMlp, emb: emb, layer: "mlp", mode: "in")
+    txtMlp = ada.modulateTxt(txtMlp, emb: emb, layer: "mlp", mode: "in")
+
+    // Feed-forward MLP
+    let mlpResult = mlp(vidMlp, txtMlp)
+    vidMlp = mlpResult.0
+    txtMlp = mlpResult.1
+
+    // Out-modulation
+    vidMlp = ada.modulateVid(vidMlp, emb: emb, layer: "mlp", mode: "out")
+    txtMlp = ada.modulateTxt(txtMlp, emb: emb, layer: "mlp", mode: "out")
+
+    // Residual
+    vidStream = vidStream + vidMlp
+    if !isLastLayer {
+      txtStream = txtStream + txtMlp
+    }
+
+    return (vidStream, txtStream)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2WindowPartitioner.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/Transformer/SeedVR2WindowPartitioner.swift
@@ -1,0 +1,244 @@
+import Foundation
+import MLX
+
+/// Spatial window partitioner for the SeedVR2 transformer attention mechanism.
+///
+/// Splits a flat token sequence into windows for local attention, analogous to the
+/// Swin Transformer's shifted window strategy. This is NOT a `Module` — it is
+/// created fresh for each forward pass based on the current spatial shape.
+///
+/// ## Key Concepts
+///
+/// 1. **Adaptive window sizing**: Window dimensions are computed relative to a
+///    reference resolution of 45x80 (720p after 2x2 patching).
+/// 2. **Forward index**: Reorders tokens from spatial order to window-local order.
+/// 3. **Reverse index**: Undoes the reordering after attention.
+/// 4. **Shifted windows**: Odd-numbered blocks shift windows by half a window size
+///    (like Swin Transformer) to enable cross-window information flow.
+/// 5. **Variable edge windows**: Windows near spatial boundaries may be smaller.
+///
+/// ## Usage
+///
+/// ```swift
+/// let partitioner = SeedVR2WindowPartitioner(shape: vidShape, windowSize: (4, 3, 3), shift: true)
+/// let windowed = partitioner.partition(qkvTokens)
+/// // ... per-window attention ...
+/// let restored = partitioner.reverse(windowedOutput)
+/// ```
+public struct SeedVR2WindowPartitioner {
+
+  /// Index array that reorders tokens from spatial to window-local order.
+  public let forwardIdx: MLXArray
+
+  /// Index array that restores tokens from window-local to spatial order.
+  public let reverseIdx: MLXArray
+
+  /// Shape of each window: `(num_windows, 3)` containing `[T, H, W]`.
+  public let windowShapes: MLXArray
+
+  /// Number of windows per batch element.
+  public let windowCounts: [Int]
+
+  /// Creates a window partitioner for the given spatial layout.
+  ///
+  /// - Parameters:
+  ///   - shape: Spatial shape tensor, `(B, 3)` containing `[T, H, W]` per batch element.
+  ///   - windowSize: Number of windows per axis `(nt, nh, nw)`. Default `(4, 3, 3)`.
+  ///   - shift: Whether to apply half-window shifting. Default `false`.
+  public init(shape: MLXArray, windowSize: (Int, Int, Int), shift: Bool = false) {
+    let result = SeedVR2WindowPartitioner.createWindowIndices(
+      shape: shape,
+      windowSize: windowSize,
+      shift: shift
+    )
+    self.forwardIdx = result.forwardIdx
+    self.reverseIdx = result.reverseIdx
+    self.windowShapes = result.windowShapes
+    self.windowCounts = result.windowCounts
+  }
+
+  /// Reorders tokens from spatial order to window-local order.
+  ///
+  /// - Parameter tensor: Token tensor of shape `(N, ...)`.
+  /// - Returns: Reordered tensor of the same shape.
+  public func partition(_ tensor: MLXArray) -> MLXArray {
+    return tensor[forwardIdx]
+  }
+
+  /// Restores tokens from window-local order back to spatial order.
+  ///
+  /// - Parameter tensor: Windowed tensor of shape `(N, ...)`.
+  /// - Returns: Spatially ordered tensor.
+  public func reverse(_ tensor: MLXArray) -> MLXArray {
+    return tensor[reverseIdx]
+  }
+
+  // MARK: - Window Computation
+
+  /// Computes window slices for a single spatial volume.
+  ///
+  /// The window boundaries are determined by:
+  /// 1. Scaling the spatial dims to a reference 45x80 resolution
+  /// 2. Computing per-axis window size from num_windows
+  /// 3. Optionally shifting by half a window
+  /// 4. Generating all (temporal, height, width) slice combinations
+  ///
+  /// - Parameters:
+  ///   - size: Spatial extent `(T, H, W)`.
+  ///   - numWindows: Number of windows per axis `(nt, nh, nw)`.
+  ///   - shift: Whether to shift windows by half.
+  /// - Returns: Array of `(tRange, hRange, wRange)` slice tuples.
+  private static func makeWindows(
+    size: (Int, Int, Int),
+    numWindows: (Int, Int, Int),
+    shift: Bool
+  ) -> [(tRange: Range<Int>, hRange: Range<Int>, wRange: Range<Int>)] {
+    let (t, h, w) = size
+    let (resizedNt, resizedNh, resizedNw) = numWindows
+
+    // Scale to reference resolution (45x80)
+    let scale = sqrt(Float(45 * 80) / Float(h * w))
+    let resizedH = Int(Float(h) * scale + 0.5)  // round
+    let resizedW = Int(Float(w) * scale + 0.5)
+
+    // Window sizes (ceil division)
+    let wh = ceilDiv(resizedH, resizedNh)
+    let ww = ceilDiv(resizedW, resizedNw)
+    let wt = ceilDiv(min(t, 30), resizedNt)
+
+    // Shift amounts and window counts
+    let st: Float, sh: Float, sw: Float
+    let nt: Int, nh: Int, nw: Int
+
+    if shift {
+      st = wt < t ? 0.5 : 0
+      sh = wh < h ? 0.5 : 0
+      sw = ww < w ? 0.5 : 0
+      nt = st > 0 ? ceilDiv(t, wt, offset: st) + 1 : 1
+      nh = sh > 0 ? ceilDiv(h, wh, offset: sh) + 1 : 1
+      nw = sw > 0 ? ceilDiv(w, ww, offset: sw) + 1 : 1
+    } else {
+      st = 0; sh = 0; sw = 0
+      nt = ceilDiv(t, wt)
+      nh = ceilDiv(h, wh)
+      nw = ceilDiv(w, ww)
+    }
+
+    var windows: [(Range<Int>, Range<Int>, Range<Int>)] = []
+
+    for iw in 0 ..< nw {
+      let wStart = max(Int((Float(iw) - sw) * Float(ww)), 0)
+      let wEnd = min(Int((Float(iw) - sw + 1) * Float(ww)), w)
+      guard wEnd > wStart else { continue }
+
+      for ih in 0 ..< nh {
+        let hStart = max(Int((Float(ih) - sh) * Float(wh)), 0)
+        let hEnd = min(Int((Float(ih) - sh + 1) * Float(wh)), h)
+        guard hEnd > hStart else { continue }
+
+        for it in 0 ..< nt {
+          let tStart = max(Int((Float(it) - st) * Float(wt)), 0)
+          let tEnd = min(Int((Float(it) - st + 1) * Float(wt)), t)
+          guard tEnd > tStart else { continue }
+
+          windows.append((tStart ..< tEnd, hStart ..< hEnd, wStart ..< wEnd))
+        }
+      }
+    }
+
+    return windows
+  }
+
+  /// Integer ceiling division.
+  private static func ceilDiv(_ a: Int, _ b: Int) -> Int {
+    return (a + b - 1) / b
+  }
+
+  /// Ceiling division with fractional offset: ceil((a - offset) / b).
+  private static func ceilDiv(_ a: Int, _ b: Int, offset: Float) -> Int {
+    return Int(ceil((Float(a) - offset) / Float(b)))
+  }
+
+  /// Unflattens a 2D tensor (N, D) into a list of 3D tensors (T, H, W, D) using shape info.
+  private static func unflattenList(
+    _ tensor: MLXArray,
+    shapes: MLXArray
+  ) -> [(array: MLXArray, shape: (Int, Int, Int))] {
+    let numBatch = shapes.dim(0)
+    var results: [(MLXArray, (Int, Int, Int))] = []
+    var offset = 0
+
+    for b in 0 ..< numBatch {
+      let t = Int(shapes[b, 0].item(Int32.self))
+      let h = Int(shapes[b, 1].item(Int32.self))
+      let w = Int(shapes[b, 2].item(Int32.self))
+      let length = t * h * w
+      let d = tensor.dim(-1)
+
+      let slice = tensor[offset ..< (offset + length)]
+      let reshaped = slice.reshaped(t, h, w, d)
+      results.append((reshaped, (t, h, w)))
+      offset += length
+    }
+
+    return results
+  }
+
+  /// Creates forward and reverse index arrays for window partitioning.
+  ///
+  /// This is the core algorithm:
+  /// 1. Create a flat index array `[0, 1, ..., totalLen-1]`
+  /// 2. Unflatten it using the spatial shapes
+  /// 3. Apply window slicing to gather indices per window
+  /// 4. The reordered indices form the forward index
+  /// 5. argsort of forward gives the reverse index
+  private static func createWindowIndices(
+    shape: MLXArray,
+    windowSize: (Int, Int, Int),
+    shift: Bool
+  ) -> (forwardIdx: MLXArray, reverseIdx: MLXArray, windowShapes: MLXArray, windowCounts: [Int]) {
+    // Total number of tokens across all batch elements
+    let totalLen = Int(MLX.sum(shape.product(axis: 1)).item(Int32.self))
+
+    // Create flat index tensor: (totalLen, 1)
+    let idx = MLXArray(Int32(0) ..< Int32(totalLen)).reshaped(-1, 1)
+
+    // Unflatten into per-batch 3D volumes
+    let volumes = unflattenList(idx, shapes: shape)
+
+    // Partition each volume into windows
+    var windowedParts: [MLXArray] = []
+    var windowShapeList: [[Int32]] = []
+    var windowCounts: [Int] = []
+
+    for (volume, volumeShape) in volumes {
+      let slices = makeWindows(size: volumeShape, numWindows: windowSize, shift: shift)
+      windowCounts.append(slices.count)
+
+      for (tRange, hRange, wRange) in slices {
+        // Extract the window using ranges
+        let window = volume[tRange, hRange, wRange]
+        let tLen = tRange.count
+        let hLen = hRange.count
+        let wLen = wRange.count
+
+        // Flatten to (tLen*hLen*wLen, 1)
+        windowedParts.append(window.reshaped(-1, 1))
+        windowShapeList.append([Int32(tLen), Int32(hLen), Int32(wLen)])
+      }
+    }
+
+    // Concatenate all windowed indices
+    let windowed = MLX.concatenated(windowedParts, axis: 0)
+    let targetIdx = windowed.reshaped(-1)
+
+    // Build window shapes array
+    let windowShapes = MLXArray(windowShapeList.flatMap { $0 })
+      .reshaped(windowShapeList.count, 3)
+
+    // Reverse index = argsort of forward index
+    let reverseIdx = argSort(targetIdx)
+
+    return (targetIdx, reverseIdx, windowShapes, windowCounts)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Attention3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Attention3D.swift
@@ -1,0 +1,112 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Spatial self-attention for the SeedVR2 3D video VAE.
+///
+/// Operates per-frame: the temporal dimension is folded into the batch so that
+/// attention is computed independently on each `(H, W)` spatial grid. This avoids
+/// the quadratic cost of attending across time while still allowing spatial
+/// feature mixing within each frame.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C, T, H, W)
+///   ├─ reshape to (B*T, H*W, C)
+///   ├─ GroupNorm(32, C)
+///   ├─ Q/K/V linear projections
+///   ├─ Scaled dot-product attention (per frame)
+///   ├─ Output linear projection
+///   ├─ reshape back to (B, C, T, H, W)
+///   └─ + residual
+/// ```
+///
+/// The Python reference uses single-head attention (head_dim = C), which we
+/// replicate here by inserting a singleton head dimension for the MLXFast SDPA call.
+public final class SeedVR2Attention3D: Module {
+
+  /// Group normalization applied in channels-last layout.
+  @ModuleInfo(key: "group_norm") var groupNorm: GroupNorm
+
+  /// Query projection.
+  @ModuleInfo(key: "to_q") var toQ: Linear
+
+  /// Key projection.
+  @ModuleInfo(key: "to_k") var toK: Linear
+
+  /// Value projection.
+  @ModuleInfo(key: "to_v") var toV: Linear
+
+  /// Output projection (wrapped in an array to match checkpoint key path `to_out.0`).
+  @ModuleInfo(key: "to_out") var toOut: [Linear]
+
+  /// The channel dimension, used to compute the attention scale.
+  public let channels: Int
+
+  /// Creates a spatial self-attention module.
+  ///
+  /// - Parameter channels: Number of input/output channels.
+  public init(channels: Int) {
+    self.channels = channels
+
+    self._groupNorm.wrappedValue = GroupNorm(
+      groupCount: 32, dimensions: channels, eps: 1e-6, pytorchCompatible: true
+    )
+    self._toQ.wrappedValue = Linear(channels, channels)
+    self._toK.wrappedValue = Linear(channels, channels)
+    self._toV.wrappedValue = Linear(channels, channels)
+    self._toOut.wrappedValue = [Linear(channels, channels)]
+
+    super.init()
+  }
+
+  /// Applies per-frame spatial self-attention.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C, T, H, W)` with spatial attention applied.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let b = x.dim(0)
+    let c = x.dim(1)
+    let t = x.dim(2)
+    let h = x.dim(3)
+    let w = x.dim(4)
+    let residual = x
+
+    // (B, C, T, H, W) → (B, T, C, H, W) → (B*T, C, H*W) → (B*T, H*W, C)
+    var hidden = x.transposed(0, 2, 1, 3, 4)
+    hidden = hidden.reshaped(b * t, c, h * w)
+    hidden = hidden.transposed(0, 2, 1)
+
+    // GroupNorm in channels-last: (B*T, H*W, C)
+    hidden = groupNorm(hidden.asType(.float32)).asType(x.dtype)
+
+    // Q, K, V projections — each (B*T, H*W, C)
+    // Add singleton head dimension → (B*T, 1, H*W, C) for SDPA
+    let q = toQ(hidden).expandedDimensions(axis: 1)
+    let k = toK(hidden).expandedDimensions(axis: 1)
+    let v = toV(hidden).expandedDimensions(axis: 1)
+
+    let scale = pow(Float(c), -0.5)
+
+    // Scaled dot-product attention (single head)
+    var attn = MLXFast.scaledDotProductAttention(
+      queries: q, keys: k, values: v,
+      scale: scale, mask: nil
+    )
+
+    // Remove head dimension → (B*T, H*W, C)
+    attn = attn.squeezed(axis: 1)
+
+    // Output projection
+    hidden = toOut[0](attn)
+
+    // (B*T, H*W, C) → (B*T, C, H*W) → (B, T, C, H, W) → (B, C, T, H, W)
+    hidden = hidden.transposed(0, 2, 1)
+    hidden = hidden.reshaped(b, t, c, h, w)
+    hidden = hidden.transposed(0, 2, 1, 3, 4)
+
+    return hidden + residual
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Decoder3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Decoder3D.swift
@@ -1,0 +1,142 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// 3D decoder for the SeedVR2 video VAE.
+///
+/// Decodes a latent tensor back into an RGB video by progressively increasing
+/// spatial (and optionally temporal) resolution through a series of up-blocks,
+/// with a mid-block bottleneck featuring spatial self-attention.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, 16, T_lat, H/8, W/8)
+///   ├─ conv_in:  CausalConv3d(16 → 512, k=3)
+///   ├─ mid_block:      ResNet → Attention → ResNet (512 channels)
+///   ├─ up_blocks[0]: UpBlock3D(512 → 512, 3 resnets, upsample spatial+temporal)
+///   ├─ up_blocks[1]: UpBlock3D(512 → 256, 3 resnets, upsample spatial+temporal)
+///   ├─ up_blocks[2]: UpBlock3D(256 → 128, 3 resnets, upsample spatial only)
+///   ├─ up_blocks[3]: UpBlock3D(128 → 128, 3 resnets, no upsample)
+///   ├─ GroupNorm(32, 128) → SiLU
+///   ├─ conv_out: CausalConv3d(128 → 3, k=3)
+///   └─ Output (B, 3, T, H, W)
+/// ```
+///
+/// ## Temporal Upsampling
+///
+/// The `temporalUpBlocks` parameter controls how many of the first up-blocks
+/// also double the temporal dimension. With the default of 2, up_blocks[0] and
+/// up_blocks[1] apply temporal upsampling, yielding a 4x temporal expansion
+/// (matching the encoders 4x temporal reduction).
+public final class SeedVR2Decoder3D: Module {
+
+  /// Initial 3D convolution from latent channels to the bottleneck width.
+  @ModuleInfo(key: "conv_in") var convIn: CausalConv3d
+
+  /// Bottleneck mid-block with spatial self-attention.
+  @ModuleInfo(key: "mid_block") var midBlock: SeedVR2MidBlock3D
+
+  /// Progressive upsampling blocks.
+  @ModuleInfo(key: "up_blocks") var upBlocks: [SeedVR2UpBlock3D]
+
+  /// Group normalization before the output convolution.
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+
+  /// Final convolution producing RGB output.
+  @ModuleInfo(key: "conv_out") var convOut: CausalConv3d
+
+  /// Creates a 3D decoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of latent channels. Default `16`.
+  ///   - outChannels: Number of output channels (RGB = 3). Default `3`.
+  ///   - blockOutChannels: Channel counts for each stage (in encoder order).
+  ///     Default `[128, 256, 512, 512]`. These are reversed internally so
+  ///     the decoder mirrors the encoder.
+  ///   - layersPerBlock: Number of residual blocks per stage. Default `3`.
+  ///   - temporalUpBlocks: Number of initial up-blocks that also upsample
+  ///     temporally. Default `2`.
+  public init(
+    inChannels: Int = 16,
+    outChannels: Int = 3,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 3,
+    temporalUpBlocks: Int = 2
+  ) {
+    let reversedChannels = Array(blockOutChannels.reversed())
+    let numBlocks = reversedChannels.count
+
+    // Input convolution
+    self._convIn.wrappedValue = CausalConv3d(
+      inChannels: inChannels, outChannels: reversedChannels[0],
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+
+    // Mid-block
+    self._midBlock.wrappedValue = SeedVR2MidBlock3D(
+      channels: reversedChannels[0]
+    )
+
+    // Up-blocks with progressive channel reduction
+    var outputChannel = reversedChannels[0]
+    var ups: [SeedVR2UpBlock3D] = []
+
+    for i in 0..<numBlocks {
+      let inputChannel = outputChannel
+      outputChannel = reversedChannels[i]
+      let isFinalBlock = i == numBlocks - 1
+
+      // Temporal upsampling applies to the first N blocks.
+      // Python: temporal_up = i < temporal_up_blocks
+      let temporalUp = i < temporalUpBlocks
+
+      ups.append(SeedVR2UpBlock3D(
+        inChannels: inputChannel,
+        outChannels: outputChannel,
+        numLayers: layersPerBlock,
+        addUpsample: !isFinalBlock,
+        temporalUp: temporalUp
+      ))
+    }
+    self._upBlocks.wrappedValue = ups
+
+    // Output normalization + convolution
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: 32,
+      dimensions: reversedChannels[numBlocks - 1],
+      eps: 1e-6,
+      pytorchCompatible: true
+    )
+    self._convOut.wrappedValue = CausalConv3d(
+      inChannels: reversedChannels[numBlocks - 1],
+      outChannels: outChannels,
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+
+    super.init()
+  }
+
+  /// Decodes a latent tensor into an RGB video.
+  ///
+  /// - Parameter z: Latent tensor of shape `(B, latentChannels, T_lat, H_lat, W_lat)`.
+  /// - Returns: Decoded tensor of shape `(B, 3, T, H, W)`.
+  public func callAsFunction(_ z: MLXArray) -> MLXArray {
+    var hidden = convIn(z)
+    hidden = midBlock(hidden)
+
+    for upBlock in upBlocks {
+      hidden = upBlock(hidden)
+    }
+
+    // GroupNorm in channels-last: BCTHW → BTHWC → norm → BCTHW
+    hidden = hidden.transposed(0, 2, 3, 4, 1)
+    hidden = convNormOut(hidden.asType(.float32)).asType(z.dtype)
+    hidden = hidden.transposed(0, 4, 1, 2, 3)
+
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+
+    return hidden
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2DownBlock3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2DownBlock3D.swift
@@ -1,0 +1,77 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Encoder downsampling block for the SeedVR2 3D VAE.
+///
+/// Chains a configurable number of ``SeedVR2ResnetBlock3D`` layers followed by
+/// an optional ``SeedVR2Downsample3D``. The first resnet handles the channel
+/// transition from `inChannels` to `outChannels`; subsequent resnets operate
+/// at `outChannels`.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C_in, T, H, W)
+///   ├─ ResnetBlock3D[0] (C_in → C_out)
+///   ├─ ResnetBlock3D[1] (C_out → C_out)
+///   ├─ ...
+///   ├─ [optional] Downsample3D (halves spatial, optionally temporal)
+///   └─ Output (B, C_out, T/?, H/2, W/2) or (B, C_out, T, H, W) if no downsample
+/// ```
+public final class SeedVR2DownBlock3D: Module {
+
+  /// Residual blocks in this stage.
+  @ModuleInfo(key: "resnets") var resnets: [SeedVR2ResnetBlock3D]
+
+  /// Optional downsampler (single-element array to match checkpoint key paths).
+  @ModuleInfo(key: "downsamplers") var downsamplers: [SeedVR2Downsample3D]
+
+  /// Creates an encoder down-block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of residual blocks. Default `2`.
+  ///   - addDownsample: Whether to append a downsampling layer. Default `true`.
+  ///   - temporalDown: Whether downsampling also halves the temporal dimension.
+  ///     Ignored when `addDownsample` is false. Default `false`.
+  public init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 2,
+    addDownsample: Bool = true,
+    temporalDown: Bool = false
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      let inputCh = i == 0 ? inChannels : outChannels
+      return SeedVR2ResnetBlock3D(inChannels: inputCh, outChannels: outChannels)
+    }
+
+    if addDownsample {
+      self._downsamplers.wrappedValue = [
+        SeedVR2Downsample3D(channels: outChannels, spatialOnly: !temporalDown)
+      ]
+    } else {
+      self._downsamplers.wrappedValue = []
+    }
+
+    super.init()
+  }
+
+  /// Applies the down-block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C_in, T, H, W)`.
+  /// - Returns: Output tensor with channels set to `outChannels` and spatial (and
+  ///   optionally temporal) dimensions halved if downsampling is present.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for downsampler in downsamplers {
+      hidden = downsampler(hidden)
+    }
+    return hidden
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Downsample3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Downsample3D.swift
@@ -1,0 +1,68 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Spatial (and optionally temporal) downsampling for the SeedVR2 3D VAE encoder.
+///
+/// Halves the spatial dimensions using a strided ``CausalConv3d``. When temporal
+/// downsampling is enabled, the temporal dimension is also halved.
+///
+/// ## Padding
+///
+/// The Python reference applies asymmetric padding of `(0, 1)` on both H and W
+/// before the convolution, rather than using the convolutions own padding parameter.
+/// This ensures correct output dimensions when the spatial size is odd.
+///
+/// ## Modes
+///
+/// - **Spatial only** (`spatialOnly = true`): kernel `(1, 3, 3)`, stride `(1, 2, 2)`.
+///   Temporal dimension is unchanged.
+/// - **Spatial + temporal** (`spatialOnly = false`): kernel `(3, 3, 3)`, stride `(2, 2, 2)`.
+///   All three dimensions are halved.
+public final class SeedVR2Downsample3D: Module {
+
+  /// Strided causal 3D convolution that performs the downsampling.
+  @ModuleInfo(key: "conv") var conv: CausalConv3d
+
+  /// Creates a downsampling module.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input/output channels (preserved).
+  ///   - spatialOnly: If true, only spatial dimensions are halved. If false,
+  ///     temporal dimension is also halved. Default `false`.
+  public init(channels: Int, spatialOnly: Bool = false) {
+    let kt = spatialOnly ? 1 : 3
+    let st = spatialOnly ? 1 : 2
+    let pt = spatialOnly ? 0 : 1
+
+    self._conv.wrappedValue = CausalConv3d(
+      inChannels: channels, outChannels: channels,
+      kernelSize: (kt, 3, 3),
+      stride: (st, 2, 2),
+      padding: (pt, 0, 0)
+    )
+
+    super.init()
+  }
+
+  /// Applies the downsampling.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Downsampled tensor. Spatial dimensions are halved (ceiling division).
+  ///   Temporal dimension is halved only when `spatialOnly` was false at init.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // Asymmetric pad: add 1 to the right of H and W dimensions.
+    // Input layout: (B, C, T, H, W) — H is axis 3, W is axis 4.
+    let padded = MLX.padded(
+      x,
+      widths: [
+        IntOrPair((0, 0)),  // B
+        IntOrPair((0, 0)),  // C
+        IntOrPair((0, 0)),  // T
+        IntOrPair((0, 1)),  // H: pad right by 1
+        IntOrPair((0, 1)),  // W: pad right by 1
+      ]
+    )
+    return conv(padded)
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Encoder3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Encoder3D.swift
@@ -1,0 +1,145 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// 3D encoder for the SeedVR2 video VAE.
+///
+/// Encodes an RGB video tensor into a latent representation by progressively
+/// reducing spatial (and optionally temporal) resolution through a series of
+/// down-blocks, with a mid-block bottleneck featuring spatial self-attention.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, 3, T, H, W)
+///   ├─ conv_in:  CausalConv3d(3 → 128, k=3)
+///   ├─ down_blocks[0]: DownBlock3D(128 → 128, downsample spatial)
+///   ├─ down_blocks[1]: DownBlock3D(128 → 256, downsample spatial+temporal)
+///   ├─ down_blocks[2]: DownBlock3D(256 → 512, downsample spatial+temporal)
+///   ├─ down_blocks[3]: DownBlock3D(512 → 512, no downsample)
+///   ├─ mid_block:      ResNet → Attention → ResNet (512 channels)
+///   ├─ GroupNorm(32, 512) → SiLU
+///   ├─ conv_out: CausalConv3d(512 → 32, k=3)     // 32 = 2 * latent_channels
+///   └─ Output (B, 32, T/4, H/8, W/8)
+/// ```
+///
+/// The output has `2 * latentChannels` channels because the VAE produces both
+/// mean and log-variance (only the mean is used at inference time).
+///
+/// ## Temporal Downsampling
+///
+/// The `temporalDownBlocks` parameter controls how many of the non-final
+/// down-blocks also halve the temporal dimension. With the default of 2,
+/// blocks at indices 1 and 2 (counting from the right before the final block)
+/// apply temporal downsampling, yielding a 4x temporal reduction.
+public final class SeedVR2Encoder3D: Module {
+
+  /// Initial 3D convolution from RGB to first blocks channel count.
+  @ModuleInfo(key: "conv_in") var convIn: CausalConv3d
+
+  /// Progressive downsampling blocks.
+  @ModuleInfo(key: "down_blocks") var downBlocks: [SeedVR2DownBlock3D]
+
+  /// Bottleneck mid-block with spatial self-attention.
+  @ModuleInfo(key: "mid_block") var midBlock: SeedVR2MidBlock3D
+
+  /// Group normalization before the output convolution.
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+
+  /// Final convolution producing 2x latent channels (mean + logvar).
+  @ModuleInfo(key: "conv_out") var convOut: CausalConv3d
+
+  /// Creates a 3D encoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels (RGB = 3). Default `3`.
+  ///   - outChannels: Number of latent channels. Default `16`.
+  ///   - blockOutChannels: Channel counts for each down-block stage.
+  ///     Default `[128, 256, 512, 512]`.
+  ///   - layersPerBlock: Number of residual blocks per stage. Default `2`.
+  ///   - temporalDownBlocks: Number of non-final blocks that also downsample
+  ///     temporally. Default `2`.
+  public init(
+    inChannels: Int = 3,
+    outChannels: Int = 16,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 2,
+    temporalDownBlocks: Int = 2
+  ) {
+    // Input convolution
+    self._convIn.wrappedValue = CausalConv3d(
+      inChannels: inChannels, outChannels: blockOutChannels[0],
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+
+    // Down-blocks with progressive channel expansion
+    let numBlocks = blockOutChannels.count
+    var outputChannel = blockOutChannels[0]
+    var downs: [SeedVR2DownBlock3D] = []
+
+    for i in 0..<numBlocks {
+      let inputChannel = outputChannel
+      outputChannel = blockOutChannels[i]
+      let isFinalBlock = i == numBlocks - 1
+
+      // Temporal downsampling applies to blocks near the end (but not the final block).
+      // Python: temporal_down = (i >= num_blocks - temporal_down_blocks - 1) and not is_final_block
+      let temporalDown = (i >= numBlocks - temporalDownBlocks - 1) && !isFinalBlock
+
+      downs.append(SeedVR2DownBlock3D(
+        inChannels: inputChannel,
+        outChannels: outputChannel,
+        numLayers: layersPerBlock,
+        addDownsample: !isFinalBlock,
+        temporalDown: temporalDown
+      ))
+    }
+    self._downBlocks.wrappedValue = downs
+
+    // Mid-block
+    self._midBlock.wrappedValue = SeedVR2MidBlock3D(
+      channels: blockOutChannels[numBlocks - 1]
+    )
+
+    // Output normalization + convolution
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: 32,
+      dimensions: blockOutChannels[numBlocks - 1],
+      eps: 1e-6,
+      pytorchCompatible: true
+    )
+    self._convOut.wrappedValue = CausalConv3d(
+      inChannels: blockOutChannels[numBlocks - 1],
+      outChannels: 2 * outChannels,
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+
+    super.init()
+  }
+
+  /// Encodes an input video tensor into the latent space.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C_in, T, H, W)`.
+  /// - Returns: Latent tensor of shape `(B, 2 * latentChannels, T_out, H/8, W/8)`,
+  ///   where the first half of channels is the mean and the second half is the
+  ///   log-variance.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = convIn(x)
+
+    for downBlock in downBlocks {
+      hidden = downBlock(hidden)
+    }
+
+    hidden = midBlock(hidden)
+
+    // GroupNorm in channels-last: BCTHW → BTHWC → norm → BCTHW
+    hidden = hidden.transposed(0, 2, 3, 4, 1)
+    hidden = convNormOut(hidden.asType(.float32)).asType(x.dtype)
+    hidden = hidden.transposed(0, 4, 1, 2, 3)
+
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+
+    return hidden
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2MidBlock3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2MidBlock3D.swift
@@ -1,0 +1,57 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Mid-block for the SeedVR2 3D VAE encoder and decoder.
+///
+/// Sits between the down/up-sampling stages, applying two residual blocks with
+/// a spatial self-attention layer sandwiched between them. This allows the model
+/// to capture long-range spatial dependencies at the bottleneck resolution.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C, T, H, W)
+///   ├─ ResnetBlock3D (C → C)
+///   ├─ Attention3D (spatial self-attention per frame)
+///   ├─ ResnetBlock3D (C → C)
+///   └─ Output (B, C, T, H, W)
+/// ```
+///
+/// Both the encoder and decoder use identical mid-block structures. The Python
+/// reference has separate `MidBlock3D` classes in encoder/ and decoder/ directories,
+/// but they share the same architecture and can be unified into a single type.
+public final class SeedVR2MidBlock3D: Module {
+
+  /// Two residual blocks: applied before and after the attention layer.
+  @ModuleInfo(key: "resnets") var resnets: [SeedVR2ResnetBlock3D]
+
+  /// Spatial self-attention (single element array matching checkpoint structure).
+  @ModuleInfo(key: "attentions") var attentions: [SeedVR2Attention3D]
+
+  /// Creates a mid-block.
+  ///
+  /// - Parameter channels: Number of channels (preserved through the block).
+  public init(channels: Int) {
+    self._resnets.wrappedValue = [
+      SeedVR2ResnetBlock3D(inChannels: channels, outChannels: channels),
+      SeedVR2ResnetBlock3D(inChannels: channels, outChannels: channels),
+    ]
+    self._attentions.wrappedValue = [
+      SeedVR2Attention3D(channels: channels)
+    ]
+
+    super.init()
+  }
+
+  /// Applies the mid-block: resnet → attention → resnet.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C, T, H, W)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = resnets[0](x)
+    hidden = attentions[0](hidden)
+    hidden = resnets[1](hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2ResnetBlock3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2ResnetBlock3D.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// A 3D residual block for the SeedVR2 video VAE.
+///
+/// Applies two sequential CausalConv3d layers with GroupNorm and SiLU activation,
+/// connected by a residual shortcut. When the input and output channel counts differ,
+/// a 1x1x1 convolution adapts the residual path.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C_in, T, H, W)
+///   ├─ GroupNorm(32, C_in) → SiLU → CausalConv3d(C_in → C_out, k=3)
+///   ├─ GroupNorm(32, C_out) → SiLU → CausalConv3d(C_out → C_out, k=3)
+///   ├─ + residual (with optional 1x1x1 shortcut if C_in ≠ C_out)
+///   └─ Output (B, C_out, T, H, W)
+/// ```
+///
+/// GroupNorm operates on channels-last layout (BTHWC), so the forward pass
+/// transposes around each normalization call, matching the Python reference.
+///
+/// Used by both the encoder and decoder paths of the SeedVR2 3D VAE.
+public final class SeedVR2ResnetBlock3D: Module {
+
+  /// First group normalization over input channels.
+  @ModuleInfo(key: "norm1") var norm1: GroupNorm
+
+  /// Second group normalization over output channels.
+  @ModuleInfo(key: "norm2") var norm2: GroupNorm
+
+  /// First causal 3D convolution (C_in → C_out).
+  @ModuleInfo(key: "conv1") var conv1: CausalConv3d
+
+  /// Second causal 3D convolution (C_out → C_out).
+  @ModuleInfo(key: "conv2") var conv2: CausalConv3d
+
+  /// Optional 1x1x1 shortcut convolution when channel counts differ.
+  @ModuleInfo(key: "conv_shortcut") var convShortcut: CausalConv3d?
+
+  /// Whether a shortcut convolution is used (input channels ≠ output channels).
+  public let hasShortcut: Bool
+
+  /// Creates a 3D residual block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  public init(inChannels: Int, outChannels: Int) {
+    self.hasShortcut = inChannels != outChannels
+
+    self._norm1.wrappedValue = GroupNorm(
+      groupCount: 32, dimensions: inChannels, eps: 1e-6, pytorchCompatible: true
+    )
+    self._norm2.wrappedValue = GroupNorm(
+      groupCount: 32, dimensions: outChannels, eps: 1e-6, pytorchCompatible: true
+    )
+    self._conv1.wrappedValue = CausalConv3d(
+      inChannels: inChannels, outChannels: outChannels,
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+    self._conv2.wrappedValue = CausalConv3d(
+      inChannels: outChannels, outChannels: outChannels,
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1)
+    )
+
+    if hasShortcut {
+      self._convShortcut.wrappedValue = CausalConv3d(
+        inChannels: inChannels, outChannels: outChannels,
+        kernelSize: (1, 1, 1), stride: (1, 1, 1), padding: (0, 0, 0)
+      )
+    }
+
+    super.init()
+  }
+
+  /// Applies the residual block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C_in, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C_out, T, H, W)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let residual = hasShortcut ? convShortcut!(x) : x
+
+    // First norm+activation+conv: transpose BCTHW → BTHWC for GroupNorm, then back.
+    var h = x.transposed(0, 2, 3, 4, 1)
+    h = norm1(h.asType(.float32)).asType(x.dtype)
+    h = h.transposed(0, 4, 1, 2, 3)
+    h = silu(h)
+    h = conv1(h)
+
+    // Second norm+activation+conv.
+    h = h.transposed(0, 2, 3, 4, 1)
+    h = norm2(h.asType(.float32)).asType(x.dtype)
+    h = h.transposed(0, 4, 1, 2, 3)
+    h = silu(h)
+    h = conv2(h)
+
+    return h + residual
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2UpBlock3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2UpBlock3D.swift
@@ -1,0 +1,77 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Decoder upsampling block for the SeedVR2 3D VAE.
+///
+/// Chains a configurable number of ``SeedVR2ResnetBlock3D`` layers followed by
+/// an optional ``SeedVR2Upsample3D``. The first resnet handles the channel
+/// transition from `inChannels` to `outChannels`; subsequent resnets operate
+/// at `outChannels`.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C_in, T, H, W)
+///   ├─ ResnetBlock3D[0] (C_in → C_out)
+///   ├─ ResnetBlock3D[1] (C_out → C_out)
+///   ├─ ResnetBlock3D[2] (C_out → C_out)
+///   ├─ [optional] Upsample3D (doubles spatial, optionally temporal)
+///   └─ Output (B, C_out, T*?, H*2, W*2) or (B, C_out, T, H, W) if no upsample
+/// ```
+public final class SeedVR2UpBlock3D: Module {
+
+  /// Residual blocks in this stage.
+  @ModuleInfo(key: "resnets") var resnets: [SeedVR2ResnetBlock3D]
+
+  /// Optional upsampler (single-element array to match checkpoint key paths).
+  @ModuleInfo(key: "upsamplers") var upsamplers: [SeedVR2Upsample3D]
+
+  /// Creates a decoder up-block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of residual blocks. Default `3`.
+  ///   - addUpsample: Whether to append an upsampling layer. Default `true`.
+  ///   - temporalUp: Whether upsampling also doubles the temporal dimension.
+  ///     Ignored when `addUpsample` is false. Default `false`.
+  public init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 3,
+    addUpsample: Bool = true,
+    temporalUp: Bool = false
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      let inputCh = i == 0 ? inChannels : outChannels
+      return SeedVR2ResnetBlock3D(inChannels: inputCh, outChannels: outChannels)
+    }
+
+    if addUpsample {
+      self._upsamplers.wrappedValue = [
+        SeedVR2Upsample3D(channels: outChannels, temporalUp: temporalUp)
+      ]
+    } else {
+      self._upsamplers.wrappedValue = []
+    }
+
+    super.init()
+  }
+
+  /// Applies the up-block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C_in, T, H, W)`.
+  /// - Returns: Output tensor with channels set to `outChannels` and spatial (and
+  ///   optionally temporal) dimensions doubled if upsampling is present.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for upsampler in upsamplers {
+      hidden = upsampler(hidden)
+    }
+    return hidden
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Upsample3D.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2Upsample3D.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Spatial (and optionally temporal) upsampling for the SeedVR2 3D VAE decoder.
+///
+/// Uses sub-pixel convolution (depth-to-space) to increase resolution: a causal
+/// convolution expands the channel dimension by `spatial_factor^2 * temporal_factor`,
+/// then the extra channels are rearranged into spatial/temporal dimensions via
+/// reshape and transpose.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, C, T, H, W)
+///   ├─ upscale_conv: CausalConv3d(C → C * factor, k=1) — expand channels
+///   ├─ reshape to (B, sf, sf, tf, C, T, H, W)
+///   ├─ transpose to (B, C, T*tf, H*sf, W*sf)         — depth-to-space
+///   ├─ conv: CausalConv3d(C → C, k=3)                — smooth
+///   └─ Output (B, C, T*tf, H*sf, W*sf)
+/// ```
+///
+/// When T=1 and temporal upsampling is enabled, the duplicated temporal frames
+/// are trimmed back to 1 to maintain single-frame semantics.
+public final class SeedVR2Upsample3D: Module {
+
+  /// 1x1x1 convolution to expand channels for sub-pixel rearrangement.
+  @ModuleInfo(key: "upscale_conv") var upscaleConv: CausalConv3d
+
+  /// 3x3x3 causal convolution to smooth after rearrangement.
+  @ModuleInfo(key: "conv") var conv: CausalConv3d
+
+  /// Spatial upsampling factor (always 2).
+  public let spatialFactor: Int
+
+  /// Temporal upsampling factor (2 if temporal, 1 otherwise).
+  public let temporalFactor: Int
+
+  /// Creates an upsampling module.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input/output channels (preserved).
+  ///   - temporalUp: If true, also doubles the temporal dimension. Default `false`.
+  public init(channels: Int, temporalUp: Bool = false) {
+    self.spatialFactor = 2
+    self.temporalFactor = temporalUp ? 2 : 1
+
+    let totalFactor = spatialFactor * spatialFactor * temporalFactor
+
+    self._upscaleConv.wrappedValue = CausalConv3d(
+      inChannels: channels, outChannels: channels * totalFactor,
+      kernelSize: (1, 1, 1), stride: (1, 1, 1), padding: (0, 0, 0)
+    )
+    self._conv.wrappedValue = CausalConv3d(
+      inChannels: channels, outChannels: channels,
+      kernelSize: (3, 3, 3), stride: (1, 1, 1), padding: (1, 1, 1),
+      usePaddingCausal: true
+    )
+
+    super.init()
+  }
+
+  /// Applies the upsampling via sub-pixel convolution.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Upsampled tensor of shape `(B, C, T*tf, H*sf, W*sf)`, where
+  ///   `sf` is the spatial factor (2) and `tf` is the temporal factor.
+  ///   When T=1 and `temporalUp` is true, T remains 1.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let b = x.dim(0)
+    let c = x.dim(1)
+    let t = x.dim(2)
+    let h = x.dim(3)
+    let w = x.dim(4)
+
+    let sf = spatialFactor
+    let tf = temporalFactor
+
+    // Expand channels: (B, C * sf*sf*tf, T, H, W)
+    var out = upscaleConv(x)
+
+    // Sub-pixel rearrangement:
+    // (B, sf, sf, tf, C, T, H, W) → transpose → (B, C, T*tf, H*sf, W*sf)
+    out = out.reshaped(b, sf, sf, tf, c, t, h, w)
+    out = out.transposed(0, 4, 5, 3, 6, 1, 7, 2)
+    out = out.reshaped(b, c, t * tf, h * sf, w * sf)
+
+    // When input is a single frame, trim duplicated temporal frames.
+    if t == 1 && tf > 1 {
+      out = out[0..., 0..., ..<1, 0..., 0...]
+    }
+
+    // Smoothing convolution
+    out = conv(out)
+
+    return out
+  }
+}

--- a/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2VAE.swift
+++ b/Sources/ZImage/Upscale/SeedVR2/VAE/SeedVR2VAE.swift
@@ -1,0 +1,135 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Top-level 3D Video VAE for the SeedVR2 upscaler.
+///
+/// Provides encode and decode operations for mapping between RGB image/video
+/// tensors and the latent space used by the SeedVR2 diffusion transformer.
+///
+/// ## Encode
+///
+/// Accepts an image `(B, 3, H, W)` or video `(B, 3, T, H, W)`. For single images,
+/// a temporal dimension of 1 is inserted automatically. The encoder produces both
+/// mean and log-variance channels; only the mean is used, scaled by ``scalingFactor``.
+///
+/// ```
+/// Input (B, 3, H, W)
+///   → (B, 3, 1, H, W)           // add temporal dim
+///   → Encoder3D → (B, 32, 1, H/8, W/8)
+///   → split first 16 channels   // take mean, discard logvar
+///   → × scalingFactor
+///   → Output (B, 16, 1, H/8, W/8)
+/// ```
+///
+/// ## Decode
+///
+/// Accepts latent `(B, 16, T, H/8, W/8)`. Divides by ``scalingFactor`` then
+/// passes through the decoder to reconstruct RGB.
+///
+/// ```
+/// Input (B, 16, 1, H/8, W/8)
+///   → ÷ scalingFactor
+///   → Decoder3D
+///   → Output (B, 3, 1, H, W)
+/// ```
+///
+/// ## Spatial Scale
+///
+/// The VAE provides an 8x spatial reduction: an H x W input produces H/8 x W/8
+/// latents. This is exposed via ``spatialScale`` for use by the diffusion pipeline.
+public final class SeedVR2VAE: Module {
+
+  /// Scaling factor applied to latents after encoding.
+  /// Normalizes the latent distribution for the downstream diffusion model.
+  public let scalingFactor: Float = 0.9152
+
+  /// Spatial downsampling factor (8x for the default architecture).
+  public let spatialScale: Int = 8
+
+  /// Number of latent channels (mean only, not including log-variance).
+  public let latentChannels: Int
+
+  /// The 3D encoder.
+  @ModuleInfo(key: "encoder") var encoder: SeedVR2Encoder3D
+
+  /// The 3D decoder.
+  @ModuleInfo(key: "decoder") var decoder: SeedVR2Decoder3D
+
+  /// Creates a SeedVR2 3D Video VAE.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels (RGB = 3). Default `3`.
+  ///   - outChannels: Number of output channels (RGB = 3). Default `3`.
+  ///   - latentChannels: Number of latent channels. Default `16`.
+  ///   - blockOutChannels: Channel counts for each encoder/decoder stage.
+  ///     Default `[128, 256, 512, 512]`.
+  public init(
+    inChannels: Int = 3,
+    outChannels: Int = 3,
+    latentChannels: Int = 16,
+    blockOutChannels: [Int] = [128, 256, 512, 512]
+  ) {
+    self.latentChannels = latentChannels
+
+    self._encoder.wrappedValue = SeedVR2Encoder3D(
+      inChannels: inChannels,
+      outChannels: latentChannels,
+      blockOutChannels: blockOutChannels,
+      layersPerBlock: 2,
+      temporalDownBlocks: 2
+    )
+
+    self._decoder.wrappedValue = SeedVR2Decoder3D(
+      inChannels: latentChannels,
+      outChannels: outChannels,
+      blockOutChannels: blockOutChannels,
+      layersPerBlock: 3,
+      temporalUpBlocks: 2
+    )
+
+    super.init()
+  }
+
+  /// Encodes an image or video into the scaled latent space.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, 3, H, W)` or `(B, 3, T, H, W)`.
+  /// - Returns: Scaled latent tensor of shape `(B, latentChannels, T_out, H/8, W/8)`.
+  public func encode(_ x: MLXArray) -> MLXArray {
+    // Add temporal dimension if input is a single image (4D → 5D).
+    var input = x
+    if input.ndim == 4 {
+      input = input.expandedDimensions(axis: 2)
+    }
+
+    // Encode → (B, 2*latentChannels, T_out, H/8, W/8)
+    let encoded = encoder(input)
+
+    // Split into mean and logvar, keep only the mean.
+    let parts = split(encoded, parts: 2, axis: 1)
+    let mean = parts[0]
+
+    // Scale the latents.
+    return mean * scalingFactor
+  }
+
+  /// Decodes a latent tensor back to an image or video.
+  ///
+  /// - Parameter z: Latent tensor of shape `(B, latentChannels, T, H/8, W/8)`
+  ///   or `(B, latentChannels, H/8, W/8)`.
+  /// - Returns: Decoded tensor of shape `(B, 3, T, H, W)`.
+  public func decode(_ z: MLXArray) -> MLXArray {
+    // Add temporal dimension if input is 4D.
+    var latent = z
+    if latent.ndim == 4 {
+      latent = latent.expandedDimensions(axis: 2)
+    }
+
+    // Unscale the latents.
+    latent = latent / scalingFactor
+
+    // Decode → (B, 3, T, H, W)
+    let decoded = decoder(latent)
+    return decoded
+  }
+}

--- a/Sources/ZImage/Weights/ZImageWeightsMapper.swift
+++ b/Sources/ZImage/Weights/ZImageWeightsMapper.swift
@@ -33,11 +33,15 @@ public struct ZImageWeightsMapper {
   }
 
   public func loadTextEncoder(dtype: DType? = .bfloat16) throws -> [String: MLXArray] {
+    if hasQuantization() {
+      // Quantized models: always load from snapshot's text_encoder/ directory
+      // to preserve native dtypes (uint32 weights, float32 scales/biases).
+      // The textEncoderDirectory override is for non-quantized encoder variants
+      // and must NOT be used here — loadStandardComponent would convert U32→BF16.
+      return try loadQuantizedComponent("text_encoder")
+    }
     if let textEncoderDirectory {
       return try loadStandardComponent(urls: ZImageFiles.resolveWeightFiles(in: textEncoderDirectory, componentName: "text_encoder"), dtype: dtype)
-    }
-    if hasQuantization() {
-      return try loadQuantizedComponent("text_encoder")
     }
     return try loadStandardComponent(files: ZImageFiles.resolveTextEncoderWeights(at: snapshot), dtype: dtype)
   }

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -163,6 +163,9 @@ struct ZImageCLI {
       case "serve":
         try runServe(args: Array(args.dropFirst()))
         return
+      case "upscale":
+        try runUpscale(args: Array(args.dropFirst()))
+        return
       default:
         logger.warning("Unknown argument: \(arg)")
       }
@@ -399,6 +402,15 @@ struct ZImageCLI {
         --lora, -l           Initial LoRA(s)
         Use 'ZImageCLI serve --help' for full options
 
+      upscale                Upscale image via SeedVR2
+        --input, -i          Input image path (required)
+        --output, -o         Output image path (default: input-upscaled.png)
+        --resolution, -r     Target resolution (default: 2048)
+        --steps              Inference steps (default: 1)
+        --seed               Random seed
+        --weights, -w        Path to SeedVR2 model weights directory
+        --softness           Preprocessing softness 0.0-1.0 (default: 0.0)
+
     Examples:
       ZImageCLI -p "a cute cat" -o cat.png
       ZImageCLI -p "a sunset" -m models/z-image-turbo-q8
@@ -410,6 +422,7 @@ struct ZImageCLI {
       ZImageCLI -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
       ZImageCLI -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
       ZImageCLI serve -m ./models/z-image-turbo --port 7862
+      ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 2048
     """)
   }
 
@@ -1094,6 +1107,104 @@ struct ZImageCLI {
     Float(nextValue(for: arg, iterator: &iterator)) ?? fallback
   }
 
+  // MARK: - Upscale Subcommand
+
+  #if canImport(CoreGraphics)
+  private static func runUpscale(args: [String]) throws {
+    var inputPath: String?
+    var outputPath: String?
+    var resolution = 2048
+    var steps = 1
+    var seed: Int?
+    var weightsPath: String?
+    var softness: Float = 0.0
+
+    var iterator = args.makeIterator()
+    while let arg = iterator.next() {
+      switch arg {
+      case "--input", "-i":
+        inputPath = nextValue(for: arg, iterator: &iterator)
+      case "--output", "-o":
+        outputPath = nextValue(for: arg, iterator: &iterator)
+      case "--resolution", "-r":
+        resolution = intValue(for: arg, iterator: &iterator, minimum: 256, fallback: resolution)
+      case "--steps":
+        steps = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: steps)
+      case "--seed":
+        if let s = Int(nextValue(for: arg, iterator: &iterator)) {
+          seed = s
+        }
+      case "--weights", "-w":
+        weightsPath = nextValue(for: arg, iterator: &iterator)
+      case "--softness":
+        softness = floatValue(for: arg, iterator: &iterator, fallback: softness)
+      case "--help", "-h":
+        print("""
+        SeedVR2 Image Upscaler
+
+        Usage: ZImageCLI upscale --input <path> --weights <path> [options]
+
+          --input, -i          Input image path (required)
+          --output, -o         Output image path (default: input-upscaled.png)
+          --resolution, -r     Target resolution for shortest side (default: 2048)
+          --steps              Inference steps (default: 1)
+          --seed               Random seed for reproducibility
+          --weights, -w        Path to SeedVR2 model weights directory (required)
+          --softness           Preprocessing softness 0.0-1.0 (default: 0.0)
+          --help, -h           Show this help
+
+        Examples:
+          ZImageCLI upscale -i photo.jpg -w ./models/seedvr2
+          ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 4096 --seed 42
+          ZImageCLI upscale -i low-res.png -w ./models/seedvr2 --softness 0.3 -o high-res.png
+        """)
+        return
+      default:
+        logger.warning("Unknown upscale argument: \(arg)")
+      }
+    }
+
+    guard let input = inputPath else {
+      fputs("Error: --input is required for upscale\n", stderr)
+      exit(1)
+    }
+
+    guard let weights = weightsPath else {
+      fputs("Error: --weights is required for upscale\n", stderr)
+      exit(1)
+    }
+
+    guard FileManager.default.fileExists(atPath: input) else {
+      fputs("Error: Input file not found: \(input)\n", stderr)
+      exit(1)
+    }
+
+    let startTime = CFAbsoluteTimeGetCurrent()
+
+    let pipeline = try SeedVR2Pipeline(
+      weightsPath: weights,
+      steps: steps,
+      logger: logger
+    )
+
+    let savedPath = try pipeline.upscaleAndSave(
+      imagePath: input,
+      outputPath: outputPath,
+      targetResolution: resolution,
+      seed: seed,
+      softness: softness
+    )
+
+    let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+    logger.info("Upscale complete in \(String(format: "%.1f", elapsed))s -> \(savedPath)")
+  }
+  #else
+  private static func runUpscale(args: [String]) throws {
+    fputs("Error: SeedVR2 upscale requires CoreGraphics (macOS)\n", stderr)
+    exit(1)
+  }
+  #endif
+
 }
 
 // MARK: - Progress Helpers
@@ -1185,6 +1296,8 @@ private final class ProgressBar {
     if m > 0 { return String(format: "%dm%02ds", m, s) }
     return String(format: "%ds", s)
   }
+
+
 }
 
 do {

--- a/docs/comfyui-bridge-protocol-spec.md
+++ b/docs/comfyui-bridge-protocol-spec.md
@@ -1,0 +1,206 @@
+# ComfyUI Protocol Bridge Specification
+
+**Issue**: #21
+**Date**: 2026-04-30
+**Status**: Scoping complete, ready for implementation
+
+## Overview
+
+The Krita AI Diffusion plugin communicates with ComfyUI via HTTP + WebSocket.
+This document specifies the exact protocol surface we must implement so the
+plugin can connect to ZImageCLI's warm server as if it were ComfyUI.
+
+## Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/system_stats` | GET | Device info |
+| `/object_info` | GET | Node definitions + model lists |
+| `/prompt` | POST | Submit workflow |
+| `/ws?clientId=X` | WS | Progress + results |
+| `/api/etn/image/<id>` | PUT | Upload input image |
+| `/api/etn/image/<id>` | GET | Download result image |
+| `/api/etn/model_info/<folder>` | GET | Model metadata |
+| `/interrupt` | POST | Cancel current job |
+| `/queue` | POST | Delete queued jobs |
+
+## 1. GET /system_stats
+
+Called first during `ComfyClient.connect()`. `DeviceInfo.parse` reads:
+
+```json
+{
+  "devices": [{
+    "name": "Apple M3 Max",
+    "type": "mps",
+    "vram_total": 137438953472
+  }]
+}
+```
+
+Fields consumed:
+- `devices[0].name` — split on ":" if present
+- `devices[0].type` — string: "cuda", "mps", "cpu", "privateuseone"
+- `devices[0].vram_total` — bytes, divided by 1024^3 and rounded to GB
+
+## 2. GET /object_info
+
+Returns node type definitions. The plugin checks `_check_for_missing_nodes`
+against `required_custom_nodes` in `resources.py`.
+
+### Required nodes that MUST appear
+
+- **comfyui_controlnet_aux**: `InpaintPreprocessor`, `DepthAnythingV2Preprocessor`
+- **ComfyUI_IPAdapter_plus**: `IPAdapterModelLoader`, `IPAdapter`
+- **comfyui-tooling-nodes**: `ETN_LoadImageCache`, `ETN_SaveImageCache`, `ETN_Translate`
+- **comfyui-inpaint-nodes**: `INPAINT_LoadFooocusInpaint`, `INPAINT_ShrinkMask`, `INPAINT_StabilizeMask`, `INPAINT_ColorMatch`
+
+### Z-Image model discovery queries
+
+The plugin queries options from these nodes to discover available models:
+- `DualCLIPLoader` / `DualCLIPLoaderGGUF` → `clip_name1` (text encoders)
+- `VAELoader` → `vae_name`
+- `ControlNetLoader` → `control_net_name`
+- `UpscaleModelLoader` → `model_name`
+- `ModelPatchLoader` → `name` (Z-Image fun controlnet patches)
+- `UNETLoader` / `NunchakuZImageDiTLoader` (diffusion model)
+- `CLIPLoader` with `type: "lumina2"` (Z-Image text encoder)
+
+### Response format per node
+
+```json
+{
+  "NodeName": {
+    "input": {
+      "required": {
+        "param": ["type_or_options", {"opts": "..."}]
+      },
+      "optional": {}
+    },
+    "output_name": ["..."]
+  }
+}
+```
+
+## 3. POST /prompt
+
+### Request
+
+```json
+{
+  "prompt": {
+    "1": { "class_type": "...", "inputs": {...} },
+    "2": { "class_type": "...", "inputs": {...} }
+  },
+  "client_id": "<uuid>",
+  "prompt_id": "<uuid>"
+}
+```
+
+### Response
+
+Must include `{"prompt_id": "<same uuid>"}`. A mismatch raises an error.
+
+## 4. WebSocket Protocol
+
+### Connection
+
+`ws://<host>/ws?clientId=<client_id>`
+- Max message size: 2^30 bytes
+- Ping timeout: 60s
+
+### Text messages (JSON)
+
+| type | data fields | Purpose |
+|------|------------|---------|
+| `status` | — | Triggers `connected` event |
+| `execution_start` | `prompt_id` | Job started |
+| `executing` | `prompt_id`, `node` (null = done) | Node executing; node=null = workflow complete |
+| `execution_cached` | `prompt_id`, `nodes` (list) | Cached nodes skipped |
+| `progress` | `prompt_id` | Sampling step progress |
+| `executed` | `prompt_id`, `output.images[].source`, `output.images[].id` | Node output with images |
+| `execution_interrupted` | `prompt_id` | Job cancelled |
+| `execution_error` | `prompt_id`, `exception_message`, `traceback` | Job failed |
+
+### Progress formula
+
+```
+0.2 * (nodes_done / (total+1)) + 0.8 * (samples_done / sample_count)
+```
+
+### Binary messages (preview images)
+
+Header: `>II` (big-endian, 2x uint32)
+- Event type 1 = `PREVIEW_IMAGE`
+- Format 2 = PNG
+- Image data follows immediately after the 8-byte header
+
+## 5. Image Transfer
+
+### Input images (inpainting)
+
+Uploaded via `PUT /api/etn/image/<id>` as raw bytes.
+The `<id>` is a CRC32 hash of the PNG data (`_add_image_hashed`).
+In the workflow, `ETN_LoadImageCache` nodes reference images by this hash ID.
+
+### Output images
+
+Retrieved via `GET /api/etn/image/<id>` when the `executed` message
+contains `output.images` with `source: "http"` and an `id` field.
+
+The `ETN_SaveImageCache` node is the output node (replaces `SaveImage`),
+with `format: "PNG"`.
+
+## 6. Z-Image txt2img Workflow
+
+The plugin builds this node graph for `Arch.zimage`:
+
+1. **Load model**: `NunchakuZImageDiTLoader` (svdq quantized) or `UNETLoader` (diffusion format)
+2. **Load CLIP**: `CLIPLoader` with `type: "lumina2"`, loading `qwen_3_4b` text encoder
+3. **Load VAE**: `VAELoader` (z-image or flux VAE)
+4. **Encode prompts**: `CLIPTextEncode` for positive and negative
+5. **Empty latent**: `EmptySD3LatentImage` (Z-Image uses SD3 latent format)
+6. **Sampling**: `SamplerCustomAdvanced` with `BasicGuider` (cfg=1) or `CFGGuider`, `BasicScheduler`, `RandomNoise`, `KSamplerSelect`
+7. **Decode**: `VAEDecode`
+8. **Output**: `ETN_SaveImageCache` with format "PNG"
+
+## 7. Z-Image Inpaint Workflow
+
+Differences from txt2img:
+
+1. Adds `DifferentialDiffusion` node wrapping the model
+2. Input image loaded via `ETN_LoadImageCache`, mask loaded separately
+3. Mask processed through `INPAINT_ExpandMask` (grow/feather) and `INPAINT_StabilizeMask`
+4. Fill masked region via `INPAINT_MaskedBlur` (blur fill mode)
+5. If inpaint controlnet available: `ZImageFunControlnet` node applies the model patch from `ModelPatchLoader` with `inpaint_image`, `mask`, `vae`, `model_patch`, and `strength: 0.5` at range `(0.0, 1.0)`
+6. Otherwise: `VAEEncode` + `SetLatentNoiseMask` for standard latent-space inpainting
+7. Uses `INPAINT_VAEEncodeInpaintConditioning` when `use_inpaint_model` is true and no controlnet
+8. Post-process: `INPAINT_ColorMatch`, `ETN_ApplyMaskToImage` for compositing
+
+### Z-Image controlnet patches
+
+- `z-image-turbo-fun-controlnet-union-2.1` (universal)
+- `z-image-turbo-fun-controlnet-tile-2.1` (blur/tile)
+
+## Implementation Strategy
+
+### Phase 1: Discovery (static responses)
+- `/system_stats` — hardcoded device info from MLX Metal query
+- `/object_info` — static JSON declaring all required nodes with our model paths
+- `/ws` — basic WebSocket accept, send `status` on connect
+
+### Phase 2: txt2img
+- `/prompt` — parse workflow JSON, match Z-Image txt2img pattern, extract: prompt, negative prompt, width, height, steps, seed, sampler, scheduler, cfg
+- Route to ZImageCLI pipeline
+- Send progress events over WebSocket during denoising
+- Save output to `/api/etn/image/<id>`, send `executed` event
+
+### Phase 3: Inpaint
+- `/api/etn/image/<id>` PUT — accept and store input images
+- Parse inpaint workflow, extract: image, mask, fill mode, grow, feather, strength
+- Route to inpaint pipeline (requires inpaint support in ZImageCLI)
+- Compositing and color matching post-process
+
+### Phase 4: ControlNet
+- Parse controlnet nodes from workflow
+- Route control images and mode to ControlNet pipeline

--- a/docs/seedvr2-porting-guide.md
+++ b/docs/seedvr2-porting-guide.md
@@ -1,0 +1,115 @@
+# SeedVR2 Native Swift/MLX Porting Guide
+
+## Overview
+
+SeedVR2 is a 3B-parameter diffusion transformer (NaDiT) for image super-resolution. This guide covers porting the mflux Python/MLX implementation to native Swift/MLX within ZImageCLI.
+
+**Source**: mflux Python at `~/Projects/mflux/src/mflux/models/seedvr2/`
+**Target**: ZImageCLI Swift at `Sources/ZImage/Upscale/`
+**Weights**: HuggingFace `numz/SeedVR2_comfyUI` — `seedvr2_ema_3b_fp16.safetensors` (~6GB) + `ema_vae_fp16.safetensors` (~150MB)
+
+## Architecture Summary
+
+- 32 transformer blocks (10 dual-stream + 22 single-stream)
+- 3D Video VAE (CausalConv3d, 8x spatial downscale, 16 latent channels)
+- Windowed attention with shifted windows (Swin-style)
+- 3D axial RoPE (temporal + height + width)
+- Pre-computed text embeddings (no runtime T5/CLIP)
+- 1-step default inference (flow-matching Euler scheduler)
+- Wavelet + LAB color correction post-processing
+
+## Key Dimensions
+
+- vid_dim = 2560, txt_dim = 2560, txt_in_dim = 5120
+- heads = 20, head_dim = 128, inner_dim = 2560
+- MLP expand: 2560 → 6912 → 2560 (SwiGLU)
+- emb_dim = 15360 (6 × vid_dim)
+- patch_size = (1, 2, 2)
+- window = (4, 3, 3)
+- VAE: 3→128→256→512→512→32(encode) / 16→512→512→256→128→3(decode)
+- scaling_factor = 0.9152
+
+## Implementation Phases
+
+### Phase 1: Foundation (independently testable)
+1. RMSNorm — `mx.fast.rms_norm` wrapper
+2. SwiGLUMLP — 3 Linears + SiLU gate
+3. CausalConv3d — causal temporal padding + `conv_general`
+4. SeedVR2EulerScheduler — flow-matching Euler step
+5. Text embeddings loader — load `pos_emb.safetensors` (58, 5120)
+
+### Phase 2: VAE (test with weight loading)
+6. ResnetBlock3D — 2× CausalConv3d + GroupNorm + optional shortcut
+7. Attention3D — per-frame spatial self-attention
+8. Downsample3D / Upsample3D — spatial/temporal scale
+9. DownBlock3D / UpBlock3D / MidBlock3D — composition
+10. Encoder3D + Decoder3D
+11. SeedVR2VAE — thin wrapper with scaling
+
+### Phase 3: Transformer (most complex)
+12. TimeEmbedding — sinusoidal(256) → MLP → (15360)
+13. AdaModulation — learned per-layer shift/scale/gate + time embedding
+14. PatchIn / PatchOut — patchify/unpatchify 5D → tokens
+15. RoPEModule — 3D axial frequencies
+16. WindowPartitioner — adaptive windows, shifted windows (HARDEST MODULE)
+17. MMAttention — windowed + text broadcast + QK-norm + RoPE
+18. MMSwiGLU — multi-modal SwiGLU wrapper
+19. TransformerBlock — full block with AdaLN
+20. SeedVR2Transformer — 32 blocks + embeddings
+
+### Phase 4: Pipeline Integration
+21. SeedVR2LatentCreator — noise + conditioning
+22. SeedVR2Util — preprocessing, wavelet, LAB color transfer
+23. Full pipeline — load, encode, denoise, decode, color correct
+
+## Inference Pipeline (tensor shapes)
+
+```
+Input image → preprocess → (1, 3, H, W) [-1, 1]
+  → add temporal dim → (1, 3, 1, H, W)
+  → VAE encode → (1, 16, 1, H/8, W/8) × 0.9152
+  → concat ones mask → condition (1, 17, 1, H/8, W/8)
+  → create noise → latents (1, 16, 1, H/8, W/8)
+  → concat [latents, condition] → model_input (1, 33, 1, H/8, W/8)
+  → load text embeddings → (1, 58, 5120)
+  → transformer(model_input, text, timestep) → noise (1, 16, 1, H/8, W/8)
+  → Euler step → denoised latents
+  → VAE decode → (1, 3, 1, H, W)
+  → crop padding + wavelet + LAB color correction → output image
+```
+
+## Weight Mapping
+
+### Transformer
+- `vid_in.proj.{w,b}` → direct
+- `txt_in.{w,b}` → direct
+- `emb_in.proj_{in,hid,out}.{w,b}` → direct
+- `vid_out_ada.out_{shift,scale}` → rename to `out_{shift,scale}`
+- Blocks 0-9: `.vid.` and `.txt.` separate weights
+- Blocks 10-31: `.all.` weights shared → load into BOTH vid and txt attributes
+- Block 31: is_last_layer (no txt MLP, txt frozen in attention)
+- `blocks.{i}.ada.vid.` → `blocks.{i}.ada.params_vid.`
+- `blocks.{i}.attn.rope.rope.freqs` → `blocks.{i}.attn.rope.freqs`
+
+### VAE
+- All conv3d weights: transpose `(out, in, kt, kh, kw)` → `(out, kt, kh, kw, in)`
+- GroupNorm, Linear, bias: direct
+
+## Risk Areas
+
+1. **WindowPartitioner** — most complex module, index computation is subtle
+2. **CausalConv3d** — causal padding + weight layout must exactly match
+3. **3D RoPE** — text offset and axial frequency concatenation, off-by-one = garbage
+4. **Shared weights (blocks 10-31)** — same safetensors tensor → both vid and txt attrs
+
+## 7B Variant
+
+Same architecture, wider dimensions. Once 3B works, 7B is a config change:
+- Larger vid_dim, more heads, wider MLP
+- ~14GB weights (fp16), ~7GB (fp8)
+
+## Workflow
+
+- Claude 4.7 (Opus) for architecture and planning
+- Codex 5.5 for code review after each module
+- Test each module against Python reference output before proceeding


### PR DESCRIPTION
## Summary

- Adds ComfyUI-compatible HTTP + WebSocket endpoints alongside the existing `/v1/generate` API, enabling the Krita AI Diffusion plugin to connect to ZImageCLI's warm server as if it were ComfyUI
- Phase 1 implements static discovery (system_stats, object_info, queue), WebSocket connection with RFC 6455 framing, temporary image storage, and prompt skeleton
- Modular `ComfyBridge` layer hooks into `WarmServer.respond(to:)` without modifying existing endpoint behavior

## Changes

**New files** (`Sources/ZImage/Server/ComfyBridge/`):
- `ComfyBridge.swift` — Main router, system_stats, object_info, prompt, interrupt, image cache endpoints
- `ComfyBridgeObjectInfo.swift` — Static node definitions for all required custom nodes (ETN, inpaint, controlnet_aux, IPAdapter, core samplers, Z-Image custom nodes)
- `ComfyBridgeWebSocket.swift` — WebSocket connection manager with RFC 6455 framing, ping/pong, per-client tracking
- `ComfyBridgeImageCache.swift` — Thread-safe temporary image storage for ETN image transfer protocol

**Modified** (`Sources/ZImage/Server/WarmServer.swift`):
- HTTP types (HTTPRequest, HTTPResponse, RoutedResponse, ErrorPayload) promoted from private to internal
- HTTPRequest gains queryString/queryParameters for WebSocket clientId parsing
- HTTPResponse gains contentType field + rawJSON/binary factory methods
- ConnectionHandler handles WebSocket upgrade before async routing
- Max request body raised from 1MB to 10MB for image uploads

## Test plan

- [ ] Verify existing `/v1/generate`, `/health`, `/v1/lora/swap`, `/v1/shutdown` endpoints still work unchanged
- [ ] `curl http://localhost:7862/system_stats` returns Metal device name and memory
- [ ] `curl http://localhost:7862/object_info` returns all required custom nodes
- [ ] `curl http://localhost:7862/queue` returns empty queues
- [ ] `curl -X POST http://localhost:7862/prompt -d '{"prompt_id":"test","prompt":{},"client_id":"c"}'` echoes prompt_id
- [ ] WebSocket connects at `ws://localhost:7862/ws?clientId=test` and receives `{"type":"status"}`
- [ ] `curl -X PUT http://localhost:7862/api/etn/image/test123 --data-binary @image.png` stores, GET retrieves
- [ ] Krita AI Diffusion plugin connects and passes node validation (Phase 1 target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)