### PR TITLE
feat(img2img): image-to-image pipeline with VAE encode and strength/creativity

### DIFF
--- a/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
@@ -1,0 +1,292 @@
+// ImageToImagePipeline.swift — Img2img generation via the existing inpainting path.
+//
+// Flow: load source image -> create synthetic all-white mask -> delegate to
+//       ZImagePipeline.generate with inpaint parameters -> output.
+//
+// Strength convention (matches Python mflux):
+//   strength 0.3 -> heavy rework (more steps, default)
+//   strength 0.7 -> light touch (fewer steps)
+// Creativity is the inverse: creativity = 1.0 - strength
+
+import Foundation
+import Logging
+import MLX
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+#endif
+
+/// Configuration for an img2img generation request.
+public struct Img2ImgRequest: Sendable {
+  public var prompt: String
+  public var negativePrompt: String?
+  public var width: Int?
+  public var height: Int?
+  public var steps: Int
+  public var guidanceScale: Float
+  public var seed: UInt64?
+  public var outputPath: URL
+  public var model: String?
+  public var textEncoderPath: String?
+  public var maxSequenceLength: Int
+  public var loras: [LoRAConfiguration]
+  public var enhancePrompt: Bool
+  public var enhanceMaxTokens: Int
+  public var forceTransformerOverrideOnly: Bool
+  public var schedulerKind: SchedulerKind
+  public var sigmaSchedule: SigmaScheduleKind
+  public var eta: Float?
+  public var dyPE: DyPEConfig
+
+  /// The source image file path.
+  public var sourceImagePath: String
+
+  /// Strength controls how many denoising steps to run (mflux convention).
+  /// 0.3 = heavy rework (default), 0.7 = light touch.
+  /// Range: (0.0, 1.0]. A value of 0.0 would mean no denoising at all.
+  public var strength: Float
+
+  /// How the user specified the value — "strength" or "creativity".
+  public var specifiedAs: Img2ImgSpecifier
+
+  public enum Img2ImgSpecifier: String, Sendable {
+    case strength
+    case creativity
+  }
+
+  public init(
+    prompt: String,
+    negativePrompt: String? = nil,
+    width: Int? = nil,
+    height: Int? = nil,
+    steps: Int = ZImageModelMetadata.recommendedInferenceSteps,
+    guidanceScale: Float = ZImageModelMetadata.recommendedGuidanceScale,
+    seed: UInt64? = nil,
+    outputPath: URL = URL(fileURLWithPath: "z-image-img2img.png"),
+    model: String? = nil,
+    textEncoderPath: String? = nil,
+    maxSequenceLength: Int = 512,
+    loras: [LoRAConfiguration] = [],
+    enhancePrompt: Bool = false,
+    enhanceMaxTokens: Int = 512,
+    forceTransformerOverrideOnly: Bool = false,
+    schedulerKind: SchedulerKind = .euler,
+    sigmaSchedule: SigmaScheduleKind = .flow,
+    eta: Float? = nil,
+    dyPE: DyPEConfig = .disabled,
+    sourceImagePath: String,
+    strength: Float = 0.3,
+    specifiedAs: Img2ImgSpecifier = .strength
+  ) {
+    self.prompt = prompt
+    self.negativePrompt = negativePrompt
+    self.width = width
+    self.height = height
+    self.steps = steps
+    self.guidanceScale = guidanceScale
+    self.seed = seed
+    self.outputPath = outputPath
+    self.model = model
+    self.textEncoderPath = textEncoderPath
+    self.maxSequenceLength = maxSequenceLength
+    self.loras = loras
+    self.enhancePrompt = enhancePrompt
+    self.enhanceMaxTokens = enhanceMaxTokens
+    self.forceTransformerOverrideOnly = forceTransformerOverrideOnly
+    self.schedulerKind = schedulerKind
+    self.sigmaSchedule = sigmaSchedule
+    self.eta = eta
+    self.dyPE = dyPE
+    self.sourceImagePath = sourceImagePath
+    self.strength = strength
+    self.specifiedAs = specifiedAs
+  }
+
+  /// Convert img2img strength to inpainting denoise value.
+  ///
+  /// mflux img2img: init_time_step = max(1, int(steps * strength))
+  ///   strength 0.3, 9 steps -> init=2, run steps 2..8 = 7 steps (heavy)
+  ///   strength 0.7, 9 steps -> init=6, run steps 6..8 = 3 steps (light)
+  ///
+  /// ZImage inpainting: inpaintStartStep = max(0, steps - Int(ceil(steps * denoise)))
+  ///   denoise 0.7, 9 steps -> startStep = 9 - 7 = 2, run 7 steps (heavy)
+  ///   denoise 0.3, 9 steps -> startStep = 9 - 3 = 6, run 3 steps (light)
+  ///
+  /// Conversion: denoise = 1.0 - strength
+  public var denoise: Float {
+    return 1.0 - max(0.01, min(0.99, strength))
+  }
+}
+
+// MARK: - White Mask Generation
+
+private enum Img2ImgUtilities {
+  enum Img2ImgError: Error, CustomStringConvertible {
+    case sourceImageNotFound(String)
+    case sourceImageLoadFailed(String)
+    case maskGenerationFailed(String)
+
+    var description: String {
+      switch self {
+      case .sourceImageNotFound(let path): return "Source image not found: \(path)"
+      case .sourceImageLoadFailed(let msg): return "Source image load failed: \(msg)"
+      case .maskGenerationFailed(let msg): return "Mask generation failed: \(msg)"
+      }
+    }
+  }
+
+  /// Generate a solid white PNG image of the given dimensions.
+  static func generateWhiteMaskPNG(width: Int, height: Int) throws -> Data {
+    #if canImport(CoreGraphics)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+    guard let context = CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo.rawValue
+    ) else {
+      throw Img2ImgError.maskGenerationFailed("Failed to create CGContext for white mask")
+    }
+
+    context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+    guard let cgImage = context.makeImage() else {
+      throw Img2ImgError.maskGenerationFailed("Failed to create CGImage from white-filled context")
+    }
+
+    let mutableData = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+      throw Img2ImgError.maskGenerationFailed("Failed to create PNG destination")
+    }
+    CGImageDestinationAddImage(destination, cgImage, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      throw Img2ImgError.maskGenerationFailed("Failed to finalize PNG data")
+    }
+
+    return mutableData as Data
+    #else
+    throw Img2ImgError.maskGenerationFailed("CoreGraphics not available")
+    #endif
+  }
+
+  /// Read the dimensions of a PNG file from its IHDR chunk.
+  static func pngDimensions(from data: Data) -> (width: Int, height: Int)? {
+    guard data.count >= 24 else { return nil }
+    let w = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
+    let h = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
+    guard w > 0 && h > 0 && w < 65536 && h < 65536 else { return nil }
+    return (w, h)
+  }
+
+  /// Round up to nearest multiple of 16 (VAE latent alignment).
+  static func roundTo16(_ n: Int) -> Int {
+    return ((n + 15) / 16) * 16
+  }
+}
+
+// MARK: - Pipeline Extension
+
+extension ZImagePipeline {
+
+  /// Generate an image from a source image + prompt (img2img).
+  ///
+  /// Internally converts the img2img request to an inpainting request with
+  /// a full white mask, delegating to the existing generateCore path.
+  public func generateImg2Img(
+    _ request: Img2ImgRequest,
+    progressHandler: ProgressHandler? = nil
+  ) async throws -> URL {
+    let pipelineRequest = try makeImg2ImgPipelineRequest(request)
+    return try await generate(pipelineRequest, progressHandler: progressHandler)
+  }
+
+  /// Generate an img2img result to memory (PNG data).
+  public func generateImg2ImgToMemory(
+    _ request: Img2ImgRequest,
+    progressHandler: ProgressHandler? = nil
+  ) async throws -> Data {
+    let pipelineRequest = try makeImg2ImgPipelineRequest(request)
+    return try await generateToMemory(pipelineRequest, progressHandler: progressHandler)
+  }
+
+  /// Convert an Img2ImgRequest to a ZImageGenerationRequest by loading
+  /// the source image, generating a white mask, and computing denoise.
+  private func makeImg2ImgPipelineRequest(_ request: Img2ImgRequest) throws -> ZImageGenerationRequest {
+    let sourceURL = URL(fileURLWithPath: request.sourceImagePath)
+    guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+      throw Img2ImgUtilities.Img2ImgError.sourceImageNotFound(request.sourceImagePath)
+    }
+
+    let imageData = try Data(contentsOf: sourceURL)
+    guard !imageData.isEmpty else {
+      throw Img2ImgUtilities.Img2ImgError.sourceImageLoadFailed("Empty file: \(request.sourceImagePath)")
+    }
+
+    // Determine output dimensions
+    let resolvedWidth: Int
+    let resolvedHeight: Int
+    if let w = request.width, let h = request.height {
+      resolvedWidth = Img2ImgUtilities.roundTo16(w)
+      resolvedHeight = Img2ImgUtilities.roundTo16(h)
+    } else if let dims = Img2ImgUtilities.pngDimensions(from: imageData) {
+      resolvedWidth = Img2ImgUtilities.roundTo16(dims.width)
+      resolvedHeight = Img2ImgUtilities.roundTo16(dims.height)
+    } else {
+      #if canImport(CoreGraphics)
+      let cgImage = try InpaintUtilities.loadCGImage(from: imageData)
+      resolvedWidth = Img2ImgUtilities.roundTo16(cgImage.width)
+      resolvedHeight = Img2ImgUtilities.roundTo16(cgImage.height)
+      #else
+      resolvedWidth = ZImageModelMetadata.recommendedWidth
+      resolvedHeight = ZImageModelMetadata.recommendedHeight
+      #endif
+    }
+
+    // Generate white mask (regenerate everything)
+    let maskData = try Img2ImgUtilities.generateWhiteMaskPNG(
+      width: resolvedWidth,
+      height: resolvedHeight
+    )
+
+    // Build DyPE config
+    let dyPEConfig: DyPEConfig
+    if request.dyPE.enabled {
+      dyPEConfig = request.dyPE
+    } else if max(resolvedWidth, resolvedHeight) > 1024 {
+      dyPEConfig = .ntk
+    } else {
+      dyPEConfig = .disabled
+    }
+
+    return ZImageGenerationRequest(
+      prompt: request.prompt,
+      negativePrompt: request.negativePrompt,
+      width: resolvedWidth,
+      height: resolvedHeight,
+      steps: request.steps,
+      guidanceScale: request.guidanceScale,
+      seed: request.seed,
+      outputPath: request.outputPath,
+      model: request.model,
+      textEncoderPath: request.textEncoderPath,
+      maxSequenceLength: request.maxSequenceLength,
+      loras: request.loras,
+      enhancePrompt: request.enhancePrompt,
+      enhanceMaxTokens: request.enhanceMaxTokens,
+      forceTransformerOverrideOnly: request.forceTransformerOverrideOnly,
+      schedulerKind: request.schedulerKind,
+      sigmaSchedule: request.sigmaSchedule,
+      eta: request.eta,
+      dyPE: dyPEConfig,
+      inpaintImageData: imageData,
+      maskData: maskData,
+      denoise: request.denoise
+    )
+  }
+}

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -644,11 +644,20 @@ private actor WarmServerCoordinator {
     let start = Date()
 
     do {
-      let request = try payload.makePipelineRequest(
-        configuration: configuration,
-        activeLoRAs: activeLoRAs
-      )
-      let outputURL = try await pipeline.generateFromRequest(request, progressHandler: progressHandler)
+      let outputURL: URL
+      if payload.imagePath != nil {
+        let img2imgRequest = try payload.makeImg2ImgRequest(
+          configuration: configuration,
+          activeLoRAs: activeLoRAs
+        )
+        outputURL = try await pipeline.generateImg2Img(img2imgRequest, progressHandler: progressHandler)
+      } else {
+        let request = try payload.makePipelineRequest(
+          configuration: configuration,
+          activeLoRAs: activeLoRAs
+        )
+        outputURL = try await pipeline.generateFromRequest(request, progressHandler: progressHandler)
+      }
       let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
       successfulRenderCount += 1
       lastRenderDurationMs = durationMs
@@ -1030,6 +1039,11 @@ private struct GeneratePayload: Sendable {
   let maskCropX: Int?
   let maskCropY: Int?
 
+  // Phase 4: Img2img (set via HTTP API)
+  let imagePath: String?
+  let imageStrength: Float?
+  let creativity: Float?
+
   /// Default memberwise init for bridge-created payloads.
   init(
     prompt: String, negativePrompt: String? = nil,
@@ -1038,7 +1052,8 @@ private struct GeneratePayload: Sendable {
     scheduler: String? = nil, sigmaSchedule: String? = nil, eta: Float? = nil,
     dype: String? = nil, inpaintImageData: Data? = nil, maskData: Data? = nil,
     denoise: Float? = nil, maskGrow: Int? = nil, maskFeather: Int? = nil,
-    maskCropX: Int? = nil, maskCropY: Int? = nil
+    maskCropX: Int? = nil, maskCropY: Int? = nil,
+    imagePath: String? = nil, imageStrength: Float? = nil, creativity: Float? = nil
   ) {
     self.prompt = prompt; self.negativePrompt = negativePrompt
     self.width = width; self.height = height; self.steps = steps
@@ -1048,6 +1063,7 @@ private struct GeneratePayload: Sendable {
     self.inpaintImageData = inpaintImageData; self.maskData = maskData
     self.denoise = denoise; self.maskGrow = maskGrow; self.maskFeather = maskFeather
     self.maskCropX = maskCropX; self.maskCropY = maskCropY
+    self.imagePath = imagePath; self.imageStrength = imageStrength; self.creativity = creativity
   }
 }
 
@@ -1055,7 +1071,7 @@ extension GeneratePayload: Decodable {
   private enum CodingKeys: String, CodingKey {
     case prompt, negativePrompt, width, height, steps, guidance, seed
     case outputPath, scheduler, sigmaSchedule, eta, dype
-    // inpaintImageData, maskData, denoise are excluded from JSON decoding
+    case imagePath, imageStrength, creativity
   }
 
   init(from decoder: Decoder) throws {
@@ -1079,6 +1095,9 @@ extension GeneratePayload: Decodable {
     maskFeather = nil
     maskCropX = nil
     maskCropY = nil
+    imagePath = try c.decodeIfPresent(String.self, forKey: .imagePath)
+    imageStrength = try c.decodeIfPresent(Float.self, forKey: .imageStrength)
+    creativity = try c.decodeIfPresent(Float.self, forKey: .creativity)
   }
 
   func makePipelineRequest(
@@ -1141,6 +1160,87 @@ extension GeneratePayload: Decodable {
       maskCropX: maskCropX ?? 0,
       maskCropY: maskCropY ?? 0
     )
+  }
+
+  func makeImg2ImgRequest(
+    configuration: WarmServerConfiguration,
+    activeLoRAs: [LoRAConfiguration]
+  ) throws -> Img2ImgRequest {
+    guard let imagePath else {
+      fatalError("makeImg2ImgRequest called without imagePath")
+    }
+
+    if imageStrength != nil && creativity != nil {
+      throw Img2ImgValidationError.mutuallyExclusive("imageStrength and creativity cannot both be specified")
+    }
+
+    let resolvedStrength: Float
+    let specifiedAs: Img2ImgRequest.Img2ImgSpecifier
+    if let creativity {
+      resolvedStrength = 1.0 - max(0.01, min(0.99, creativity))
+      specifiedAs = .creativity
+    } else {
+      resolvedStrength = imageStrength ?? 0.3
+      specifiedAs = .strength
+    }
+
+    let schedulerKind = scheduler.flatMap { SchedulerKind(rawValue: $0) } ?? .euler
+    let sigmaScheduleKind = sigmaSchedule.flatMap { SigmaScheduleKind(rawValue: $0) } ?? .flow
+
+    let resolvedWidth = width ?? ZImageModelMetadata.recommendedWidth
+    let resolvedHeight = height ?? ZImageModelMetadata.recommendedHeight
+    let dyPEConfig: DyPEConfig
+    if let dypeRaw = dype?.lowercased() {
+      switch dypeRaw {
+      case "ntk": dyPEConfig = .ntk
+      case "yarn": dyPEConfig = .yarn
+      default: dyPEConfig = .disabled
+      }
+    } else if max(resolvedWidth, resolvedHeight) > 1024 {
+      dyPEConfig = .ntk
+    } else {
+      dyPEConfig = .disabled
+    }
+
+    let outputURL: URL
+    if let outputPath, !outputPath.isEmpty {
+      outputURL = URL(fileURLWithPath: outputPath)
+    } else {
+      outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("zimage-img2img-\(UUID().uuidString).png")
+    }
+
+    return Img2ImgRequest(
+      prompt: prompt,
+      negativePrompt: negativePrompt,
+      width: width,
+      height: height,
+      steps: steps ?? ZImageModelMetadata.recommendedInferenceSteps,
+      guidanceScale: guidance ?? ZImageModelMetadata.recommendedGuidanceScale,
+      seed: seed,
+      outputPath: outputURL,
+      model: configuration.modelSpec,
+      textEncoderPath: configuration.textEncoderPath,
+      maxSequenceLength: configuration.maxSequenceLength,
+      loras: activeLoRAs,
+      forceTransformerOverrideOnly: configuration.forceTransformerOverrideOnly,
+      schedulerKind: schedulerKind,
+      sigmaSchedule: sigmaScheduleKind,
+      eta: eta,
+      dyPE: dyPEConfig,
+      sourceImagePath: imagePath,
+      strength: resolvedStrength,
+      specifiedAs: specifiedAs
+    )
+  }
+
+  enum Img2ImgValidationError: Error, LocalizedError {
+    case mutuallyExclusive(String)
+    var errorDescription: String? {
+      switch self {
+      case .mutuallyExclusive(let msg): return msg
+      }
+    }
   }
 }
 

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -75,6 +75,11 @@ struct ZImageCLI {
     var resumeBatchPath: String?
     var promptFilePath: String?
 
+    // --- Img2img ---
+    var imagePath: String?
+    var imageStrength: Float?
+    var imageCreativity: Float?
+
     let args = Array(CommandLine.arguments.dropFirst())
     var iterator = args.makeIterator()
 
@@ -165,6 +170,12 @@ struct ZImageCLI {
         resumeBatchPath = nextValue(for: arg, iterator: &iterator)
       case "--prompt-file":
         promptFilePath = nextValue(for: arg, iterator: &iterator)
+      case "--image-path", "--image":
+        imagePath = nextValue(for: arg, iterator: &iterator)
+      case "--image-strength":
+        imageStrength = floatValue(for: arg, iterator: &iterator, fallback: 0.3)
+      case "--creativity":
+        imageCreativity = floatValue(for: arg, iterator: &iterator, fallback: 0.7)
       case "--help", "-h":
         printUsage()
         return
@@ -252,6 +263,19 @@ struct ZImageCLI {
     guard let prompt else {
       printUsage()
       return
+    }
+
+    // Validate img2img flags
+    if imageStrength != nil && imageCreativity != nil {
+      fputs("Error: --image-strength and --creativity are mutually exclusive.\n", stderr)
+      exit(1)
+    }
+    if imagePath != nil && (imageStrength == nil && imageCreativity == nil) {
+      imageStrength = 0.3
+    }
+    if (imageStrength != nil || imageCreativity != nil) && imagePath == nil {
+      fputs("Error: --image-strength/--creativity requires --image-path.\n", stderr)
+      exit(1)
     }
 
     if let limit = cacheLimit {
@@ -403,6 +427,137 @@ struct ZImageCLI {
           print("Checkpoint: \(checkpoint)")
         }
       }
+      return
+    }
+
+    // === IMG2IMG PATH ===
+    if let imagePath {
+      let resolvedStrength: Float
+      let specifiedAs: Img2ImgRequest.Img2ImgSpecifier
+      if let creativity = imageCreativity {
+        resolvedStrength = 1.0 - max(0.01, min(0.99, creativity))
+        specifiedAs = .creativity
+      } else {
+        resolvedStrength = imageStrength ?? 0.3
+        specifiedAs = .strength
+      }
+      let specifiedValue = specifiedAs == .creativity ? (imageCreativity ?? 0.7) : resolvedStrength
+
+      let img2imgRequest = Img2ImgRequest(
+        prompt: prompt,
+        negativePrompt: negativePrompt,
+        width: width == ZImageModelMetadata.recommendedWidth ? nil : width,
+        height: height == ZImageModelMetadata.recommendedHeight ? nil : height,
+        steps: steps,
+        guidanceScale: guidance,
+        seed: seed,
+        outputPath: URL(fileURLWithPath: outputPath),
+        model: model,
+        textEncoderPath: textEncoderPath,
+        maxSequenceLength: maxSequenceLength,
+        loras: loraConfigs,
+        enhancePrompt: enhancePrompt,
+        enhanceMaxTokens: enhanceMaxTokens,
+        forceTransformerOverrideOnly: forceTransformerOverrideOnly,
+        schedulerKind: schedulerKind,
+        sigmaSchedule: sigmaSchedule,
+        eta: eta,
+        dyPE: dyPEConfig,
+        sourceImagePath: imagePath,
+        strength: resolvedStrength,
+        specifiedAs: specifiedAs
+      )
+
+      let pipeline = ZImagePipeline(logger: logger)
+      nonisolated(unsafe) let semaphore = DispatchSemaphore(value: 0)
+      let shouldWriteMetadata = writeMetadata
+      let capturedStartTime = Date()
+      let useBar = !noProgress && (isatty(STDERR_FILENO) != 0)
+      let bar = useBar ? ProgressBar(total: steps) : nil
+      let finalOutputPath = URL(fileURLWithPath: outputPath)
+      let shouldGenerateSVG = generateSVG
+      let svgPresetCopy = svgPreset
+      let capturedSeed = seed
+      let capturedModel = model
+      let capturedLoraConfigs = loraConfigs
+      let capturedImagePath = imagePath
+      let capturedStrength = resolvedStrength
+      let capturedSpecifiedAs = specifiedAs.rawValue
+      let capturedSpecifiedValue = specifiedValue
+      Task {
+        do {
+          _ = try await pipeline.generateImg2Img(img2imgRequest, progressHandler: { progress in
+            guard !noProgress else { return }
+            guard progress.stage == .denoising else { return }
+            let completed = min(progress.totalSteps, max(0, progress.stepIndex))
+            if let bar {
+              bar.update(completed: completed)
+              if completed == progress.totalSteps {
+                bar.finish(forceNewline: true)
+              }
+            } else {
+              PlainProgress.shared.report(completed: completed, total: progress.totalSteps)
+            }
+          })
+          if let bar { bar.finish(forceNewline: true) }
+          if shouldWriteMetadata {
+            let loraInfos = capturedLoraConfigs.map { lora -> LoRAInfo in
+              let path: String
+              switch lora.source {
+              case .local(let url): path = url.path
+              case .huggingFace(let id, _): path = id
+              }
+              return LoRAInfo(path: path, scale: lora.scale)
+            }
+            let metadata = GenerationMetadata(
+              pipeline: .img2img,
+              model: ModelInfo(
+                family: "zimage",
+                variant: "turbo",
+                path: capturedModel ?? ZImageRepository.id
+              ),
+              parameters: GenerationParameters(
+                prompt: prompt,
+                negativePrompt: negativePrompt,
+                seed: capturedSeed ?? 0,
+                steps: steps,
+                guidance: guidance,
+                width: width,
+                height: height,
+                scheduler: schedulerKind.rawValue,
+                sigmaSchedule: sigmaSchedule == .flow ? nil : sigmaSchedule.rawValue
+              ),
+              img2img: Img2ImgInfo(
+                sourceImage: capturedImagePath,
+                strength: capturedStrength,
+                specifiedAs: capturedSpecifiedAs,
+                specifiedValue: capturedSpecifiedValue
+              ),
+              loras: loraInfos,
+              output: OutputInfo(
+                path: finalOutputPath.path,
+                width: width,
+                height: height,
+                renderTimeSeconds: Date().timeIntervalSince(capturedStartTime)
+              )
+            )
+            if let written = MetadataWriter.write(metadata, for: finalOutputPath.path) {
+              logger.info("Metadata written: \(written)")
+            }
+          }
+          if shouldGenerateSVG {
+            let svgOutputPath = finalOutputPath.deletingPathExtension().appendingPathExtension("svg")
+            logger.info("Converting to SVG: \(svgOutputPath.path)")
+            try convertToSVG(input: finalOutputPath, output: svgOutputPath, preset: svgPresetCopy)
+            logger.info("SVG generated: \(svgOutputPath.path)")
+          }
+        } catch {
+          logger.error("Img2img generation failed: \(error)")
+          if let bar { bar.finish(forceNewline: true) }
+        }
+        semaphore.signal()
+      }
+      semaphore.wait()
       return
     }
 
@@ -609,6 +764,12 @@ struct ZImageCLI {
       --seed                 Random seed (repeatable for batch: --seed 42 --seed 99)
       --resume-batch <path>  Resume batch from checkpoint file
       --prompt-file <path>   Re-read prompt from file before each batch iteration
+
+    Img2img:
+      --image-path, --image  Source image for img2img transformation
+      --image-strength       Strength (0.0-1.0): 0.3=heavy rework (default), 0.7=light touch
+      --creativity           Creativity (0.0-1.0): 0.7=heavy rework, 0.3=light touch (inverse of strength)
+                             Cannot be used with --image-strength
       --help, -h             Show help
 
     Subcommands:


### PR DESCRIPTION
## Summary
- **New**: `ImageToImagePipeline.swift` — img2img via delegation to inpainting path with synthetic all-white mask
- **Modified**: CLI gains `--image-path`, `--image-strength`, `--creativity` flags with mutual exclusion validation
- **Modified**: WarmServer `/v1/generate` endpoint accepts `imagePath`, `imageStrength`, `creativity` for HTTP API

## Design
Delegates to the existing inpainting code path rather than duplicating the denoising loop. An all-white mask means "regenerate everything" — the VAE encode + noise blending + partial denoise logic is proven and battle-tested.

Strength convention matches Python mflux exactly:
- `strength 0.3` → heavy rework (7 of 9 steps, default)
- `strength 0.7` → light touch (3 of 9 steps)
- Conversion: `denoise = 1.0 - strength`

## Test plan
- [ ] `ZImageCLI --image-path input.png --prompt "oil painting" --image-strength 0.3` — heavy rework
- [ ] Verify mutual exclusion: `--image-strength` and `--creativity` together → error
- [ ] WarmServer: `POST /v1/generate` with `imagePath` field → routes to img2img
- [ ] Metadata sidecar: verify `pipeline: img2img` and `img2img` block populated
- [ ] Build: `swift build -c release` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)