### PR TITLE
feat(flux2): port Flux2 VAE from mflux

### DIFF
--- a/Sources/ZImage/Flux2/VAE/Flux2BatchNormStats.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2BatchNormStats.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Pre-computed batch normalization statistics for the Flux2 VAE packed latent pipeline.
+///
+/// Unlike standard BatchNorm, this module does not learn gamma/beta parameters.
+/// It stores only running mean and variance loaded from model weights, used to
+/// un-normalize packed latents before decoding.
+///
+/// ## Weight Keys
+///
+/// - `running_mean`: Shape `(num_features,)` -- loaded from checkpoint
+/// - `running_var`: Shape `(num_features,)` -- loaded from checkpoint
+public final class Flux2BatchNormStats: Module {
+
+  /// Running mean loaded from checkpoint. Shape `(num_features,)`.
+  @ModuleInfo(key: "running_mean") var runningMean: MLXArray
+
+  /// Running variance loaded from checkpoint. Shape `(num_features,)`.
+  @ModuleInfo(key: "running_var") var runningVar: MLXArray
+
+  /// Small constant for numerical stability.
+  public let eps: Float
+
+  /// Creates a batch norm statistics container.
+  ///
+  /// - Parameters:
+  ///   - numFeatures: Number of channels/features.
+  ///   - eps: Epsilon for numerical stability. Default `1e-4`.
+  public init(numFeatures: Int, eps: Float = 1e-4) {
+    self.eps = eps
+    self._runningMean.wrappedValue = MLXArray.zeros([numFeatures])
+    self._runningVar.wrappedValue = MLXArray.ones([numFeatures])
+    super.init()
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Decoder.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Decoder.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Up-decoder block for the Flux2 VAE.
+///
+/// Contains a sequence of ResNet blocks followed by an optional upsampler.
+/// All operations use NHWC layout.
+private final class Flux2UpDecoderBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "upsamplers") var upsamplers: [Flux2Upsample]
+
+  /// Creates an up-decoder block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of ResNet blocks. Default `3`.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addUpsample: Whether to add an upsampler. Default `true`.
+  init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 3,
+    groups: Int = 32,
+    eps: Float = 1e-6,
+    addUpsample: Bool = true
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      Flux2ResnetBlock(
+        inChannels: i == 0 ? inChannels : outChannels,
+        outChannels: outChannels,
+        groups: groups,
+        eps: eps)
+    }
+    self._upsamplers.wrappedValue = addUpsample
+      ? [Flux2Upsample(channels: outChannels, outChannels: outChannels)]
+      : []
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for upsampler in upsamplers {
+      hidden = upsampler(hidden)
+    }
+    return hidden
+  }
+}
+
+/// Decoder for the Flux2 VAE.
+///
+/// Takes latent features in NHWC layout and reconstructs an image. The architecture
+/// mirrors the encoder: conv_in, mid block, a series of up-decoder blocks,
+/// normalization, and conv_out.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H/8, W/8, 32)
+///   -> Conv2d(32 -> 512, k=3, p=1)            // conv_in
+///   -> MidBlock(512, attention)
+///   -> UpBlock(512 -> 512, upsample)
+///   -> UpBlock(512 -> 512, upsample)
+///   -> UpBlock(512 -> 256, upsample)
+///   -> UpBlock(256 -> 128, no upsample)        // final block
+///   -> GroupNorm(32, 128)
+///   -> SiLU
+///   -> Conv2d(128 -> 3, k=3, p=1)             // conv_out
+///   -> Output (B, H, W, 3)
+/// ```
+public final class Flux2Decoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: Conv2d
+  @ModuleInfo(key: "mid_block") var midBlock: Flux2MidBlock
+  @ModuleInfo(key: "up_blocks") fileprivate var upBlocks: [Flux2UpDecoderBlock]
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+  @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+  /// Creates a Flux2 VAE decoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of latent channels. Default `32`.
+  ///   - outChannels: Number of output channels (RGB = 3). Default `3`.
+  ///   - blockOutChannels: Channel counts per stage (in encoder order). Default `[128, 256, 512, 512]`.
+  ///   - layersPerBlock: Number of ResNet blocks per stage (decoder adds 1). Default `2`.
+  ///   - normNumGroups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - midBlockAddAttention: Whether the mid block includes attention. Default `true`.
+  public init(
+    inChannels: Int = 32,
+    outChannels: Int = 3,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 2,
+    normNumGroups: Int = 32,
+    eps: Float = 1e-6,
+    midBlockAddAttention: Bool = true
+  ) {
+    // Decoder processes channels in reverse order
+    let reversedChannels = Array(blockOutChannels.reversed())
+
+    self._convIn.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: reversedChannels[0],
+      kernelSize: 3, stride: 1, padding: 1)
+
+    self._midBlock.wrappedValue = Flux2MidBlock(
+      channels: reversedChannels[0],
+      groups: normNumGroups,
+      eps: eps,
+      addAttention: midBlockAddAttention)
+
+    var ups: [Flux2UpDecoderBlock] = []
+    for (i, outCh) in reversedChannels.enumerated() {
+      let prevOutCh = i == 0 ? outCh : reversedChannels[i - 1]
+      let isFinal = i == reversedChannels.count - 1
+      ups.append(Flux2UpDecoderBlock(
+        inChannels: prevOutCh,
+        outChannels: outCh,
+        numLayers: layersPerBlock + 1,
+        groups: normNumGroups,
+        eps: eps,
+        addUpsample: !isFinal))
+    }
+    self._upBlocks.wrappedValue = ups
+
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: normNumGroups, dimensions: blockOutChannels[0],
+      eps: eps, pytorchCompatible: true)
+
+    self._convOut.wrappedValue = Conv2d(
+      inputChannels: blockOutChannels[0], outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    super.init()
+  }
+
+  /// Decodes latent features into an image.
+  ///
+  /// - Parameter x: Latent tensor in NHWC layout `(B, H/8, W/8, latent_channels)`.
+  /// - Returns: Decoded image in NHWC layout `(B, H, W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = convIn(x)
+    hidden = midBlock(hidden)
+    for block in upBlocks {
+      hidden = block(hidden)
+    }
+    hidden = convNormOut(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Downsample.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Downsample.swift
@@ -1,0 +1,45 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Stride-2 convolution downsampling for the Flux2 VAE encoder.
+///
+/// Uses a 3x3 convolution with stride 2 to halve spatial dimensions.
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> pad (right and bottom by 1)
+///   -> Conv2d(C -> C, k=3, s=2, p=0)
+///   -> Output (B, H/2, W/2, C)
+/// ```
+///
+/// Note: The Python source uses `padding=0` for the downsample conv, which
+/// means asymmetric padding (pad-then-conv) is needed to match behavior.
+public final class Flux2Downsample: Module {
+
+  @ModuleInfo(key: "conv") var conv: Conv2d
+
+  /// Creates a Flux2 stride-2 downsampling layer.
+  ///
+  /// - Parameter channels: Number of input/output channels.
+  public init(channels: Int) {
+    // Python uses padding=0 on the conv, with asymmetric pad before
+    self._conv.wrappedValue = Conv2d(
+      inputChannels: channels, outputChannels: channels,
+      kernelSize: 3, stride: 2)
+    super.init()
+  }
+
+  /// Applies stride-2 downsampling.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H/2, W/2, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // Pad right and bottom by 1 (NHWC: pad H and W dims)
+    let padded = padded(x, widths: [[0, 0], [0, 1], [0, 1], [0, 0]])
+    return conv(padded)
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Encoder.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Encoder.swift
@@ -1,0 +1,154 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Down-encoder block for the Flux2 VAE.
+///
+/// Contains a sequence of ResNet blocks followed by an optional downsampler.
+/// All operations use NHWC layout.
+private final class Flux2DownEncoderBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "downsamplers") var downsamplers: [Flux2Downsample]
+
+  /// Creates a down-encoder block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of ResNet blocks. Default `2`.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addDownsample: Whether to add a downsampler. Default `true`.
+  init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 2,
+    groups: Int = 32,
+    eps: Float = 1e-6,
+    addDownsample: Bool = true
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      Flux2ResnetBlock(
+        inChannels: i == 0 ? inChannels : outChannels,
+        outChannels: outChannels,
+        groups: groups,
+        eps: eps)
+    }
+    self._downsamplers.wrappedValue = addDownsample
+      ? [Flux2Downsample(channels: outChannels)]
+      : []
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for downsampler in downsamplers {
+      hidden = downsampler(hidden)
+    }
+    return hidden
+  }
+}
+
+/// Encoder for the Flux2 VAE.
+///
+/// Takes an image in NHWC layout and produces latent features. The architecture
+/// follows a standard VAE encoder pattern: conv_in, a series of down-encoder
+/// blocks, a mid block, normalization, and conv_out.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, 3)
+///   -> Conv2d(3 -> 128, k=3, p=1)           // conv_in
+///   -> DownBlock(128 -> 128, downsample)
+///   -> DownBlock(128 -> 256, downsample)
+///   -> DownBlock(256 -> 512, downsample)
+///   -> DownBlock(512 -> 512, no downsample)  // final block
+///   -> MidBlock(512, attention)
+///   -> GroupNorm(32, 512)
+///   -> SiLU
+///   -> Conv2d(512 -> 64, k=3, p=1)          // conv_out (2 * latent_channels)
+///   -> Output (B, H/8, W/8, 64)
+/// ```
+public final class Flux2Encoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: Conv2d
+  @ModuleInfo(key: "down_blocks") fileprivate var downBlocks: [Flux2DownEncoderBlock]
+  @ModuleInfo(key: "mid_block") var midBlock: Flux2MidBlock
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+  @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+  /// Creates a Flux2 VAE encoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels (RGB = 3). Default `3`.
+  ///   - outChannels: Number of latent channels. Default `32`.
+  ///   - blockOutChannels: Channel counts per stage. Default `[128, 256, 512, 512]`.
+  ///   - layersPerBlock: Number of ResNet blocks per stage. Default `2`.
+  ///   - normNumGroups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - midBlockAddAttention: Whether the mid block includes attention. Default `true`.
+  public init(
+    inChannels: Int = 3,
+    outChannels: Int = 32,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 2,
+    normNumGroups: Int = 32,
+    eps: Float = 1e-6,
+    midBlockAddAttention: Bool = true
+  ) {
+    self._convIn.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: blockOutChannels[0],
+      kernelSize: 3, stride: 1, padding: 1)
+
+    var downs: [Flux2DownEncoderBlock] = []
+    for (i, outCh) in blockOutChannels.enumerated() {
+      let inCh = i > 0 ? blockOutChannels[i - 1] : blockOutChannels[0]
+      let isFinal = i == blockOutChannels.count - 1
+      downs.append(Flux2DownEncoderBlock(
+        inChannels: inCh,
+        outChannels: outCh,
+        numLayers: layersPerBlock,
+        groups: normNumGroups,
+        eps: eps,
+        addDownsample: !isFinal))
+    }
+    self._downBlocks.wrappedValue = downs
+
+    self._midBlock.wrappedValue = Flux2MidBlock(
+      channels: blockOutChannels.last!,
+      groups: normNumGroups,
+      eps: eps,
+      addAttention: midBlockAddAttention)
+
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: normNumGroups, dimensions: blockOutChannels.last!,
+      eps: eps, pytorchCompatible: true)
+
+    self._convOut.wrappedValue = Conv2d(
+      inputChannels: blockOutChannels.last!, outputChannels: 2 * outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    super.init()
+  }
+
+  /// Encodes an image into latent features.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C_in)`.
+  /// - Returns: Encoded features in NHWC layout `(B, H/8, W/8, 2*latent_channels)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = convIn(x)
+    for block in downBlocks {
+      hidden = block(hidden)
+    }
+    hidden = midBlock(hidden)
+    hidden = convNormOut(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2MidBlock.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2MidBlock.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// UNet-style mid block for the Flux2 VAE encoder and decoder.
+///
+/// Contains two ResNet blocks with an optional attention block between them.
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> ResNet(C -> C)
+///   -> [Attention(C)]   (optional)
+///   -> ResNet(C -> C)
+///   -> Output (B, H, W, C)
+/// ```
+public final class Flux2MidBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "attentions") var attentions: [Flux2VAEAttention]
+
+  /// Creates a Flux2 VAE mid block.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of channels (constant through the block).
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addAttention: Whether to include an attention block. Default `true`.
+  public init(channels: Int, groups: Int = 32, eps: Float = 1e-6, addAttention: Bool = true) {
+    self._resnets.wrappedValue = [
+      Flux2ResnetBlock(inChannels: channels, outChannels: channels, groups: groups, eps: eps),
+      Flux2ResnetBlock(inChannels: channels, outChannels: channels, groups: groups, eps: eps),
+    ]
+    self._attentions.wrappedValue = addAttention
+      ? [Flux2VAEAttention(channels: channels, groups: groups, eps: eps)]
+      : []
+    super.init()
+  }
+
+  /// Applies the mid block.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = resnets[0](x)
+    if !attentions.isEmpty {
+      hidden = attentions[0](hidden)
+    }
+    hidden = resnets[1](hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2ResnetBlock.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2ResnetBlock.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// ResNet block for the Flux2 VAE encoder and decoder.
+///
+/// Two group-norm + SiLU + conv layers with a residual connection.
+/// When input and output channel counts differ, a 1x1 shortcut convolution
+/// adapts the residual path.
+///
+/// All operations use NHWC layout (the native layout for MLX Conv2d / GroupNorm).
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C_in)
+///   |-- GroupNorm(32, C_in) -> SiLU -> Conv2d(C_in -> C_out, k=3, p=1)
+///   |-- GroupNorm(32, C_out) -> SiLU -> Conv2d(C_out -> C_out, k=3, p=1)
+///   |-- + residual (with optional 1x1 shortcut if C_in != C_out)
+///   --> Output (B, H, W, C_out)
+/// ```
+public final class Flux2ResnetBlock: Module {
+
+  @ModuleInfo(key: "norm1") var norm1: GroupNorm
+  @ModuleInfo(key: "norm2") var norm2: GroupNorm
+  @ModuleInfo(key: "conv1") var conv1: Conv2d
+  @ModuleInfo(key: "conv2") var conv2: Conv2d
+  @ModuleInfo(key: "conv_shortcut") var convShortcut: Conv2d?
+
+  /// Whether a shortcut convolution is needed.
+  public let hasShortcut: Bool
+
+  /// Creates a Flux2 ResNet block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  public init(inChannels: Int, outChannels: Int, groups: Int = 32, eps: Float = 1e-6) {
+    self.hasShortcut = inChannels != outChannels
+
+    self._norm1.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: inChannels, eps: eps, pytorchCompatible: true)
+    self._norm2.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: outChannels, eps: eps, pytorchCompatible: true)
+    self._conv1.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+    self._conv2.wrappedValue = Conv2d(
+      inputChannels: outChannels, outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    if hasShortcut {
+      self._convShortcut.wrappedValue = Conv2d(
+        inputChannels: inChannels, outputChannels: outChannels,
+        kernelSize: 1, stride: 1)
+    }
+
+    super.init()
+  }
+
+  /// Applies the residual block.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C_in)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let residual = hasShortcut ? convShortcut!(x) : x
+
+    var hidden = norm1(x.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = conv1(hidden)
+    hidden = norm2(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = conv2(hidden)
+
+    return hidden + residual
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Upsample.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Upsample.swift
@@ -1,0 +1,43 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// 2x nearest-neighbor upsampling followed by a 3x3 convolution for the Flux2 VAE decoder.
+///
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> nearest-neighbor 2x upsample -> (B, 2H, 2W, C)
+///   -> Conv2d(C -> C_out, k=3, p=1)
+///   -> Output (B, 2H, 2W, C_out)
+/// ```
+public final class Flux2Upsample: Module {
+
+  @ModuleInfo(key: "conv") var conv: Conv2d
+
+  /// Creates a Flux2 2x upsampling layer.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input channels.
+  ///   - outChannels: Number of output channels. If `nil`, uses `channels`.
+  public init(channels: Int, outChannels: Int? = nil) {
+    let out = outChannels ?? channels
+    self._conv.wrappedValue = Conv2d(
+      inputChannels: channels, outputChannels: out,
+      kernelSize: 3, stride: 1, padding: 1)
+    super.init()
+  }
+
+  /// Applies 2x nearest-neighbor upsampling and convolution.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, 2H, 2W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // Nearest-neighbor 2x upsample using MLXNN.Upsample
+    let upsampled = Upsample(scaleFactor: .array([2.0, 2.0]), mode: .nearest)(x)
+    return conv(upsampled)
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2VAE.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2VAE.swift
@@ -1,0 +1,186 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Top-level VAE for the Flux2 image generation model.
+///
+/// The Flux2 VAE is a completely different architecture from the Flux1 AutoencoderKL.
+/// It uses batch normalization statistics for packed latent decoding, different block
+/// structures, and 32 latent channels (vs 16 for Flux1).
+///
+/// ## Key Differences from Flux1
+///
+/// | Feature | Flux1 (AutoencoderKL) | Flux2 (Flux2VAE) |
+/// |---------|----------------------|------------------|
+/// | Latent channels | 16 | 32 |
+/// | Scaling factor | 0.3611 | 1.0 |
+/// | Shift factor | 0.1159 | 0.0 |
+/// | Packed latents | No | Yes (decode_packed_latents) |
+/// | Batch norm stats | No | Yes (for unpacking) |
+/// | quant_conv / post_quant_conv | No | Yes (1x1 convolutions) |
+///
+/// ## Decode Pipeline
+///
+/// The primary decode path for generation is `decodePackedLatents`:
+///
+/// ```
+/// Packed latents (B, 4*C, H/2, W/2) in NCHW
+///   -> un-normalize using batch norm stats (mean + std)
+///   -> unpatchify: (B, 4*C, H/2, W/2) -> (B, C, H, W)
+///   -> scale/shift: (x / scaling_factor) + shift_factor
+///   -> NCHW -> NHWC transpose
+///   -> post_quant_conv (1x1)
+///   -> NHWC -> NCHW transpose (for decoder entry in Python; we stay NHWC)
+///   -> decoder
+///   -> NCHW -> NHWC transpose (Python output; we're already NHWC)
+///   -> Output image (B, H, W, 3) in NHWC
+/// ```
+public final class Flux2VAE: Module, VAEImageDecoding {
+
+  /// Scaling factor for latents. Flux2 uses 1.0 (no scaling).
+  public let scalingFactor: Float = 1.0
+
+  /// Shift factor for latents. Flux2 uses 0.0 (no shift).
+  public let shiftFactor: Float = 0.0
+
+  /// Number of latent channels.
+  public let latentChannels: Int = 32
+
+  @ModuleInfo(key: "encoder") var encoder: Flux2Encoder
+  @ModuleInfo(key: "decoder") var decoder: Flux2Decoder
+  @ModuleInfo(key: "quant_conv") var quantConv: Conv2d
+  @ModuleInfo(key: "post_quant_conv") var postQuantConv: Conv2d
+  @ModuleInfo(key: "bn") var bn: Flux2BatchNormStats
+
+  /// Creates a Flux2 VAE.
+  public override init() {
+    self._encoder.wrappedValue = Flux2Encoder(
+      inChannels: 3, outChannels: 32,
+      blockOutChannels: [128, 256, 512, 512])
+    self._decoder.wrappedValue = Flux2Decoder(
+      inChannels: 32, outChannels: 3,
+      blockOutChannels: [128, 256, 512, 512])
+    self._quantConv.wrappedValue = Conv2d(
+      inputChannels: 2 * 32, outputChannels: 2 * 32,
+      kernelSize: 1, stride: 1)
+    self._postQuantConv.wrappedValue = Conv2d(
+      inputChannels: 32, outputChannels: 32,
+      kernelSize: 1, stride: 1)
+    self._bn.wrappedValue = Flux2BatchNormStats(numFeatures: 4 * 32, eps: 1e-4)
+    super.init()
+  }
+
+  /// Encodes an image into latent space.
+  ///
+  /// - Parameter image: Image tensor in NCHW layout `(B, 3, H, W)` or `(B, 3, 1, H, W)`.
+  /// - Returns: Latent tensor in NCHW layout `(B, latent_channels, H/8, W/8)`.
+  public func encode(_ image: MLXArray) -> MLXArray {
+    var x = image
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // NCHW -> NHWC for encoder
+    x = x.transposed(0, 2, 3, 1)
+    x = encoder(x)
+
+    // NHWC -> NCHW for quant_conv, then back to NHWC
+    x = x.transposed(0, 3, 1, 2)
+    x = x.transposed(0, 2, 3, 1)
+    x = quantConv(x)
+    x = x.transposed(0, 3, 1, 2)
+
+    // Split mean/logvar, keep mean
+    let parts = split(x, parts: 2, axis: 1)
+    let mean = parts[0]
+
+    // Apply scaling
+    return (mean - shiftFactor) * scalingFactor
+  }
+
+  /// Decodes latent features into an image.
+  ///
+  /// This implements the standard VAE decode path (not packed latents).
+  ///
+  /// - Parameter latents: Latent tensor in NCHW layout `(B, latent_channels, H/8, W/8)`.
+  /// - Returns: Decoded image in NCHW layout `(B, 3, H, W)`.
+  public func decodeLatents(_ latents: MLXArray) -> MLXArray {
+    var x = latents
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // Un-scale
+    x = (x / scalingFactor) + shiftFactor
+
+    // NCHW -> NHWC for post_quant_conv
+    x = x.transposed(0, 2, 3, 1)
+    x = postQuantConv(x)
+
+    // Decode (stays in NHWC)
+    x = decoder(x)
+
+    // NHWC -> NCHW for output
+    return x.transposed(0, 3, 1, 2)
+  }
+
+  /// Decodes packed latents into an image.
+  ///
+  /// This is the primary decode path used during Flux2 image generation.
+  /// Packed latents have their channels patchified (4x channels, half spatial size)
+  /// and are normalized by batch norm statistics.
+  ///
+  /// - Parameter packedLatents: Packed latent tensor in NCHW layout
+  ///   `(B, 4*latent_channels, H/16, W/16)` or with temporal dim `(B, 4*C, 1, H/16, W/16)`.
+  /// - Returns: Decoded image in NCHW layout `(B, 3, H, W)`.
+  public func decodePackedLatents(_ packedLatents: MLXArray) -> MLXArray {
+    var x = packedLatents
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // Un-normalize using batch norm running statistics
+    // bn_mean: (1, num_features, 1, 1), bn_std: (1, num_features, 1, 1)
+    let bnMean = bn.runningMean.reshaped(1, -1, 1, 1)
+    let bnStd = sqrt(bn.runningVar.reshaped(1, -1, 1, 1) + bn.eps)
+    x = x * bnStd + bnMean
+
+    // Unpatchify: (B, 4*C, H/2, W/2) -> (B, C, H, W)
+    x = Flux2VAE.unpatchifyLatents(x)
+
+    // Standard decode
+    return decodeLatents(x)
+  }
+
+  /// VAEImageDecoding conformance -- delegates to standard latent decode.
+  ///
+  /// - Parameters:
+  ///   - latents: Latent tensor in NCHW layout.
+  ///   - return_dict: Ignored (kept for protocol conformance).
+  /// - Returns: Tuple of decoded image and empty dict.
+  public func decode(_ latents: MLXArray, return_dict: Bool = false) -> (MLXArray, Any) {
+    let decoded = decodeLatents(latents)
+    return (decoded, [:] as [String: Int])
+  }
+
+  /// Unpatchifies latents from packed format to standard spatial layout.
+  ///
+  /// Converts `(B, 4*C, H, W)` -> `(B, C, 2*H, 2*W)` by rearranging the
+  /// channel dimension into 2x2 spatial patches.
+  ///
+  /// - Parameter latents: Packed latent tensor `(B, 4*C, H, W)` in NCHW.
+  /// - Returns: Unpatchified tensor `(B, C, 2*H, 2*W)` in NCHW.
+  static func unpatchifyLatents(_ latents: MLXArray) -> MLXArray {
+    let (batch, numChannels, height, width) = (latents.shape[0], latents.shape[1], latents.shape[2], latents.shape[3])
+    // (B, 4C, H, W) -> (B, C, 2, 2, H, W)
+    var x = latents.reshaped(batch, numChannels / 4, 2, 2, height, width)
+    // (B, C, 2, 2, H, W) -> (B, C, H, 2, W, 2)
+    x = x.transposed(0, 1, 4, 2, 5, 3)
+    // (B, C, H, 2, W, 2) -> (B, C, 2H, 2W)
+    x = x.reshaped(batch, numChannels / 4, height * 2, width * 2)
+    return x
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2VAEAttention.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2VAEAttention.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Self-attention block used in the Flux2 VAE mid-block.
+///
+/// Applies group normalization, then single-head scaled dot-product attention
+/// over the spatial dimensions, followed by a linear projection. Connected
+/// by a residual shortcut.
+///
+/// All operations use NHWC layout internally.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   |-- GroupNorm(32, C)
+///   |-- to_q, to_k, to_v: Linear(C -> C)
+///   |-- reshape to (B, 1, H*W, C) -> scaled_dot_product_attention
+///   |-- to_out: Linear(C -> C)
+///   |-- + residual
+///   --> Output (B, H, W, C)
+/// ```
+public final class Flux2VAEAttention: Module {
+
+  @ModuleInfo(key: "group_norm") var groupNorm: GroupNorm
+  @ModuleInfo(key: "to_q") var toQ: Linear
+  @ModuleInfo(key: "to_k") var toK: Linear
+  @ModuleInfo(key: "to_v") var toV: Linear
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  /// Creates a Flux2 VAE attention block.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input/output channels.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  public init(channels: Int, groups: Int = 32, eps: Float = 1e-6) {
+    self._groupNorm.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: channels, eps: eps, pytorchCompatible: true)
+    self._toQ.wrappedValue = Linear(channels, channels)
+    self._toK.wrappedValue = Linear(channels, channels)
+    self._toV.wrappedValue = Linear(channels, channels)
+    self._toOut.wrappedValue = Linear(channels, channels)
+    super.init()
+  }
+
+  /// Applies self-attention over spatial dimensions.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let (batch, height, width, channels) = (x.shape[0], x.shape[1], x.shape[2], x.shape[3])
+
+    let normed = groupNorm(x.asType(.float32)).asType(x.dtype)
+
+    // Project to Q, K, V and reshape for single-head attention
+    // Shape: (B, H*W, C) -> (B, H*W, 1, C) -> (B, 1, H*W, C)
+    var q = toQ(normed).reshaped(batch, height * width, 1, channels)
+    var k = toK(normed).reshaped(batch, height * width, 1, channels)
+    var v = toV(normed).reshaped(batch, height * width, 1, channels)
+
+    q = q.transposed(0, 2, 1, 3)
+    k = k.transposed(0, 2, 1, 3)
+    v = v.transposed(0, 2, 1, 3)
+
+    let scale = 1.0 / sqrt(Float(channels))
+
+    let attended = MLXFast.scaledDotProductAttention(
+      queries: q, keys: k, values: v, scale: scale, mask: nil)
+
+    // Reshape back to spatial: (B, 1, H*W, C) -> (B, H, W, C)
+    let reshaped = attended.transposed(0, 2, 1, 3).reshaped(batch, height, width, channels)
+    let projected = toOut(reshaped)
+
+    return x + projected
+  }
+}


### PR DESCRIPTION
## Summary
Port of the Flux 2 VAE (encoder + decoder) from Python mflux to Swift — PR 3 of 5 for native Flux 2 Klein support.

**9 new files** (834 lines):
- `Flux2VAE.swift` — Main VAE with encode, decode, packed latent path
- `Flux2Encoder.swift` — 4 down-encoder blocks + mid block
- `Flux2Decoder.swift` — 4 up-decoder blocks + mid block
- `Flux2ResnetBlock.swift` — GroupNorm + SiLU + Conv2d residual blocks
- `Flux2VAEAttention.swift` — Single-head SDPA for mid block
- `Flux2MidBlock.swift` — resnet-attention-resnet sandwich
- `Flux2Upsample.swift` / `Flux2Downsample.swift` — spatial scaling
- `Flux2BatchNormStats.swift` — Pre-computed running mean/var for packed latent un-normalization

## Design
- NHWC internally (MLX native), NCHW at API boundary
- Conforms to existing `VAEImageDecoding` protocol
- `@ModuleInfo(key:)` keys match Python weight names exactly
- Packed latent decode: BN un-normalize → unpatchify → standard decode

## Test plan
- [ ] Build: `swift build -c release` passes clean
- [ ] Weight loading: verify VAE weights load from Klein 4B
- [ ] Decode: verify output image dimensions match Python mflux

🤖 Generated with [Claude Code](https://claude.com/claude-code)