### PR TITLE
feat(batch): multi-seed batch runner with JSONL checkpoint recovery

### DIFF
--- a/Sources/ZImage/Pipeline/BatchCheckpoint.swift
+++ b/Sources/ZImage/Pipeline/BatchCheckpoint.swift
@@ -64,6 +64,7 @@ public struct BatchCheckpoint: Sendable {
         if let handle = FileHandle(forWritingAtPath: checkpointPath) {
             handle.seekToEndOfFile()
             handle.write(Data(line.utf8))
+            handle.synchronizeFile()
             handle.closeFile()
         } else {
             try? line.write(toFile: checkpointPath, atomically: true, encoding: .utf8)

--- a/Sources/ZImage/Pipeline/BatchCheckpoint.swift
+++ b/Sources/ZImage/Pipeline/BatchCheckpoint.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Append-only JSONL checkpoint file for batch crash recovery.
+/// Each completed seed is appended as a single JSON line. On resume,
+/// already-completed seeds are skipped — no work is repeated.
+public struct BatchCheckpoint: Sendable {
+    public let path: String?
+
+    public struct Entry: Codable, Sendable {
+        public let seed: UInt64
+        public let outputPath: String
+        public let completedAt: Date
+
+        public init(seed: UInt64, outputPath: String, completedAt: Date = Date()) {
+            self.seed = seed
+            self.outputPath = outputPath
+            self.completedAt = completedAt
+        }
+    }
+
+    public init(path: String?) {
+        self.path = path
+    }
+
+    /// Load completed seeds from checkpoint file. Returns empty set if no file.
+    public func load() -> Set<UInt64> {
+        guard let path = path else { return [] }
+        guard let data = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var seeds = Set<UInt64>()
+        for line in data.split(separator: "\n") where !line.isEmpty {
+            if let entry = try? decoder.decode(Entry.self, from: Data(line.utf8)) {
+                seeds.insert(entry.seed)
+            }
+        }
+        return seeds
+    }
+
+    /// Load full checkpoint entries (seed + output path + timestamp).
+    public func loadEntries() -> [Entry] {
+        guard let path = path else { return [] }
+        guard let data = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var entries: [Entry] = []
+        for line in data.split(separator: "\n") where !line.isEmpty {
+            if let entry = try? decoder.decode(Entry.self, from: Data(line.utf8)) {
+                entries.append(entry)
+            }
+        }
+        return entries
+    }
+
+    /// Append a completed seed to the checkpoint file.
+    public func append(seed: UInt64, path outputPath: String) {
+        guard let checkpointPath = path else { return }
+        let entry = Entry(seed: seed, outputPath: outputPath, completedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(entry),
+              var line = String(data: data, encoding: .utf8) else { return }
+        line += "\n"
+        if let handle = FileHandle(forWritingAtPath: checkpointPath) {
+            handle.seekToEndOfFile()
+            handle.write(Data(line.utf8))
+            handle.closeFile()
+        } else {
+            try? line.write(toFile: checkpointPath, atomically: true, encoding: .utf8)
+        }
+    }
+}

--- a/Sources/ZImage/Pipeline/BatchRunner.swift
+++ b/Sources/ZImage/Pipeline/BatchRunner.swift
@@ -115,8 +115,13 @@ public struct BatchRunner {
             // Re-read prompt file if configured
             let prompt: String?
             if let promptFilePath = config.promptFilePath {
-                prompt = try? String(contentsOfFile: promptFilePath, encoding: .utf8)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                do {
+                    prompt = try String(contentsOfFile: promptFilePath, encoding: .utf8)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } catch {
+                    fputs("[batch] WARNING: Failed to read prompt file \(promptFilePath): \(error). Using original prompt.\n", stderr)
+                    prompt = nil
+                }
             } else {
                 prompt = nil
             }

--- a/Sources/ZImage/Pipeline/BatchRunner.swift
+++ b/Sources/ZImage/Pipeline/BatchRunner.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Configuration for a multi-seed batch run.
+public struct BatchConfig: Sendable {
+    public let seeds: [UInt64]
+    public let autoSeedCount: Int?        // generate N random seeds
+    public let outputPattern: String      // e.g., "output_{seed}.png"
+    public let continueOnError: Bool      // default true
+    public let metadataEnabled: Bool      // write JSON sidecar per image
+    public let promptFilePath: String?    // re-read before each iteration
+    public let checkpointPath: String?    // batch progress file
+
+    public init(
+        seeds: [UInt64] = [],
+        autoSeedCount: Int? = nil,
+        outputPattern: String = "{output}_{seed}.png",
+        continueOnError: Bool = true,
+        metadataEnabled: Bool = false,
+        promptFilePath: String? = nil,
+        checkpointPath: String? = nil
+    ) {
+        self.seeds = seeds
+        self.autoSeedCount = autoSeedCount
+        self.outputPattern = outputPattern
+        self.continueOnError = continueOnError
+        self.metadataEnabled = metadataEnabled
+        self.promptFilePath = promptFilePath
+        self.checkpointPath = checkpointPath
+    }
+}
+
+/// Result summary for a completed batch run.
+public struct BatchResult: Sendable {
+    public let totalSeeds: Int
+    public let completed: Int
+    public let failed: Int
+    public let skipped: Int              // from checkpoint resume
+    public let outputs: [(seed: UInt64, path: String?, error: String?)]
+    public let totalDuration: TimeInterval
+
+    public init(
+        totalSeeds: Int,
+        completed: Int,
+        failed: Int,
+        skipped: Int,
+        outputs: [(seed: UInt64, path: String?, error: String?)],
+        totalDuration: TimeInterval
+    ) {
+        self.totalSeeds = totalSeeds
+        self.completed = completed
+        self.failed = failed
+        self.skipped = skipped
+        self.outputs = outputs
+        self.totalDuration = totalDuration
+    }
+}
+
+/// Sequential multi-seed batch runner. GPU renders are NEVER concurrent.
+/// Supports checkpoint resume, prompt-file re-read, and output path templating.
+public struct BatchRunner {
+
+    /// Run a batch of seeds sequentially.
+    ///
+    /// - Parameters:
+    ///   - config: Batch configuration (seeds, output pattern, checkpoint, etc.)
+    ///   - generate: Closure called for each seed. Receives (seed, prompt?) and returns the output path.
+    ///               The prompt parameter is non-nil only when `promptFilePath` is set and the file is re-read.
+    /// - Returns: Summary of the batch run.
+    public static func run(
+        config: BatchConfig,
+        generate: (_ seed: UInt64, _ prompt: String?) async throws -> String
+    ) async throws -> BatchResult {
+        let startTime = Date()
+
+        // Resolve seeds: auto-generate or use explicit list
+        let allSeeds: [UInt64]
+        if let count = config.autoSeedCount, count > 0 {
+            var generated: [UInt64] = []
+            for _ in 0..<count {
+                generated.append(UInt64.random(in: 0...UInt64.max))
+            }
+            // Append any explicitly provided seeds
+            allSeeds = generated + config.seeds
+        } else {
+            allSeeds = config.seeds
+        }
+
+        guard !allSeeds.isEmpty else {
+            return BatchResult(
+                totalSeeds: 0, completed: 0, failed: 0, skipped: 0,
+                outputs: [], totalDuration: 0
+            )
+        }
+
+        // Load checkpoint for resume
+        let checkpoint = BatchCheckpoint(path: config.checkpointPath)
+        let completedSeeds = checkpoint.load()
+        let skippedCount = allSeeds.filter { completedSeeds.contains($0) }.count
+
+        if skippedCount > 0 {
+            fputs("[batch] Resuming: \(skippedCount) seed(s) already completed, skipping.\n", stderr)
+        }
+
+        var outputs: [(seed: UInt64, path: String?, error: String?)] = []
+        var completedCount = 0
+        var failedCount = 0
+
+        for (index, seed) in allSeeds.enumerated() {
+            // Skip if already completed (checkpoint resume)
+            if completedSeeds.contains(seed) {
+                outputs.append((seed: seed, path: nil, error: nil))
+                continue
+            }
+
+            // Re-read prompt file if configured
+            let prompt: String?
+            if let promptFilePath = config.promptFilePath {
+                prompt = try? String(contentsOfFile: promptFilePath, encoding: .utf8)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                prompt = nil
+            }
+
+            // Resolve output path from pattern
+            let outputPath = resolveOutputPath(
+                pattern: config.outputPattern,
+                seed: seed,
+                index: index
+            )
+
+            fputs("[batch] [\(index + 1)/\(allSeeds.count)] seed=\(seed) -> \(outputPath)\n", stderr)
+
+            do {
+                let actualPath = try await generate(seed, prompt)
+                completedCount += 1
+                outputs.append((seed: seed, path: actualPath, error: nil))
+                checkpoint.append(seed: seed, path: actualPath)
+            } catch {
+                failedCount += 1
+                let errorMsg = error.localizedDescription
+                outputs.append((seed: seed, path: nil, error: errorMsg))
+                fputs("[batch] FAILED seed=\(seed): \(errorMsg)\n", stderr)
+
+                if !config.continueOnError {
+                    break
+                }
+            }
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        return BatchResult(
+            totalSeeds: allSeeds.count,
+            completed: completedCount,
+            failed: failedCount,
+            skipped: skippedCount,
+            outputs: outputs,
+            totalDuration: duration
+        )
+    }
+
+    /// Replace `{seed}`, `{index}`, and `{output}` placeholders in the pattern.
+    public static func resolveOutputPath(pattern: String, seed: UInt64, index: Int) -> String {
+        var result = pattern
+        result = result.replacingOccurrences(of: "{seed}", with: String(seed))
+        result = result.replacingOccurrences(of: "{index}", with: String(index))
+        return result
+    }
+
+    /// Build an output pattern from a base output path.
+    /// "photo.png" -> "photo_{seed}.png"
+    public static func outputPattern(from outputPath: String) -> String {
+        let url = URL(fileURLWithPath: outputPath)
+        let ext = url.pathExtension
+        let basename = url.deletingPathExtension().lastPathComponent
+        let dir = url.deletingLastPathComponent().path
+        if ext.isEmpty {
+            return (dir as NSString).appendingPathComponent("\(basename)_{seed}")
+        }
+        return (dir as NSString).appendingPathComponent("\(basename)_{seed}.\(ext)")
+    }
+}

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -49,7 +49,7 @@ struct ZImageCLI {
     var height = ZImageModelMetadata.recommendedHeight
     var steps = ZImageModelMetadata.recommendedInferenceSteps
     var guidance = ZImageModelMetadata.recommendedGuidanceScale
-    var seed: UInt64?
+    var seeds: [UInt64] = []
     var outputPath = "z-image.png"
     var model: String?
     var textEncoderPath: String?
@@ -71,6 +71,9 @@ struct ZImageCLI {
     var dyPEDisabled = false
     var writeMetadata = false
     var configFromMetadata: String?
+    var autoSeeds: Int?
+    var resumeBatchPath: String?
+    var promptFilePath: String?
 
     let args = Array(CommandLine.arguments.dropFirst())
     var iterator = args.makeIterator()
@@ -90,7 +93,9 @@ struct ZImageCLI {
       case "--guidance", "-g":
         guidance = floatValue(for: arg, iterator: &iterator, fallback: guidance)
       case "--seed":
-        seed = UInt64(nextValue(for: arg, iterator: &iterator))
+        if let s = UInt64(nextValue(for: arg, iterator: &iterator)) {
+          seeds.append(s)
+        }
       case "--output", "-o":
         outputPath = nextValue(for: arg, iterator: &iterator)
       case "--model", "-m":
@@ -154,6 +159,12 @@ struct ZImageCLI {
         writeMetadata = true
       case "--config-from-metadata":
         configFromMetadata = nextValue(for: arg, iterator: &iterator)
+      case "--auto-seeds":
+        autoSeeds = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: 1)
+      case "--resume-batch":
+        resumeBatchPath = nextValue(for: arg, iterator: &iterator)
+      case "--prompt-file":
+        promptFilePath = nextValue(for: arg, iterator: &iterator)
       case "--help", "-h":
         printUsage()
         return
@@ -216,7 +227,7 @@ struct ZImageCLI {
       }
       if prompt == nil { prompt = loaded.parameters.prompt }
       if negativePrompt == nil { negativePrompt = loaded.parameters.negativePrompt }
-      if seed == nil { seed = loaded.parameters.seed }
+      if seeds.isEmpty { seeds.append(loaded.parameters.seed) }
       if width == ZImageModelMetadata.recommendedWidth { width = loaded.parameters.width }
       if height == ZImageModelMetadata.recommendedHeight { height = loaded.parameters.height }
       if steps == ZImageModelMetadata.recommendedInferenceSteps { steps = loaded.parameters.steps }
@@ -252,10 +263,14 @@ struct ZImageCLI {
       logger.info("Using \(loraConfigs.count) LoRA(s)")
     }
 
-    // Pin seed before request so metadata always records the actual seed used
-    if seed == nil {
-      seed = UInt64.random(in: 0...UInt64.max)
+    // Determine if this is a batch run
+    let isBatchRun = (autoSeeds != nil && autoSeeds! > 0) || seeds.count > 1
+
+    // Pin seed for single-image flow (batch runner handles its own seeds)
+    if !isBatchRun && seeds.isEmpty {
+      seeds.append(UInt64.random(in: 0...UInt64.max))
     }
+    let seed: UInt64? = isBatchRun ? nil : seeds.first
 
     // Build DyPE config — auto-enable when resolution exceeds base training size
     let dyPEConfig: DyPEConfig
@@ -272,6 +287,126 @@ struct ZImageCLI {
       dyPEConfig = .disabled
     }
 
+    // === BATCH EXECUTION PATH ===
+    if isBatchRun {
+      let batchOutputPattern = BatchRunner.outputPattern(from: outputPath)
+      let checkpointPath = resumeBatchPath ?? {
+        let dir = URL(fileURLWithPath: outputPath).deletingLastPathComponent().path
+        return (dir as NSString).appendingPathComponent(".batch-progress.jsonl")
+      }()
+      let batchConfig = BatchConfig(
+        seeds: seeds,
+        autoSeedCount: autoSeeds,
+        outputPattern: batchOutputPattern,
+        continueOnError: true,
+        metadataEnabled: writeMetadata,
+        promptFilePath: promptFilePath,
+        checkpointPath: checkpointPath
+      )
+
+      let capturedNegativePrompt = negativePrompt
+      let capturedModel = model
+      let capturedTextEncoderPath = textEncoderPath
+      let capturedLoraConfigs = loraConfigs
+      let capturedWriteMetadata = writeMetadata
+
+      let pipeline = ZImagePipeline(logger: logger)
+      nonisolated(unsafe) let batchSemaphore = DispatchSemaphore(value: 0)
+      let resultBox = Box<BatchResult?>(nil)
+
+      Task {
+        do {
+          let result = try await BatchRunner.run(config: batchConfig) { batchSeed, batchPrompt in
+            let effectivePrompt = batchPrompt ?? prompt
+            let batchOutputPath = BatchRunner.resolveOutputPath(
+              pattern: batchOutputPattern, seed: batchSeed, index: 0
+            )
+            let batchRequest = ZImageGenerationRequest(
+              prompt: effectivePrompt,
+              negativePrompt: capturedNegativePrompt,
+              width: width,
+              height: height,
+              steps: steps,
+              guidanceScale: guidance,
+              seed: batchSeed,
+              outputPath: URL(fileURLWithPath: batchOutputPath),
+              model: capturedModel,
+              textEncoderPath: capturedTextEncoderPath,
+              maxSequenceLength: maxSequenceLength,
+              loras: capturedLoraConfigs,
+              enhancePrompt: enhancePrompt,
+              enhanceMaxTokens: enhanceMaxTokens,
+              forceTransformerOverrideOnly: forceTransformerOverrideOnly,
+              schedulerKind: schedulerKind,
+              sigmaSchedule: sigmaSchedule,
+              eta: eta,
+              dyPE: dyPEConfig
+            )
+            let startTime = Date()
+            _ = try await pipeline.generate(batchRequest, progressHandler: nil)
+
+            // Write metadata sidecar if enabled
+            if capturedWriteMetadata {
+              let loraInfos = capturedLoraConfigs.map { lora -> LoRAInfo in
+                let path: String
+                switch lora.source {
+                case .local(let url): path = url.path
+                case .huggingFace(let id, _): path = id
+                }
+                return LoRAInfo(path: path, scale: lora.scale)
+              }
+              let metadata = GenerationMetadata(
+                pipeline: .txt2img,
+                model: ModelInfo(
+                  family: "zimage",
+                  variant: "turbo",
+                  path: capturedModel ?? ZImageRepository.id
+                ),
+                parameters: GenerationParameters(
+                  prompt: effectivePrompt,
+                  negativePrompt: capturedNegativePrompt,
+                  seed: batchSeed,
+                  steps: steps,
+                  guidance: guidance,
+                  width: width,
+                  height: height,
+                  scheduler: schedulerKind.rawValue,
+                  sigmaSchedule: sigmaSchedule == .flow ? nil : sigmaSchedule.rawValue
+                ),
+                loras: loraInfos,
+                output: OutputInfo(
+                  path: batchOutputPath,
+                  width: width,
+                  height: height,
+                  renderTimeSeconds: Date().timeIntervalSince(startTime)
+                )
+              )
+              MetadataWriter.write(metadata, for: batchOutputPath)
+            }
+
+            return batchOutputPath
+          }
+          resultBox.value = result
+        } catch {
+          logger.error("Batch failed: \(error)")
+        }
+        batchSemaphore.signal()
+      }
+      batchSemaphore.wait()
+
+      // Print batch summary
+      if let result = resultBox.value {
+        let duration = String(format: "%.1f", result.totalDuration)
+        print("\nBatch complete: \(result.completed)/\(result.totalSeeds) succeeded, \(result.failed) failed, \(result.skipped) skipped (resumed)")
+        print("Total time: \(duration)s")
+        if let checkpoint = batchConfig.checkpointPath {
+          print("Checkpoint: \(checkpoint)")
+        }
+      }
+      return
+    }
+
+    // === SINGLE IMAGE PATH ===
     let request = ZImageGenerationRequest(
       prompt: prompt,
       negativePrompt: negativePrompt,
@@ -470,6 +605,10 @@ struct ZImageCLI {
       --svg-preset           SVG preset: default, logo, detailed, simplified, bw
       --metadata             Write generation metadata JSON sidecar alongside output image
       --config-from-metadata Load generation parameters from a metadata JSON sidecar (CLI flags override)
+      --auto-seeds <N>       Generate N random seeds for batch run
+      --seed                 Random seed (repeatable for batch: --seed 42 --seed 99)
+      --resume-batch <path>  Resume batch from checkpoint file
+      --prompt-file <path>   Re-read prompt from file before each batch iteration
       --help, -h             Show help
 
     Subcommands:
@@ -521,6 +660,9 @@ struct ZImageCLI {
       ZImageCLI -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
       ZImageCLI -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
       ZImageCLI serve -m ./models/z-image-turbo --port 7862
+      ZImageCLI -p "portrait" --auto-seeds 5 -o portraits.png  # Generate 5 random variations
+      ZImageCLI -p "cat" --seed 42 --seed 99 --seed 123 -o cats.png  # 3 specific seeds
+      ZImageCLI -p "scene" --auto-seeds 10 --resume-batch progress.jsonl  # Resume interrupted batch
       ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 2048
     """)
   }


### PR DESCRIPTION
## Summary

Phase 0, PR 2 of ComfyBox — adds multi-seed batch generation with crash recovery:

- **BatchRunner** — Sequential multi-seed execution, prompt-file re-read per iteration, output path templating (`{seed}`, `{index}` patterns). GPU renders are strictly sequential — never concurrent.
- **BatchCheckpoint** — Append-only JSONL checkpoint file. On crash, resume skips completed seeds automatically.
- **CLI flags** — `--auto-seeds <N>` (random seeds), `--seed` (repeatable for explicit list), `--resume-batch <path>`, `--prompt-file <path>`
- Backward compatible — single-seed path unchanged

Depends on PR #27 (metadata sidecar) for `--metadata` integration during batch runs.

### Codex Review: Pending

## Test plan
- [ ] `swift build -c release` passes
- [ ] `--auto-seeds 3 --metadata` produces 3 images + 3 JSON sidecars
- [ ] `--seed 42 --seed 137 --seed 256` produces 3 images with specified seeds
- [ ] Kill during seed 2 of 5 → `.batch-progress.jsonl` has 1 entry
- [ ] `--resume-batch .batch-progress.jsonl --auto-seeds 5` skips completed, generates remaining
- [ ] `--prompt-file test.txt` + edit between iterations → subsequent images use updated prompt
- [ ] Single `--seed 42` (no batch) → same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)