### PR TITLE
feat(flux2): port Flux2 transformer from mflux

### DIFF
--- a/Sources/ZImage/Flux2/Transformer/Flux2Attention.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Attention.swift
@@ -1,0 +1,166 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Cross-attention for Flux 2 double-stream transformer blocks.
+///
+/// Computes joint attention between image hidden states and encoder (text) hidden states.
+/// Both streams produce Q/K/V projections that are concatenated, RoPE-rotated, and
+/// attended jointly, then split back into separate image and encoder outputs.
+final class Flux2Attention: Module {
+  let heads: Int
+  let dimHead: Int
+  let innerDim: Int
+  let scale: Float
+
+  @ModuleInfo(key: "to_q") var toQ: Linear
+  @ModuleInfo(key: "to_k") var toK: Linear
+  @ModuleInfo(key: "to_v") var toV: Linear
+  @ModuleInfo(key: "norm_q") var normQ: RMSNorm
+  @ModuleInfo(key: "norm_k") var normK: RMSNorm
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  // Added KV projections for encoder hidden states
+  @ModuleInfo(key: "norm_added_q") var normAddedQ: RMSNorm
+  @ModuleInfo(key: "norm_added_k") var normAddedK: RMSNorm
+  @ModuleInfo(key: "add_q_proj") var addQProj: Linear
+  @ModuleInfo(key: "add_k_proj") var addKProj: Linear
+  @ModuleInfo(key: "add_v_proj") var addVProj: Linear
+  @ModuleInfo(key: "to_add_out") var toAddOut: Linear
+
+  init(dim: Int, heads: Int, dimHead: Int, addedKVProjDim: Int) {
+    self.heads = heads
+    self.dimHead = dimHead
+    self.innerDim = heads * dimHead
+    self.scale = 1.0 / sqrt(Float(dimHead))
+
+    self._toQ.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._toK.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._toV.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._normQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._toOut.wrappedValue = Linear(innerDim, dim, bias: false)
+
+    self._normAddedQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normAddedK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._addQProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._addKProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._addVProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._toAddOut.wrappedValue = Linear(innerDim, dim, bias: false)
+
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Image hidden states `[batch, imgSeq, dim]`.
+  ///   - encoderHiddenStates: Text hidden states `[batch, txtSeq, dim]`.
+  ///   - imageRotaryEmb: Tuple of `(cos, sin)` for RoPE.
+  /// - Returns: Tuple of `(imageOutput, encoderOutput)`.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> (MLXArray, MLXArray) {
+    let batch = hiddenStates.dim(0)
+    let encSeqLen = encoderHiddenStates.dim(1)
+
+    // Image Q/K/V
+    var query = processQKV(hiddenStates, proj: toQ, norm: normQ)
+    var key = processQKV(hiddenStates, proj: toK, norm: normK)
+    var value = reshapeBSHD(toV(hiddenStates), batch: batch)
+
+    // Encoder Q/K/V
+    let encQuery = processQKV(encoderHiddenStates, proj: addQProj, norm: normAddedQ)
+    let encKey = processQKV(encoderHiddenStates, proj: addKProj, norm: normAddedK)
+    let encValue = reshapeBSHD(addVProj(encoderHiddenStates), batch: batch)
+
+    // Concatenate: [enc, img] along sequence dimension
+    query = MLX.concatenated([encQuery, query], axis: 2)
+    key = MLX.concatenated([encKey, key], axis: 2)
+    value = MLX.concatenated([encValue, value], axis: 2)
+
+    // Apply RoPE
+    let (cos, sin) = imageRotaryEmb
+    (query, key) = Flux2AttentionUtils.applyRopeBSHD(query: query, key: key, cos: cos, sin: sin)
+
+    // Scaled dot-product attention
+    let attnOut = MLXFast.scaledDotProductAttention(
+      queries: query,
+      keys: key,
+      values: value,
+      scale: scale,
+      mask: nil
+    )
+    // [B, H, S, D] -> [B, S, H*D]
+    let combined = attnOut.transposed(0, 2, 1, 3).reshaped(batch, -1, innerDim)
+
+    // Split back into encoder and image
+    let encoderOut = toAddOut(combined[0..., ..<encSeqLen, 0...])
+    let imageOut = toOut(combined[0..., encSeqLen..., 0...])
+
+    return (imageOut, encoderOut)
+  }
+
+  /// Project, reshape to [B, H, S, D], normalize in float32.
+  private func processQKV(_ x: MLXArray, proj: Linear, norm: RMSNorm) -> MLXArray {
+    let batch = x.dim(0)
+    let seqLen = x.dim(1)
+    let projected = proj(x).reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    let origDtype = projected.dtype
+    return norm(projected.asType(.float32)).asType(origDtype)
+  }
+
+  /// Reshape [B, S, H*D] -> [B, H, S, D].
+  private func reshapeBSHD(_ x: MLXArray, batch: Int) -> MLXArray {
+    let seqLen = x.dim(1)
+    return x.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+  }
+}
+
+// MARK: - Flux2 RoPE Utilities
+
+/// Attention utilities specific to Flux 2's cos/sin RoPE format.
+///
+/// Flux 2 uses explicit (cos, sin) pairs rather than Flux 1's complex-valued table.
+/// The rotation formula is applied in the interleaved (real, imag) layout.
+enum Flux2AttentionUtils {
+
+  /// Apply rotary position embeddings in B,S,H,D layout using cos/sin pairs.
+  ///
+  /// - Parameters:
+  ///   - query: `[batch, heads, seq, headDim]`
+  ///   - key: `[batch, heads, seq, headDim]`
+  ///   - cos: `[seq, halfDim]`
+  ///   - sin: `[seq, halfDim]`
+  /// - Returns: Rotated `(query, key)`.
+  static func applyRopeBSHD(
+    query: MLXArray,
+    key: MLXArray,
+    cos: MLXArray,
+    sin: MLXArray
+  ) -> (MLXArray, MLXArray) {
+    let outDtype = query.dtype
+    let qf = query.asType(.float32)
+    let kf = key.asType(.float32)
+    // Broadcast cos/sin: [seq, halfDim] -> [1, 1, seq, halfDim]
+    let cosB = cos.reshaped(1, 1, cos.dim(0), cos.dim(1))
+    let sinB = sin.reshaped(1, 1, sin.dim(0), sin.dim(1))
+
+    return (mix(qf, cosB, sinB).asType(outDtype), mix(kf, cosB, sinB).asType(outDtype))
+  }
+
+  /// Rotate x using interleaved (real, imag) pairs.
+  private static func mix(_ x: MLXArray, _ cos: MLXArray, _ sin: MLXArray) -> MLXArray {
+    // x shape: [B, H, S, D] -> [B, H, S, D/2, 2]
+    var shape = x.shape
+    shape[shape.count - 1] = shape.last! / 2
+    shape.append(2)
+    let x2 = x.reshaped(shape)
+    let real = x2[0..., 0..., 0..., 0..., 0]
+    let imag = x2[0..., 0..., 0..., 0..., 1]
+    let out0 = real * cos + (-imag) * sin
+    let out1 = imag * cos + real * sin
+    return MLX.stacked([out0, out1], axis: -1).reshaped(x.shape)
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2FeedForward.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2FeedForward.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// SwiGLU activation for Flux 2.
+///
+/// Splits input in half along the last axis, applies SiLU to the first half,
+/// and element-wise multiplies with the second half.
+final class Flux2SwiGLU: Module {
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let chunks = MLX.split(x, parts: 2, axis: -1)
+    return silu(chunks[0]) * chunks[1]
+  }
+}
+
+/// Feed-forward network (SwiGLU) for Flux 2 double-stream transformer blocks.
+///
+/// Projects `dim` -> `innerDim * 2` (for SwiGLU gate+value), applies SwiGLU,
+/// then projects `innerDim` -> `dim`.
+final class Flux2FeedForward: Module {
+  @ModuleInfo(key: "linear_in") var linearIn: Linear
+  @ModuleInfo(key: "act") var act: Flux2SwiGLU
+  @ModuleInfo(key: "linear_out") var linearOut: Linear
+
+  init(dim: Int, mult: Float = 3.0) {
+    let innerDim = Int(Float(dim) * mult)
+    self._linearIn.wrappedValue = Linear(dim, innerDim * 2, bias: false)
+    self._act.wrappedValue = Flux2SwiGLU()
+    self._linearOut.wrappedValue = Linear(innerDim, dim, bias: false)
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    linearOut(act(linearIn(x)))
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2Modulation.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Modulation.swift
@@ -1,0 +1,49 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Adaptive modulation for Flux 2 transformer blocks.
+///
+/// Produces shift/scale/gate parameter sets from the timestep embedding.
+/// Double-stream blocks use `modParamSets=2` (one set per norm),
+/// single-stream blocks use `modParamSets=1`.
+final class Flux2Modulation: Module {
+  let modParamSets: Int
+
+  @ModuleInfo(key: "linear") var linear: Linear
+
+  init(dim: Int, modParamSets: Int = 2) {
+    self.modParamSets = modParamSets
+    self._linear.wrappedValue = Linear(dim, dim * 3 * modParamSets, bias: false)
+    super.init()
+  }
+
+  /// Compute modulation parameters from timestep embedding.
+  ///
+  /// - Parameter temb: Timestep embedding of shape `[batch, dim]`.
+  /// - Returns: Array of `modParamSets` tuples, each containing `(shift, scale, gate)`.
+  func callAsFunction(_ temb: MLXArray) -> [[(MLXArray)]] {
+    var mod = linear(silu(temb))
+    if mod.ndim == 2 {
+      mod = mod.expandedDimensions(axis: 1)
+    }
+
+    // Split into 3 * modParamSets chunks along last axis
+    let totalChunks = 3 * modParamSets
+    let chunkSize = mod.dim(-1) / totalChunks
+    var allParams: [MLXArray] = []
+    for c in 0..<totalChunks {
+      let start = c * chunkSize
+      let end = (c + 1) * chunkSize
+      allParams.append(mod[0..., 0..., start..<end])
+    }
+
+    // Group into sets of 3: (shift, scale, gate)
+    var result: [[(MLXArray)]] = []
+    for i in 0..<modParamSets {
+      let base = 3 * i
+      result.append([allParams[base], allParams[base + 1], allParams[base + 2]])
+    }
+    return result
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2ParallelSelfAttention.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2ParallelSelfAttention.swift
@@ -1,0 +1,90 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Parallel self-attention with fused QKV + MLP projection for Flux 2 single-stream blocks.
+///
+/// A single linear projection produces Q, K, V for attention AND the MLP hidden state
+/// simultaneously. After attention and SwiGLU, the outputs are concatenated and projected
+/// back to the model dimension. This fused approach is more efficient than separate
+/// attention + MLP passes.
+final class Flux2ParallelSelfAttention: Module {
+  let heads: Int
+  let dimHead: Int
+  let innerDim: Int
+  let mlpHiddenDim: Int
+  let scale: Float
+
+  @ModuleInfo(key: "to_qkv_mlp_proj") var toQkvMlpProj: Linear
+  @ModuleInfo(key: "norm_q") var normQ: RMSNorm
+  @ModuleInfo(key: "norm_k") var normK: RMSNorm
+  @ModuleInfo(key: "mlp_act") var mlpAct: Flux2SwiGLU
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  init(dim: Int, heads: Int, dimHead: Int, mlpRatio: Float = 3.0) {
+    self.heads = heads
+    self.dimHead = dimHead
+    self.innerDim = heads * dimHead
+    self.mlpHiddenDim = Int(Float(dim) * mlpRatio)
+    self.scale = 1.0 / sqrt(Float(dimHead))
+
+    // Single projection for Q + K + V + MLP gate + MLP value
+    self._toQkvMlpProj.wrappedValue = Linear(dim, innerDim * 3 + mlpHiddenDim * 2, bias: false)
+    self._normQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._mlpAct.wrappedValue = Flux2SwiGLU()
+    self._toOut.wrappedValue = Linear(innerDim + mlpHiddenDim, dim, bias: false)
+    super.init()
+  }
+
+  func callAsFunction(_ hiddenStates: MLXArray, imageRotaryEmb: (MLXArray, MLXArray)) -> MLXArray {
+    let proj = toQkvMlpProj(hiddenStates)
+
+    // Split: [QKV | MLP_hidden]
+    let splits = MLX.split(proj, indices: [innerDim * 3], axis: -1)
+    let qkvPart = splits[0]
+    let mlpHidden = splits[1]
+
+    // Split QKV into Q, K, V
+    let qkvSplits = MLX.split(qkvPart, parts: 3, axis: -1)
+    let queryRaw = qkvSplits[0]
+    let keyRaw = qkvSplits[1]
+    let valueRaw = qkvSplits[2]
+
+    let batch = queryRaw.dim(0)
+    let seqLen = queryRaw.dim(1)
+
+    // Reshape to [B, H, S, D]
+    var query = queryRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    var key = keyRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    let value = valueRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+
+    // Normalize Q/K in float32
+    let qDtype = query.dtype
+    query = normQ(query.asType(.float32)).asType(qDtype)
+    key = normK(key.asType(.float32)).asType(qDtype)
+
+    // Apply RoPE
+    let (cos, sin) = imageRotaryEmb
+    (query, key) = Flux2AttentionUtils.applyRopeBSHD(query: query, key: key, cos: cos, sin: sin)
+
+    // Attention
+    let attnOut = MLXFast.scaledDotProductAttention(
+      queries: query,
+      keys: key,
+      values: value,
+      scale: scale,
+      mask: nil
+    )
+    // [B, H, S, D] -> [B, S, H*D]
+    var hiddenOut = attnOut.transposed(0, 2, 1, 3).reshaped(batch, seqLen, innerDim)
+
+    // Parallel MLP: SwiGLU on the MLP hidden part
+    let mlpOut = mlpAct(mlpHidden)
+
+    // Concatenate attention output and MLP output, project
+    hiddenOut = MLX.concatenated([hiddenOut, mlpOut], axis: -1)
+    return toOut(hiddenOut)
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2PosEmbed.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2PosEmbed.swift
@@ -1,0 +1,51 @@
+import Foundation
+import MLX
+
+/// Rotary position embeddings for Flux 2 transformer.
+///
+/// Unlike Flux 1's complex-valued RoPE table, Flux 2 uses explicit cos/sin pairs
+/// computed per-axis from position IDs, then concatenated across all axes.
+final class Flux2PosEmbed {
+  let theta: Int
+  let axesDim: [Int]
+
+  init(theta: Int = 2000, axesDim: [Int] = [32, 32, 32, 32]) {
+    self.theta = theta
+    self.axesDim = axesDim
+  }
+
+  /// Compute rotary embeddings for the given position IDs.
+  ///
+  /// - Parameter ids: Position IDs of shape `[seqLen, numAxes]`.
+  /// - Returns: Tuple of `(cos, sin)` each of shape `[seqLen, totalHalfDim]`.
+  func callAsFunction(_ ids: MLXArray) -> (MLXArray, MLXArray) {
+    let pos = ids.asType(.float32)
+    var cosOut: [MLXArray] = []
+    var sinOut: [MLXArray] = []
+
+    for (i, dim) in axesDim.enumerated() {
+      let (cos, sin) = get1dRope(dim: dim, pos: pos[0..., i])
+      cosOut.append(cos)
+      sinOut.append(sin)
+    }
+
+    let freqsCos = MLX.concatenated(cosOut, axis: -1)
+    let freqsSin = MLX.concatenated(sinOut, axis: -1)
+    return (freqsCos, freqsSin)
+  }
+
+  /// Compute 1D RoPE frequencies for a single axis.
+  private func get1dRope(dim: Int, pos: MLXArray) -> (MLXArray, MLXArray) {
+    // scale = arange(0, dim, 2) / dim
+    let scale = MLXArray(stride(from: 0, to: dim, by: 2).map { Float($0) / Float(dim) })
+    // omega = 1.0 / (theta ^ scale)
+    let omega = 1.0 / MLX.pow(MLXArray(Float(theta)), scale)
+
+    // [seqLen, 1] * [1, halfDim] -> [seqLen, halfDim]
+    let posExpanded = pos.expandedDimensions(axis: -1)
+    let omegaExpanded = omega.expandedDimensions(axis: 0)
+    let out = posExpanded * omegaExpanded
+
+    return (MLX.cos(out), MLX.sin(out))
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2SingleTransformerBlock.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2SingleTransformerBlock.swift
@@ -1,0 +1,41 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Single-stream transformer block for Flux 2.
+///
+/// After the double-stream blocks merge image and text into a single sequence,
+/// these blocks process the unified stream with parallel self-attention + MLP.
+/// Modulation (shift/scale/gate) from the timestep embedding is applied.
+final class Flux2SingleTransformerBlock: Module {
+  @ModuleInfo(key: "norm") var norm: LayerNorm
+  @ModuleInfo(key: "attn") var attn: Flux2ParallelSelfAttention
+
+  init(dim: Int, numAttentionHeads: Int, attentionHeadDim: Int, mlpRatio: Float = 3.0) {
+    self._norm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._attn.wrappedValue = Flux2ParallelSelfAttention(
+      dim: dim,
+      heads: numAttentionHeads,
+      dimHead: attentionHeadDim,
+      mlpRatio: mlpRatio
+    )
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Unified hidden states `[batch, seq, dim]`.
+  ///   - tembModParams: Single modulation set `(shift, scale, gate)`.
+  ///   - imageRotaryEmb: `(cos, sin)` for RoPE.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    tembModParams: (MLXArray, MLXArray, MLXArray),
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> MLXArray {
+    let (modShift, modScale, modGate) = tembModParams
+
+    var normHidden = norm(hiddenStates)
+    normHidden = (1 + modScale) * normHidden + modShift
+    let attnOutput = attn(normHidden, imageRotaryEmb: imageRotaryEmb)
+    return hiddenStates + modGate * attnOutput
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2TimestepEmbedding.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2TimestepEmbedding.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Timestep and optional guidance embeddings for Flux 2.
+///
+/// Computes sinusoidal frequency embeddings from scalar timestep values,
+/// projects through a 2-layer MLP (with SiLU activation), and optionally
+/// adds a guidance embedding computed through a parallel MLP.
+final class Flux2TimestepEmbedding: Module {
+  let inChannels: Int
+  let embeddingDim: Int
+  let guidanceEmbeds: Bool
+
+  @ModuleInfo(key: "linear_1") var linear1: Linear
+  @ModuleInfo(key: "linear_2") var linear2: Linear
+  @ModuleInfo(key: "guidance_linear_1") var guidanceLinear1: Linear?
+  @ModuleInfo(key: "guidance_linear_2") var guidanceLinear2: Linear?
+
+  init(inChannels: Int = 256, embeddingDim: Int = 6144, guidanceEmbeds: Bool = true) {
+    self.inChannels = inChannels
+    self.embeddingDim = embeddingDim
+    self.guidanceEmbeds = guidanceEmbeds
+
+    self._linear1.wrappedValue = Linear(inChannels, embeddingDim, bias: false)
+    self._linear2.wrappedValue = Linear(embeddingDim, embeddingDim, bias: false)
+
+    if guidanceEmbeds {
+      self._guidanceLinear1.wrappedValue = Linear(inChannels, embeddingDim, bias: false)
+      self._guidanceLinear2.wrappedValue = Linear(embeddingDim, embeddingDim, bias: false)
+    }
+
+    super.init()
+  }
+
+  func callAsFunction(timestep: MLXArray, guidance: MLXArray?) -> MLXArray {
+    let timestepEmb = Self.timestepEmbedding(timestep.asType(.float32), dim: inChannels)
+    let tEmb = linear2(silu(linear1(timestepEmb)))
+
+    if let guidance, let gLinear1 = guidanceLinear1, let gLinear2 = guidanceLinear2 {
+      let guidanceEmb = Self.timestepEmbedding(guidance.asType(.float32), dim: inChannels)
+      let gEmb = gLinear2(silu(gLinear1(guidanceEmb)))
+      return tEmb + gEmb
+    }
+
+    return tEmb
+  }
+
+  /// Compute sinusoidal timestep embeddings.
+  ///
+  /// Matches the diffusers convention: `flip_sin_to_cos=True` puts cos before sin.
+  static func timestepEmbedding(
+    _ timesteps: MLXArray,
+    dim: Int,
+    flipSinToCos: Bool = true
+  ) -> MLXArray {
+    let half = dim / 2
+    let freqs = MLX.exp(
+      MLXArray(-Foundation.log(10000.0))
+        * MLXArray(stride(from: 0, to: half, by: 1).map { Float($0) })
+        / MLXArray(Float(half))
+    )
+    let args = timesteps.expandedDimensions(axis: -1) * freqs.expandedDimensions(axis: 0)
+    var emb = MLX.concatenated([MLX.sin(args), MLX.cos(args)], axis: -1)
+
+    if flipSinToCos {
+      // Swap sin and cos halves
+      let cosHalf = emb[0..., half...]
+      let sinHalf = emb[0..., ..<half]
+      emb = MLX.concatenated([cosHalf, sinHalf], axis: -1)
+    }
+
+    if dim % 2 == 1 {
+      let pad = MLX.zeros([emb.dim(0), 1], dtype: emb.dtype)
+      emb = MLX.concatenated([emb, pad], axis: -1)
+    }
+
+    return emb
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2Transformer.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Transformer.swift
@@ -1,0 +1,261 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Adaptive layer norm with continuous conditioning for the Flux 2 output projection.
+///
+/// Applies SiLU-activated linear projection of the conditioning signal to produce
+/// scale and shift parameters for layer normalization.
+final class Flux2AdaLayerNormContinuous: Module {
+  let embeddingDim: Int
+
+  @ModuleInfo(key: "linear") var linear: Linear
+  @ModuleInfo(key: "norm") var norm: LayerNorm
+
+  init(embeddingDim: Int, conditioningEmbeddingDim: Int) {
+    self.embeddingDim = embeddingDim
+    self._linear.wrappedValue = Linear(conditioningEmbeddingDim, embeddingDim * 2, bias: false)
+    self._norm.wrappedValue = LayerNorm(dimensions: embeddingDim, eps: 1e-6, affine: false)
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray, conditioning: MLXArray) -> MLXArray {
+    let mod = linear(silu(conditioning))
+    let chunkSize = embeddingDim
+    let scale = mod[0..., (0 * chunkSize)..<(1 * chunkSize)]
+    let shift = mod[0..., (1 * chunkSize)..<(2 * chunkSize)]
+    return norm(x) * (1 + scale).expandedDimensions(axis: 1) + shift.expandedDimensions(axis: 1)
+  }
+}
+
+// MARK: - Flux2Transformer Configuration
+
+/// Configuration for the Flux 2 transformer.
+public struct Flux2TransformerConfig {
+  public let patchSize: Int
+  public let inChannels: Int
+  public let outChannels: Int
+  public let numLayers: Int
+  public let numSingleLayers: Int
+  public let attentionHeadDim: Int
+  public let numAttentionHeads: Int
+  public let jointAttentionDim: Int
+  public let timestepGuidanceChannels: Int
+  public let mlpRatio: Float
+  public let axesDimsRope: [Int]
+  public let ropeTheta: Int
+  public let guidanceEmbeds: Bool
+
+  public init(
+    patchSize: Int = 1,
+    inChannels: Int = 128,
+    outChannels: Int? = nil,
+    numLayers: Int = 5,
+    numSingleLayers: Int = 20,
+    attentionHeadDim: Int = 128,
+    numAttentionHeads: Int = 24,
+    jointAttentionDim: Int = 7680,
+    timestepGuidanceChannels: Int = 256,
+    mlpRatio: Float = 3.0,
+    axesDimsRope: [Int] = [32, 32, 32, 32],
+    ropeTheta: Int = 2000,
+    guidanceEmbeds: Bool = false
+  ) {
+    self.patchSize = patchSize
+    self.inChannels = inChannels
+    self.outChannels = outChannels ?? inChannels
+    self.numLayers = numLayers
+    self.numSingleLayers = numSingleLayers
+    self.attentionHeadDim = attentionHeadDim
+    self.numAttentionHeads = numAttentionHeads
+    self.jointAttentionDim = jointAttentionDim
+    self.timestepGuidanceChannels = timestepGuidanceChannels
+    self.mlpRatio = mlpRatio
+    self.axesDimsRope = axesDimsRope
+    self.ropeTheta = ropeTheta
+    self.guidanceEmbeds = guidanceEmbeds
+  }
+}
+
+// MARK: - Flux2Transformer
+
+/// Flux 2 transformer — the denoising backbone for Flux 2 image generation.
+///
+/// Architecture:
+/// 1. Embed timestep (+ optional guidance) into a conditioning vector
+/// 2. Embed image latents and text embeddings into the model dimension
+/// 3. Compute RoPE for image and text positions
+/// 4. Run double-stream (joint) transformer blocks with cross-attention
+/// 5. Concatenate streams and run single-stream blocks with parallel self-attention
+/// 6. Apply adaptive layer norm and project to output
+public final class Flux2Transformer: Module {
+  public let config: Flux2TransformerConfig
+  let innerDim: Int
+
+  @ModuleInfo(key: "pos_embed") var posEmbed: Flux2PosEmbed
+  @ModuleInfo(key: "time_guidance_embed") var timeGuidanceEmbed: Flux2TimestepEmbedding
+  @ModuleInfo(key: "double_stream_modulation_img") var doubleStreamModulationImg: Flux2Modulation
+  @ModuleInfo(key: "double_stream_modulation_txt") var doubleStreamModulationTxt: Flux2Modulation
+  @ModuleInfo(key: "single_stream_modulation") var singleStreamModulation: Flux2Modulation
+
+  @ModuleInfo(key: "x_embedder") var xEmbedder: Linear
+  @ModuleInfo(key: "context_embedder") var contextEmbedder: Linear
+  @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [Flux2TransformerBlock]
+  @ModuleInfo(key: "single_transformer_blocks") var singleTransformerBlocks: [Flux2SingleTransformerBlock]
+  @ModuleInfo(key: "norm_out") var normOut: Flux2AdaLayerNormContinuous
+  @ModuleInfo(key: "proj_out") var projOut: Linear
+
+  public init(config: Flux2TransformerConfig = Flux2TransformerConfig()) {
+    self.config = config
+    self.innerDim = config.numAttentionHeads * config.attentionHeadDim
+
+    self._posEmbed.wrappedValue = Flux2PosEmbed(
+      theta: config.ropeTheta,
+      axesDim: config.axesDimsRope
+    )
+    self._timeGuidanceEmbed.wrappedValue = Flux2TimestepEmbedding(
+      inChannels: config.timestepGuidanceChannels,
+      embeddingDim: innerDim,
+      guidanceEmbeds: config.guidanceEmbeds
+    )
+    self._doubleStreamModulationImg.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 2)
+    self._doubleStreamModulationTxt.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 2)
+    self._singleStreamModulation.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 1)
+
+    self._xEmbedder.wrappedValue = Linear(config.inChannels, innerDim, bias: false)
+    self._contextEmbedder.wrappedValue = Linear(config.jointAttentionDim, innerDim, bias: false)
+
+    var doubleBlocks: [Flux2TransformerBlock] = []
+    for _ in 0..<config.numLayers {
+      doubleBlocks.append(Flux2TransformerBlock(
+        dim: innerDim,
+        numAttentionHeads: config.numAttentionHeads,
+        attentionHeadDim: config.attentionHeadDim,
+        mlpRatio: config.mlpRatio
+      ))
+    }
+    self._transformerBlocks.wrappedValue = doubleBlocks
+
+    var singleBlocks: [Flux2SingleTransformerBlock] = []
+    for _ in 0..<config.numSingleLayers {
+      singleBlocks.append(Flux2SingleTransformerBlock(
+        dim: innerDim,
+        numAttentionHeads: config.numAttentionHeads,
+        attentionHeadDim: config.attentionHeadDim,
+        mlpRatio: config.mlpRatio
+      ))
+    }
+    self._singleTransformerBlocks.wrappedValue = singleBlocks
+
+    self._normOut.wrappedValue = Flux2AdaLayerNormContinuous(
+      embeddingDim: innerDim,
+      conditioningEmbeddingDim: innerDim
+    )
+    self._projOut.wrappedValue = Linear(
+      innerDim,
+      config.patchSize * config.patchSize * config.outChannels,
+      bias: false
+    )
+
+    super.init()
+  }
+
+  /// Run the Flux 2 transformer forward pass.
+  ///
+  /// - Parameters:
+  ///   - hiddenStates: Image latents `[batch, seq, inChannels]`.
+  ///   - encoderHiddenStates: Text embeddings `[batch, txtSeq, jointAttentionDim]`.
+  ///   - timestep: Scalar or `[batch]` timestep values.
+  ///   - imgIds: Image position IDs `[seqLen, numAxes]` or `[1, seqLen, numAxes]`.
+  ///   - txtIds: Text position IDs `[txtSeqLen, numAxes]` or `[1, txtSeqLen, numAxes]`.
+  ///   - guidance: Optional guidance scale (for distilled models).
+  /// - Returns: Denoised output `[batch, seq, outChannels]`.
+  public func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    timestep: MLXArray,
+    imgIds: MLXArray,
+    txtIds: MLXArray,
+    guidance: MLXArray? = nil
+  ) -> MLXArray {
+    let dtype = hiddenStates.dtype
+
+    // Prepare timestep: ensure [batch] shape, scale to [0, 1000] if needed
+    var t = timestep.ndim == 0
+      ? MLX.broadcast(timestep, to: [hiddenStates.dim(0)]).asType(dtype)
+      : timestep.asType(dtype)
+    let tScale = MLX.where(MLX.max(t) .<= 1.0, MLXArray(1000.0), MLXArray(1.0)).asType(dtype)
+    t = t * tScale
+
+    // Prepare guidance similarly
+    var g: MLXArray? = nil
+    if var guidance = guidance {
+      if guidance.ndim == 0 {
+        guidance = MLX.broadcast(guidance, to: [hiddenStates.dim(0)]).asType(dtype)
+      } else {
+        guidance = guidance.asType(dtype)
+      }
+      let gScale = MLX.where(MLX.max(guidance) .<= 1.0, MLXArray(1000.0), MLXArray(1.0)).asType(dtype)
+      g = guidance * gScale
+    }
+
+    // Timestep embedding
+    var temb = timeGuidanceEmbed(timestep: t, guidance: g)
+    temb = temb.asType(.bfloat16)
+
+    // Embed inputs
+    var hidden = xEmbedder(hiddenStates)
+    var encoder = contextEmbedder(encoderHiddenStates)
+
+    // Squeeze batch dimension from position IDs if present
+    let imgIdsFlat = imgIds.ndim == 3 ? imgIds[0] : imgIds
+    let txtIdsFlat = txtIds.ndim == 3 ? txtIds[0] : txtIds
+
+    // Compute RoPE
+    let imageRotaryEmb = posEmbed(imgIdsFlat)
+    let textRotaryEmb = posEmbed(txtIdsFlat)
+    let concatRotaryEmb = (
+      MLX.concatenated([textRotaryEmb.0, imageRotaryEmb.0], axis: 0),
+      MLX.concatenated([textRotaryEmb.1, imageRotaryEmb.1], axis: 0)
+    )
+
+    // Compute modulation params (shared across all blocks)
+    let tembModParamsImg = doubleStreamModulationImg(temb)
+    let tembModParamsTxt = doubleStreamModulationTxt(temb)
+
+    // Double-stream blocks
+    for block in transformerBlocks {
+      (encoder, hidden) = block(
+        hiddenStates: hidden,
+        encoderHiddenStates: encoder,
+        tembModParamsImg: tembModParamsImg,
+        tembModParamsTxt: tembModParamsTxt,
+        imageRotaryEmb: concatRotaryEmb
+      )
+    }
+
+    // Merge streams for single-stream blocks
+    hidden = MLX.concatenated([encoder, hidden], axis: 1)
+
+    // Single-stream modulation: extract the first (and only) set
+    let singleModParams = singleStreamModulation(temb)[0]
+    let singleMod = (singleModParams[0], singleModParams[1], singleModParams[2])
+
+    for block in singleTransformerBlocks {
+      hidden = block(
+        hiddenStates: hidden,
+        tembModParams: singleMod,
+        imageRotaryEmb: concatRotaryEmb
+      )
+    }
+
+    // Slice off encoder tokens, keep only image tokens
+    hidden = hidden[0..., encoder.dim(1)..., 0...]
+
+    // Final norm + projection
+    hidden = normOut(hidden, conditioning: temb)
+    hidden = projOut(hidden)
+
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2TransformerBlock.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2TransformerBlock.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Double-stream (joint) transformer block for Flux 2.
+///
+/// Processes image and text hidden states through parallel norm → attention → FFN paths.
+/// Both streams share the same attention computation (cross-attention via Flux2Attention)
+/// but have separate norms, modulation, and feed-forward networks.
+final class Flux2TransformerBlock: Module {
+  @ModuleInfo(key: "norm1") var norm1: LayerNorm
+  @ModuleInfo(key: "norm1_context") var norm1Context: LayerNorm
+  @ModuleInfo(key: "attn") var attn: Flux2Attention
+  @ModuleInfo(key: "norm2") var norm2: LayerNorm
+  @ModuleInfo(key: "ff") var ff: Flux2FeedForward
+  @ModuleInfo(key: "norm2_context") var norm2Context: LayerNorm
+  @ModuleInfo(key: "ff_context") var ffContext: Flux2FeedForward
+
+  init(dim: Int, numAttentionHeads: Int, attentionHeadDim: Int, mlpRatio: Float = 3.0) {
+    self._norm1.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._norm1Context.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._attn.wrappedValue = Flux2Attention(
+      dim: dim,
+      heads: numAttentionHeads,
+      dimHead: attentionHeadDim,
+      addedKVProjDim: dim
+    )
+    self._norm2.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._ff.wrappedValue = Flux2FeedForward(dim: dim, mult: mlpRatio)
+    self._norm2Context.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._ffContext.wrappedValue = Flux2FeedForward(dim: dim, mult: mlpRatio)
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Image hidden states `[batch, imgSeq, dim]`.
+  ///   - encoderHiddenStates: Text hidden states `[batch, txtSeq, dim]`.
+  ///   - tembModParamsImg: Modulation params for image stream: `[[shift, scale, gate], [shift, scale, gate]]`.
+  ///   - tembModParamsTxt: Modulation params for text stream: `[[shift, scale, gate], [shift, scale, gate]]`.
+  ///   - imageRotaryEmb: `(cos, sin)` for RoPE.
+  /// - Returns: `(encoderHiddenStates, hiddenStates)`.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    tembModParamsImg: [[MLXArray]],
+    tembModParamsTxt: [[MLXArray]],
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> (MLXArray, MLXArray) {
+    // Image modulation params
+    let (shiftMSA, scaleMSA, gateMSA) = (tembModParamsImg[0][0], tembModParamsImg[0][1], tembModParamsImg[0][2])
+    let (shiftMLP, scaleMLP, gateMLP) = (tembModParamsImg[1][0], tembModParamsImg[1][1], tembModParamsImg[1][2])
+    // Text modulation params
+    let (cShiftMSA, cScaleMSA, cGateMSA) = (tembModParamsTxt[0][0], tembModParamsTxt[0][1], tembModParamsTxt[0][2])
+    let (cShiftMLP, cScaleMLP, cGateMLP) = (tembModParamsTxt[1][0], tembModParamsTxt[1][1], tembModParamsTxt[1][2])
+
+    // Normalize and modulate image
+    var normHidden = norm1(hiddenStates)
+    normHidden = (1 + scaleMSA) * normHidden + shiftMSA
+
+    // Normalize and modulate text
+    var normEncoder = norm1Context(encoderHiddenStates)
+    normEncoder = (1 + cScaleMSA) * normEncoder + cShiftMSA
+
+    // Joint attention
+    let (attnOutput, encoderAttnOutput) = attn(
+      hiddenStates: normHidden,
+      encoderHiddenStates: normEncoder,
+      imageRotaryEmb: imageRotaryEmb
+    )
+
+    // Residual + gating for attention
+    var hidden = hiddenStates + gateMSA * attnOutput
+    var encoder = encoderHiddenStates + cGateMSA * encoderAttnOutput
+
+    // FFN for image
+    var normHidden2 = norm2(hidden)
+    normHidden2 = (1 + scaleMLP) * normHidden2 + shiftMLP
+    hidden = hidden + gateMLP * ff(normHidden2)
+
+    // FFN for text
+    var normEncoder2 = norm2Context(encoder)
+    normEncoder2 = (1 + cScaleMLP) * normEncoder2 + cShiftMLP
+    encoder = encoder + cGateMLP * ffContext(normEncoder2)
+
+    return (encoder, hidden)
+  }
+}


### PR DESCRIPTION
## Summary
Port of the Flux 2 transformer from Python mflux to Swift — PR 2 of 5 for native Flux 2 Klein support.

**9 new files** (861 lines):
- `Flux2Transformer.swift` — Main denoising backbone + AdaLayerNormContinuous
- `Flux2Attention.swift` — Cross-attention with image/text QKV + RoPE utils
- `Flux2ParallelSelfAttention.swift` — Fused QKV+MLP single projection
- `Flux2TransformerBlock.swift` — Double-stream joint block
- `Flux2SingleTransformerBlock.swift` — Single-stream with parallel self-attention
- `Flux2TimestepEmbedding.swift` — Sinusoidal timestep + guidance MLP
- `Flux2PosEmbed.swift` — Per-axis cos/sin RoPE
- `Flux2Modulation.swift` — Adaptive shift/scale/gate
- `Flux2FeedForward.swift` — SwiGLU feed-forward

## Key Differences from Flux 1
- Explicit cos/sin RoPE pairs (not complex-valued)
- Parallel self-attention in single-stream blocks
- Modulation computed once and shared across all blocks
- Double-stream cross-attention → single-stream self-attention

## Test plan
- [ ] Build: `swift build -c release` passes clean
- [ ] Weight loading: verify transformer weights load from Klein 4B
- [ ] Forward pass shape: verify output matches Python mflux dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)