### PR TITLE
fix(tokenizer): auto-inline chat_template.jinja into tokenizer_config.json

### DIFF
--- a/Sources/ZImage/Flux2/Flux2Initializer.swift
+++ b/Sources/ZImage/Flux2/Flux2Initializer.swift
@@ -1,0 +1,164 @@
+// Flux2Initializer.swift — Model initialization and weight loading orchestration
+// Ported from mflux: flux2_initializer.py
+
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+/// Orchestrates initialization and weight loading for the Flux 2 Klein pipeline.
+///
+/// The initializer handles:
+/// 1. Resolving the model snapshot (local path or HuggingFace download)
+/// 2. Loading safetensors weight shards for each component
+/// 3. Constructing the model modules (transformer, VAE, text encoder)
+/// 4. Applying mapped weights to each module
+///
+/// ## Usage
+///
+/// ```swift
+/// let components = try Flux2Initializer.load(
+///   from: snapshotURL,
+///   transformerConfig: config,
+///   dtype: .bfloat16,
+///   logger: logger
+/// )
+/// // components.transformer, components.vae, components.textEncoder are ready
+/// ```
+public enum Flux2Initializer {
+
+  /// Loaded Flux 2 model components, ready for inference.
+  public struct Components {
+    /// The denoising transformer backbone.
+    public let transformer: Flux2Transformer
+    /// The VAE for latent encode/decode.
+    public let vae: Flux2VAE
+    /// The Qwen3 text encoder.
+    public let textEncoder: Qwen3TextEncoder
+  }
+
+  /// Load and initialize all Flux 2 Klein model components from a snapshot.
+  ///
+  /// This is the primary entry point for model loading. It resolves weight files,
+  /// constructs modules, loads weights from safetensors, and applies them.
+  ///
+  /// - Parameters:
+  ///   - snapshot: Root URL of the model snapshot directory.
+  ///   - transformerConfig: Configuration for the Flux2 transformer.
+  ///   - textEncoderConfig: Configuration for the Qwen3 text encoder.
+  ///   - dtype: Target data type for weights (default `.bfloat16`).
+  ///   - logger: Logger for progress and diagnostic output.
+  /// - Returns: Initialized `Components` with all weights loaded.
+  public static func load(
+    from snapshot: URL,
+    transformerConfig: Flux2TransformerConfig = Flux2TransformerConfig(),
+    textEncoderConfig: Qwen3TextEncoderConfiguration = Qwen3TextEncoderConfiguration(),
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws -> Components {
+    logger.info("Loading Flux 2 Klein model from \(snapshot.path)")
+
+    // 1. Resolve weight files for each component
+    let transformerFiles = Flux2WeightDefinition.resolveWeightFiles(for: .transformer, at: snapshot)
+    let vaeFiles = Flux2WeightDefinition.resolveWeightFiles(for: .vae, at: snapshot)
+    let textEncoderFiles = Flux2WeightDefinition.resolveWeightFiles(for: .textEncoder, at: snapshot)
+
+    logger.info("Transformer shards: \(transformerFiles.count), VAE shards: \(vaeFiles.count), Text encoder shards: \(textEncoderFiles.count)")
+
+    // 2. Construct model modules
+    let transformer = Flux2Transformer(config: transformerConfig)
+    let vae = Flux2VAE()
+    let textEncoder = Qwen3TextEncoder(configuration: textEncoderConfig)
+
+    // 3. Load and map weights from safetensors
+    logger.info("Loading transformer weights...")
+    let transformerWeights = try Flux2WeightMapping.loadTransformerWeights(from: transformerFiles, dtype: dtype)
+    logger.info("Loaded \(transformerWeights.count) transformer weight tensors")
+
+    logger.info("Loading VAE weights...")
+    let vaeWeights = try Flux2WeightMapping.loadVAEWeights(from: vaeFiles, dtype: dtype)
+    logger.info("Loaded \(vaeWeights.count) VAE weight tensors")
+
+    logger.info("Loading text encoder weights...")
+    let textEncoderWeights = try Flux2WeightMapping.loadTextEncoderWeights(from: textEncoderFiles, dtype: dtype)
+    logger.info("Loaded \(textEncoderWeights.count) text encoder weight tensors")
+
+    // 4. Apply weights to modules
+    logger.info("Applying weights to transformer...")
+    try Flux2WeightMapping.applyTransformerWeights(transformerWeights, to: transformer)
+
+    logger.info("Applying weights to VAE...")
+    try Flux2WeightMapping.applyVAEWeights(vaeWeights, to: vae)
+
+    logger.info("Applying weights to text encoder...")
+    try Flux2WeightMapping.applyTextEncoderWeights(textEncoderWeights, to: textEncoder)
+
+    logger.info("Flux 2 Klein model loaded successfully")
+
+    return Components(
+      transformer: transformer,
+      vae: vae,
+      textEncoder: textEncoder
+    )
+  }
+
+  /// Load only the transformer weights from a snapshot.
+  ///
+  /// Useful when the transformer needs to be reloaded independently
+  /// (e.g., swapping transformer checkpoints while keeping VAE/encoder).
+  ///
+  /// - Parameters:
+  ///   - snapshot: Root URL of the model snapshot directory.
+  ///   - transformer: The Flux2Transformer module to load weights into.
+  ///   - dtype: Target data type (default `.bfloat16`).
+  ///   - logger: Logger for progress output.
+  public static func loadTransformer(
+    from snapshot: URL,
+    into transformer: Flux2Transformer,
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws {
+    let files = Flux2WeightDefinition.resolveWeightFiles(for: .transformer, at: snapshot)
+    let weights = try Flux2WeightMapping.loadTransformerWeights(from: files, dtype: dtype)
+    logger.info("Loaded \(weights.count) transformer weight tensors")
+    try Flux2WeightMapping.applyTransformerWeights(weights, to: transformer)
+  }
+
+  /// Load only the VAE weights from a snapshot.
+  ///
+  /// - Parameters:
+  ///   - snapshot: Root URL of the model snapshot directory.
+  ///   - vae: The Flux2VAE module to load weights into.
+  ///   - dtype: Target data type (default `.bfloat16`).
+  ///   - logger: Logger for progress output.
+  public static func loadVAE(
+    from snapshot: URL,
+    into vae: Flux2VAE,
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws {
+    let files = Flux2WeightDefinition.resolveWeightFiles(for: .vae, at: snapshot)
+    let weights = try Flux2WeightMapping.loadVAEWeights(from: files, dtype: dtype)
+    logger.info("Loaded \(weights.count) VAE weight tensors")
+    try Flux2WeightMapping.applyVAEWeights(weights, to: vae)
+  }
+
+  /// Load only the text encoder weights from a snapshot.
+  ///
+  /// - Parameters:
+  ///   - snapshot: Root URL of the model snapshot directory.
+  ///   - textEncoder: The Qwen3TextEncoder module to load weights into.
+  ///   - dtype: Target data type (default `.bfloat16`).
+  ///   - logger: Logger for progress output.
+  public static func loadTextEncoder(
+    from snapshot: URL,
+    into textEncoder: Qwen3TextEncoder,
+    dtype: DType = .bfloat16,
+    logger: Logger
+  ) throws {
+    let files = Flux2WeightDefinition.resolveWeightFiles(for: .textEncoder, at: snapshot)
+    let weights = try Flux2WeightMapping.loadTextEncoderWeights(from: files, dtype: dtype)
+    logger.info("Loaded \(weights.count) text encoder weight tensors")
+    try Flux2WeightMapping.applyTextEncoderWeights(weights, to: textEncoder)
+  }
+}

--- a/Sources/ZImage/Flux2/Flux2LatentCreator.swift
+++ b/Sources/ZImage/Flux2/Flux2LatentCreator.swift
@@ -1,0 +1,259 @@
+// Flux2LatentCreator.swift — Latent noise creation, patchify, pack for Flux 2
+// Ported from mflux: flux2_latent_creator.py
+
+import Foundation
+import MLX
+import MLXRandom
+
+/// Creates and manipulates latent tensors for the Flux 2 diffusion pipeline.
+///
+/// Flux 2 uses a patchified latent representation where the spatial dimensions
+/// are halved and the channels are quadrupled (2x2 patches folded into channels).
+/// The packing step then flattens the spatial dims into a sequence.
+///
+/// ## Latent Layout Pipeline
+///
+/// ```
+/// Random noise:      (B, 4*C, H/2, W/2)  — patchified at creation
+///   -> pack:         (B, H/2 * W/2, 4*C)  — spatial flattened to sequence
+///   -> transformer:  (B, seq, dim)         — denoising
+///   -> unpack:       (B, 4*C, H/2, W/2)   — back to spatial
+///   -> unpatchify:   (B, C, H, W)          — full resolution latent
+///   -> VAE decode:   (B, 3, H*8, W*8)     — pixel image
+/// ```
+public enum Flux2LatentCreator {
+
+  /// Default number of latent channels for Flux 2.
+  public static let defaultNumLatentChannels: Int = 32
+
+  /// Default VAE scale factor (spatial downsampling ratio).
+  public static let defaultVAEScaleFactor: Int = 8
+
+  // MARK: - Patchify / Unpatchify
+
+  /// Patchify latents by folding 2x2 spatial patches into the channel dimension.
+  ///
+  /// Converts `(B, C, H, W)` -> `(B, 4*C, H/2, W/2)` by rearranging 2x2 spatial
+  /// neighborhoods into the channel axis. Height and width must be even.
+  ///
+  /// - Parameter latents: Latent tensor in NCHW layout `(B, C, H, W)`.
+  /// - Returns: Patchified tensor `(B, 4*C, H/2, W/2)`.
+  public static func patchifyLatents(_ latents: MLXArray) -> MLXArray {
+    var x = latents
+    // Remove temporal dimension if present
+    if x.ndim == 5 && x.shape[2] == 1 {
+      x = x.squeezed(axis: 2)
+    }
+    precondition(x.ndim == 4, "Expected latents with ndim=4, got shape=\(x.shape)")
+
+    let batchSize = x.shape[0]
+    let numChannels = x.shape[1]
+    let height = x.shape[2]
+    let width = x.shape[3]
+
+    // (B, C, H, W) -> (B, C, H/2, 2, W/2, 2)
+    x = x.reshaped(batchSize, numChannels, height / 2, 2, width / 2, 2)
+    // (B, C, H/2, 2, W/2, 2) -> (B, C, 2, 2, H/2, W/2)
+    x = x.transposed(0, 1, 3, 5, 2, 4)
+    // (B, C, 2, 2, H/2, W/2) -> (B, 4*C, H/2, W/2)
+    x = x.reshaped(batchSize, numChannels * 4, height / 2, width / 2)
+
+    return x
+  }
+
+  /// Unpatchify latents by unfolding channel patches back to spatial dimensions.
+  ///
+  /// Inverse of `patchifyLatents`. Converts `(B, 4*C, H, W)` -> `(B, C, 2*H, 2*W)`.
+  ///
+  /// - Parameter latents: Patchified latent tensor `(B, 4*C, H, W)`.
+  /// - Returns: Unpatchified tensor `(B, C, 2*H, 2*W)`.
+  public static func unpatchifyLatents(_ latents: MLXArray) -> MLXArray {
+    let batchSize = latents.shape[0]
+    let numChannels = latents.shape[1]
+    let height = latents.shape[2]
+    let width = latents.shape[3]
+
+    // (B, 4C, H, W) -> (B, C, 2, 2, H, W)
+    var x = latents.reshaped(batchSize, numChannels / 4, 2, 2, height, width)
+    // (B, C, 2, 2, H, W) -> (B, C, H, 2, W, 2)
+    x = x.transposed(0, 1, 4, 2, 5, 3)
+    // (B, C, H, 2, W, 2) -> (B, C, 2H, 2W)
+    x = x.reshaped(batchSize, numChannels / 4, height * 2, width * 2)
+
+    return x
+  }
+
+  // MARK: - Pack / Unpack
+
+  /// Pack latents by flattening spatial dimensions into a sequence.
+  ///
+  /// Converts `(B, C, H, W)` -> `(B, H*W, C)` for transformer processing.
+  ///
+  /// - Parameter latents: Spatial latent tensor `(B, C, H, W)`.
+  /// - Returns: Packed sequence tensor `(B, H*W, C)`.
+  public static func packLatents(_ latents: MLXArray) -> MLXArray {
+    let batchSize = latents.shape[0]
+    let numChannels = latents.shape[1]
+    let height = latents.shape[2]
+    let width = latents.shape[3]
+    return latents.reshaped(batchSize, numChannels, height * width).transposed(0, 2, 1)
+  }
+
+  /// Unpack latents from sequence back to spatial layout.
+  ///
+  /// Converts `(B, seq, C)` -> `(B, C, H, W)`. If the input is already 4D,
+  /// returns it unchanged.
+  ///
+  /// - Parameters:
+  ///   - latents: Packed sequence tensor `(B, seq, C)` or already spatial `(B, C, H, W)`.
+  ///   - height: Target image height in pixels.
+  ///   - width: Target image width in pixels.
+  ///   - vaeScaleFactor: VAE spatial downsampling factor (default 8).
+  /// - Returns: Spatial latent tensor `(B, C, H, W)`.
+  public static func unpackLatents(
+    _ latents: MLXArray,
+    height: Int,
+    width: Int,
+    vaeScaleFactor: Int = defaultVAEScaleFactor
+  ) -> MLXArray {
+    if latents.ndim == 4 {
+      return latents
+    }
+    precondition(latents.ndim == 3, "Expected packed latents with ndim=3, got shape=\(latents.shape)")
+
+    let batchSize = latents.shape[0]
+    let seqLen = latents.shape[1]
+    let channels = latents.shape[2]
+
+    let latentHeight = height / (vaeScaleFactor * 2)
+    let latentWidth = width / (vaeScaleFactor * 2)
+    let expectedSeqLen = latentHeight * latentWidth
+
+    precondition(
+      expectedSeqLen == seqLen,
+      "Packed latent seq_len mismatch: got \(seqLen), expected \(expectedSeqLen) "
+      + "for height=\(height) width=\(width) (latent \(latentHeight)x\(latentWidth))"
+    )
+
+    return latents.reshaped(batchSize, latentHeight, latentWidth, channels)
+      .transposed(0, 3, 1, 2)
+  }
+
+  // MARK: - Grid IDs
+
+  /// Prepare spatial grid position IDs for the transformer's RoPE.
+  ///
+  /// Each spatial position gets a 4D coordinate `[t, h, w, layer]` where:
+  ///   - `t`: temporal coordinate (always `tCoord` for images)
+  ///   - `h`: height index
+  ///   - `w`: width index
+  ///   - `layer`: always 0 (reserved for future use)
+  ///
+  /// - Parameters:
+  ///   - latents: Latent tensor `(B, C, H, W)` — used for shape only.
+  ///   - tCoord: Temporal coordinate value (default 0 for static images).
+  /// - Returns: Grid IDs tensor `(B, H*W, 4)`.
+  public static func prepareGridIds(
+    _ latents: MLXArray,
+    tCoord: Int = 0
+  ) -> MLXArray {
+    let batchSize = latents.shape[0]
+    let height = latents.shape[2]
+    let width = latents.shape[3]
+
+    let hIds = MLXArray(0..<height)
+    let wIds = MLXArray(0..<width)
+
+    // Create H x W grid
+    let hGrid = MLX.broadcast(
+      hIds.expandedDimensions(axis: 1),
+      to: [height, width]
+    )
+    let wGrid = MLX.broadcast(
+      wIds.expandedDimensions(axis: 0),
+      to: [height, width]
+    )
+
+    let flatH = hGrid.reshaped(-1)
+    let flatW = wGrid.reshaped(-1)
+    let t = MLX.full([flatH.shape[0]], values: MLXArray(Int32(tCoord)), dtype: .int32)
+    let layerIds = MLX.zeros(like: flatH).asType(.int32)
+
+    // Stack [t, h, w, layer] -> (H*W, 4)
+    var coords = MLX.stacked([t, flatH.asType(.int32), flatW.asType(.int32), layerIds], axis: 1)
+
+    // Expand to batch: (1, H*W, 4) -> (B, H*W, 4)
+    coords = coords.expandedDimensions(axis: 0)
+    return MLX.broadcast(coords, to: [batchSize, coords.shape[1], coords.shape[2]])
+  }
+
+  // MARK: - Full Preparation
+
+  /// Prepare initial noise latents for the diffusion process.
+  ///
+  /// Generates random noise, already patchified (2x2 patches folded into channels).
+  /// The noise is drawn from a standard normal distribution with the given seed.
+  ///
+  /// - Parameters:
+  ///   - seed: Random seed for reproducibility.
+  ///   - height: Target image height in pixels.
+  ///   - width: Target image width in pixels.
+  ///   - batchSize: Number of images to generate.
+  ///   - numLatentChannels: Number of base latent channels (default 32).
+  ///   - vaeScaleFactor: VAE spatial downsampling factor (default 8).
+  ///   - dtype: Data type for the latent tensor (default `.bfloat16`).
+  /// - Returns: Tuple of `(latents, latentIds, latentHeight, latentWidth)` where
+  ///   latents is `(B, 4*C, H', W')` in patchified NCHW layout.
+  public static func prepareLatents(
+    seed: UInt64,
+    height: Int,
+    width: Int,
+    batchSize: Int = 1,
+    numLatentChannels: Int = defaultNumLatentChannels,
+    vaeScaleFactor: Int = defaultVAEScaleFactor,
+    dtype: DType = .bfloat16
+  ) -> (latents: MLXArray, latentIds: MLXArray, latentHeight: Int, latentWidth: Int) {
+    // Align to patch grid: height/width must be multiples of vaeScaleFactor * 2
+    let alignedHeight = 2 * (height / (vaeScaleFactor * 2))
+    let alignedWidth = 2 * (width / (vaeScaleFactor * 2))
+    let latentHeight = alignedHeight / 2
+    let latentWidth = alignedWidth / 2
+
+    // Generate noise in patchified shape: (B, 4*C, H/2, W/2)
+    let shape = [batchSize, numLatentChannels * 4, latentHeight, latentWidth]
+    let key = MLXRandom.key(seed)
+    let latents = MLXRandom.normal(shape, key: key).asType(dtype)
+
+    let latentIds = prepareGridIds(latents, tCoord: 0)
+
+    return (latents, latentIds, latentHeight, latentWidth)
+  }
+
+  /// Prepare initial noise latents in packed (sequence) format.
+  ///
+  /// Same as `prepareLatents` but additionally packs the spatial dimensions
+  /// into a sequence for direct consumption by the transformer.
+  ///
+  /// - Returns: Tuple of `(packedLatents, latentIds, latentHeight, latentWidth)` where
+  ///   packedLatents is `(B, H'*W', 4*C)` in packed sequence layout.
+  public static func preparePackedLatents(
+    seed: UInt64,
+    height: Int,
+    width: Int,
+    batchSize: Int = 1,
+    numLatentChannels: Int = defaultNumLatentChannels,
+    vaeScaleFactor: Int = defaultVAEScaleFactor,
+    dtype: DType = .bfloat16
+  ) -> (packedLatents: MLXArray, latentIds: MLXArray, latentHeight: Int, latentWidth: Int) {
+    let (latents, latentIds, latentHeight, latentWidth) = prepareLatents(
+      seed: seed,
+      height: height,
+      width: width,
+      batchSize: batchSize,
+      numLatentChannels: numLatentChannels,
+      vaeScaleFactor: vaeScaleFactor,
+      dtype: dtype
+    )
+    return (packLatents(latents), latentIds, latentHeight, latentWidth)
+  }
+}

--- a/Sources/ZImage/Flux2/Flux2ModelDetection.swift
+++ b/Sources/ZImage/Flux2/Flux2ModelDetection.swift
@@ -1,0 +1,168 @@
+// Flux2ModelDetection.swift — Detect Flux 2 Klein models from snapshot directories
+
+import Foundation
+
+/// Model family detection for routing to the correct pipeline.
+public enum ZImageModelFamily: String, Sendable {
+  case flux1 = "flux1"
+  case flux2 = "flux2"
+}
+
+/// Detected Flux 2 Klein model variant with its configuration.
+public struct Flux2DetectedModel {
+  /// The model variant (e.g., "klein-4b", "klein-9b").
+  public let variant: String
+  /// Transformer config parsed from the model directory.
+  public let transformerConfig: Flux2TransformerConfig
+  /// Text encoder config inferred from the model directory.
+  public let textEncoderConfig: Qwen3TextEncoderConfiguration
+}
+
+/// Detects Flux 2 Klein models from snapshot directories.
+public enum Flux2ModelDetection {
+
+  /// Detect whether a model snapshot directory contains a Flux 2 model.
+  ///
+  /// Detection signals:
+  /// 1. `transformer/config.json` contains `"_class_name": "Flux2Transformer2DModel"`
+  /// 2. `text_encoder/config.json` contains `"Qwen3ForCausalLM"` in architectures
+  ///
+  /// - Parameter snapshot: Root URL of the model snapshot directory.
+  /// - Returns: Detected model info, or nil if not a Flux 2 model.
+  public static func detect(at snapshot: URL) -> Flux2DetectedModel? {
+    let fm = FileManager.default
+
+    // Check transformer config for Flux2Transformer2DModel
+    let transformerConfigURL = snapshot
+      .appendingPathComponent("transformer")
+      .appendingPathComponent("config.json")
+
+    guard fm.fileExists(atPath: transformerConfigURL.path),
+          let configData = try? Data(contentsOf: transformerConfigURL),
+          let configDict = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+          let className = configDict["_class_name"] as? String,
+          className == "Flux2Transformer2DModel" else {
+      return nil
+    }
+
+    // Parse transformer config from JSON
+    let numLayers = configDict["num_layers"] as? Int ?? 5
+    let numSingleLayers = configDict["num_single_layers"] as? Int ?? 20
+    let numAttentionHeads = configDict["num_attention_heads"] as? Int ?? 24
+    let attentionHeadDim = configDict["attention_head_dim"] as? Int ?? 128
+    let jointAttentionDim = configDict["joint_attention_dim"] as? Int ?? 7680
+    let inChannels = configDict["in_channels"] as? Int ?? 128
+    let patchSize = configDict["patch_size"] as? Int ?? 1
+    let ropeTheta = configDict["rope_theta"] as? Int ?? 2000
+    let guidanceEmbeds = configDict["guidance_embeds"] as? Bool ?? false
+    let mlpRatio = (configDict["mlp_ratio"] as? NSNumber)?.floatValue ?? 3.0
+
+    let axesDimsRope: [Int]
+    if let axes = configDict["axes_dims_rope"] as? [Int] {
+      axesDimsRope = axes
+    } else {
+      axesDimsRope = [32, 32, 32, 32]
+    }
+
+    let transformerConfig = Flux2TransformerConfig(
+      patchSize: patchSize,
+      inChannels: inChannels,
+      numLayers: numLayers,
+      numSingleLayers: numSingleLayers,
+      attentionHeadDim: attentionHeadDim,
+      numAttentionHeads: numAttentionHeads,
+      jointAttentionDim: jointAttentionDim,
+      mlpRatio: mlpRatio,
+      axesDimsRope: axesDimsRope,
+      ropeTheta: ropeTheta,
+      guidanceEmbeds: guidanceEmbeds
+    )
+
+    // Parse text encoder config if available
+    let textEncoderConfig = parseTextEncoderConfig(at: snapshot) ?? Qwen3TextEncoderConfiguration()
+
+    // Determine variant from model dimensions
+    let variant: String
+    if numLayers == 8 && numSingleLayers == 24 && numAttentionHeads == 32 {
+      variant = "klein-9b"
+    } else {
+      variant = "klein-4b"
+    }
+
+    return Flux2DetectedModel(
+      variant: variant,
+      transformerConfig: transformerConfig,
+      textEncoderConfig: textEncoderConfig
+    )
+  }
+
+  /// Detect model family from a snapshot directory.
+  ///
+  /// - Parameter snapshot: Root URL of the model snapshot directory.
+  /// - Returns: `.flux2` if a Flux2 model is detected, `.flux1` otherwise.
+  public static func detectFamily(at snapshot: URL) -> ZImageModelFamily {
+    if detect(at: snapshot) != nil {
+      return .flux2
+    }
+    return .flux1
+  }
+
+  // MARK: - Text Encoder Config Parsing
+
+  private static func parseTextEncoderConfig(at snapshot: URL) -> Qwen3TextEncoderConfiguration? {
+    let configURL = snapshot
+      .appendingPathComponent("text_encoder")
+      .appendingPathComponent("config.json")
+
+    guard let data = try? Data(contentsOf: configURL),
+          let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return nil
+    }
+
+    // Verify it's a Qwen3 model
+    if let architectures = dict["architectures"] as? [String],
+       !architectures.contains("Qwen3ForCausalLM") {
+      return nil
+    }
+
+    let hiddenSize = dict["hidden_size"] as? Int ?? 2560
+    let numHiddenLayers = dict["num_hidden_layers"] as? Int ?? 36
+    let numAttentionHeads = dict["num_attention_heads"] as? Int ?? 32
+    let numKeyValueHeads = dict["num_key_value_heads"] as? Int ?? 8
+    let intermediateSize = dict["intermediate_size"] as? Int ?? 9728
+    let maxPositionEmbeddings = dict["max_position_embeddings"] as? Int ?? 40960
+    let ropeTheta = (dict["rope_theta"] as? NSNumber)?.floatValue ?? 1_000_000.0
+    let vocabSize = dict["vocab_size"] as? Int ?? 151936
+    let rmsNormEps = (dict["rms_norm_eps"] as? NSNumber)?.floatValue ?? 1e-6
+    let headDim = dict["head_dim"] as? Int ?? 128
+
+    return Qwen3TextEncoderConfiguration(
+      vocabSize: vocabSize,
+      hiddenSize: hiddenSize,
+      numHiddenLayers: numHiddenLayers,
+      numAttentionHeads: numAttentionHeads,
+      numKeyValueHeads: numKeyValueHeads,
+      intermediateSize: intermediateSize,
+      maxPositionEmbeddings: maxPositionEmbeddings,
+      ropeTheta: ropeTheta,
+      rmsNormEps: rmsNormEps,
+      headDim: headDim
+    )
+  }
+
+  /// Known Flux 2 Klein HuggingFace model IDs.
+  public static let knownModelIds: [String] = [
+    "black-forest-labs/FLUX.2-klein-4B",
+    "black-forest-labs/FLUX.2-klein-9B",
+    "black-forest-labs/FLUX.2-klein-base-4B",
+    "black-forest-labs/FLUX.2-klein-base-9B",
+  ]
+
+  /// Check if a model spec string refers to a known Flux 2 model.
+  public static func isKnownFlux2Model(_ modelSpec: String) -> Bool {
+    let normalized = modelSpec.lowercased()
+    return knownModelIds.contains { $0.lowercased() == normalized }
+      || normalized.contains("flux.2-klein")
+      || normalized.contains("flux2-klein")
+  }
+}

--- a/Sources/ZImage/Flux2/Flux2Pipeline.swift
+++ b/Sources/ZImage/Flux2/Flux2Pipeline.swift
@@ -1,0 +1,407 @@
+// Flux2Pipeline.swift — Pipeline orchestration for Flux 2 Klein image generation
+// Ported from mflux: flux2_klein.py
+
+import Foundation
+import Logging
+import MLX
+import MLXNN
+import MLXRandom
+import Hub
+
+/// Configuration for a Flux 2 Klein generation request.
+public struct Flux2GenerationRequest: Sendable {
+  public var prompt: String
+  public var negativePrompt: String?
+  public var width: Int
+  public var height: Int
+  public var steps: Int
+  public var guidanceScale: Float
+  public var seed: UInt64?
+  public var outputPath: URL
+  public var maxSequenceLength: Int
+
+  public init(
+    prompt: String,
+    negativePrompt: String? = nil,
+    width: Int = 1024,
+    height: Int = 1024,
+    steps: Int = 4,
+    guidanceScale: Float = 1.0,
+    seed: UInt64? = nil,
+    outputPath: URL = URL(fileURLWithPath: "flux2-output.png"),
+    maxSequenceLength: Int = 512
+  ) {
+    self.prompt = prompt
+    self.negativePrompt = negativePrompt
+    self.width = width
+    self.height = height
+    self.steps = steps
+    self.guidanceScale = guidanceScale
+    self.seed = seed
+    self.outputPath = outputPath
+    self.maxSequenceLength = maxSequenceLength
+  }
+}
+
+/// Orchestrates Flux 2 Klein image generation.
+///
+/// ## Pipeline Stages
+///
+/// 1. Load model components via `Flux2Initializer`
+/// 2. Load tokenizer and encode prompt via `Flux2PromptEncoder`
+/// 3. Prepare packed latents via `Flux2LatentCreator`
+/// 4. Run denoising loop using flow-match Euler scheduler
+/// 5. Decode packed latents via `Flux2VAE.decodePackedLatents`
+/// 6. Save output image
+///
+/// The Flux 2 denoising loop differs from Flux 1 in several ways:
+/// - Uses packed latents (spatial dims folded into sequence)
+/// - Timestep is passed as a raw sigma value (not normalized)
+/// - Optional CFG with negative prompt when guidance > 1.0
+/// - Transformer expects `(hiddenStates, encoderHiddenStates, timestep, imgIds, txtIds)`
+public final class Flux2Pipeline {
+
+  public enum Flux2PipelineError: Error, LocalizedError {
+    case modelNotLoaded
+    case tokenizerNotLoaded
+    case invalidDimensions(String)
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+      switch self {
+      case .modelNotLoaded: return "Model not loaded"
+      case .tokenizerNotLoaded: return "Tokenizer not loaded"
+      case .invalidDimensions(let msg): return "Invalid dimensions: \(msg)"
+      case .generationFailed(let msg): return "Generation failed: \(msg)"
+      }
+    }
+  }
+
+  /// Progress reporting for Flux 2 generation.
+  public struct GenerationProgress: Sendable {
+    public let stage: Stage
+    public let stepIndex: Int
+    public let totalSteps: Int
+
+    public enum Stage: String, Sendable {
+      case loadingModel = "Loading model"
+      case encodingText = "Encoding text"
+      case denoising = "Denoising"
+      case decoding = "Decoding"
+      case saving = "Saving"
+    }
+
+    public var fractionCompleted: Double {
+      guard totalSteps > 0 else { return 0 }
+      return Double(stepIndex) / Double(totalSteps)
+    }
+  }
+
+  public typealias ProgressHandler = (GenerationProgress) -> Void
+
+  private var logger: Logger
+  private var components: Flux2Initializer.Components?
+  private var tokenizer: QwenTokenizer?
+  private var modelSnapshot: URL?
+  private var isLoaded: Bool = false
+
+  // Model configs for current loaded model
+  private var transformerConfig: Flux2TransformerConfig?
+  private var textEncoderConfig: Qwen3TextEncoderConfiguration?
+
+  public init(logger: Logger = Logger(label: "z-image.flux2-pipeline")) {
+    self.logger = logger
+  }
+
+  /// Whether the model is currently loaded.
+  public var loaded: Bool { isLoaded }
+
+  /// Unload model components and free memory.
+  public func unload() {
+    components = nil
+    tokenizer = nil
+    modelSnapshot = nil
+    transformerConfig = nil
+    textEncoderConfig = nil
+    isLoaded = false
+    GPU.clearCache()
+    logger.info("Flux 2 model unloaded")
+  }
+
+  /// Load the Flux 2 Klein model from a snapshot directory.
+  ///
+  /// - Parameters:
+  ///   - snapshot: Root URL of the model snapshot directory.
+  ///   - config: Transformer config for this model variant. Defaults to Klein 4B.
+  ///   - textEncoderConfig: Text encoder config. Defaults to Klein 4B Qwen3 config.
+  ///   - progressHandler: Optional progress callback.
+  public func loadModel(
+    from snapshot: URL,
+    config: Flux2TransformerConfig = Flux2TransformerConfig(),
+    textEncoderConfig: Qwen3TextEncoderConfiguration = Qwen3TextEncoderConfiguration(),
+    progressHandler: ProgressHandler? = nil
+  ) throws {
+    if isLoaded && modelSnapshot == snapshot { return }
+
+    progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 0, totalSteps: 1))
+
+    // Load tokenizer
+    let tokenizerDir = snapshot.appendingPathComponent("tokenizer")
+    let hub = HubApi()
+    self.tokenizer = try QwenTokenizer.load(from: tokenizerDir, hubApi: hub)
+
+    // Load all model components
+    self.components = try Flux2Initializer.load(
+      from: snapshot,
+      transformerConfig: config,
+      textEncoderConfig: textEncoderConfig,
+      dtype: .bfloat16,
+      logger: logger
+    )
+
+    self.modelSnapshot = snapshot
+    self.transformerConfig = config
+    self.textEncoderConfig = textEncoderConfig
+    self.isLoaded = true
+
+    progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 1, totalSteps: 1))
+    logger.info("Flux 2 Klein model loaded from \(snapshot.path)")
+  }
+
+  /// Generate an image and save it to disk.
+  ///
+  /// - Parameters:
+  ///   - request: Generation parameters.
+  ///   - progressHandler: Optional progress callback.
+  /// - Returns: The output file URL.
+  public func generate(
+    _ request: Flux2GenerationRequest,
+    progressHandler: ProgressHandler? = nil
+  ) async throws -> URL {
+    let decoded = try await generateCore(request, progressHandler: progressHandler)
+
+    progressHandler?(GenerationProgress(stage: .saving, stepIndex: request.steps, totalSteps: request.steps))
+    try QwenImageIO.saveImage(array: decoded, to: request.outputPath)
+    logger.info("Wrote image to \(request.outputPath.path)")
+
+    return request.outputPath
+  }
+
+  /// Generate an image and return raw PNG data.
+  public func generateToMemory(
+    _ request: Flux2GenerationRequest,
+    progressHandler: ProgressHandler? = nil
+  ) async throws -> Data {
+    let decoded = try await generateCore(request, progressHandler: progressHandler)
+
+    progressHandler?(GenerationProgress(stage: .saving, stepIndex: request.steps, totalSteps: request.steps))
+    let imageData = try QwenImageIO.imageData(from: decoded)
+    logger.info("Generated image data (\(imageData.count) bytes)")
+
+    return imageData
+  }
+
+  // MARK: - Core Generation
+
+  private func generateCore(
+    _ request: Flux2GenerationRequest,
+    progressHandler: ProgressHandler? = nil
+  ) async throws -> MLXArray {
+    guard let components = components else {
+      throw Flux2PipelineError.modelNotLoaded
+    }
+    guard let tokenizer = tokenizer else {
+      throw Flux2PipelineError.tokenizerNotLoaded
+    }
+
+    // Validate dimensions — Flux 2 needs multiples of 16
+    let vaeScale = 16
+    if request.width % vaeScale != 0 {
+      throw Flux2PipelineError.invalidDimensions(
+        "Width must be divisible by \(vaeScale) (got \(request.width))"
+      )
+    }
+    if request.height % vaeScale != 0 {
+      throw Flux2PipelineError.invalidDimensions(
+        "Height must be divisible by \(vaeScale) (got \(request.height))"
+      )
+    }
+
+    // 1. Encode prompt
+    progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 0, totalSteps: request.steps))
+    logger.info("Encoding prompt...")
+
+    let doCFG = request.guidanceScale > 1.0
+
+    let (promptEmbeds, textIds) = Flux2PromptEncoder.encodePrompt(
+      prompt: request.prompt,
+      tokenizer: tokenizer,
+      textEncoder: components.textEncoder,
+      numImagesPerPrompt: 1,
+      maxSequenceLength: request.maxSequenceLength,
+      textEncoderOutLayers: Flux2PromptEncoder.defaultOutputLayers
+    )
+
+    var negativePromptEmbeds: MLXArray?
+    var negativeTextIds: MLXArray?
+    if doCFG {
+      let negPrompt = request.negativePrompt ?? " "
+      let (ne, nti) = Flux2PromptEncoder.encodePrompt(
+        prompt: negPrompt,
+        tokenizer: tokenizer,
+        textEncoder: components.textEncoder,
+        numImagesPerPrompt: 1,
+        maxSequenceLength: request.maxSequenceLength,
+        textEncoderOutLayers: Flux2PromptEncoder.defaultOutputLayers
+      )
+      negativePromptEmbeds = ne
+      negativeTextIds = nti
+      MLX.eval(promptEmbeds, ne)
+    } else {
+      MLX.eval(promptEmbeds)
+    }
+    logger.info("Text encoding complete")
+
+    // 2. Prepare latents
+    let seed = request.seed ?? UInt64.random(in: 0...UInt64.max)
+    let (packedLatents, latentIds, latentHeight, latentWidth) = Flux2LatentCreator.preparePackedLatents(
+      seed: seed,
+      height: request.height,
+      width: request.width,
+      batchSize: 1
+    )
+    var latents = packedLatents
+
+    // 3. Build sigma schedule
+    // Flux 2 uses FlowMatchEulerDiscrete with empirical mu shift.
+    let hPatches = request.height / 16
+    let wPatches = request.width / 16
+    let imageSeqLen = hPatches * wPatches
+    let mu = Flux2Pipeline.computeEmpiricalMu(imageSeqLen: imageSeqLen, numSteps: request.steps)
+
+    let sigmaValues = Flux2Pipeline.computeFlux2Sigmas(
+      numSteps: request.steps,
+      mu: mu,
+      numTrainTimesteps: 1000
+    )
+
+    let sigmas = MLXArray(sigmaValues)
+
+    // 4. Denoising loop
+    logger.info("Running \(request.steps) denoising steps...")
+    for stepIndex in 0..<request.steps {
+      try Task.checkCancellation()
+      progressHandler?(GenerationProgress(stage: .denoising, stepIndex: stepIndex, totalSteps: request.steps))
+
+      let timestep = sigmas[stepIndex]
+
+      // Forward pass through transformer
+      let noisePred = components.transformer(
+        hiddenStates: latents,
+        encoderHiddenStates: promptEmbeds,
+        timestep: timestep,
+        imgIds: latentIds,
+        txtIds: textIds,
+        guidance: nil
+      )
+
+      // Apply CFG if guidance > 1.0
+      let guidedNoise: MLXArray
+      if doCFG, let ne = negativePromptEmbeds, let nti = negativeTextIds {
+        let negativeNoisePred = components.transformer(
+          hiddenStates: latents,
+          encoderHiddenStates: ne,
+          timestep: timestep,
+          imgIds: latentIds,
+          txtIds: nti,
+          guidance: nil
+        )
+        guidedNoise = negativeNoisePred + request.guidanceScale * (noisePred - negativeNoisePred)
+      } else {
+        guidedNoise = noisePred
+      }
+
+      // Euler step: latents = latents + noise * dt
+      // Note: In Python mflux, step does latents + dt * noise where dt = sigmas[t+1] - sigmas[t]
+      let dt = (sigmas[stepIndex + 1] - sigmas[stepIndex]).asType(latents.dtype)
+      latents = latents + guidedNoise * dt
+      MLX.eval(latents)
+    }
+
+    progressHandler?(GenerationProgress(stage: .denoising, stepIndex: request.steps, totalSteps: request.steps))
+    logger.info("Denoising complete")
+
+    // 5. Decode latents
+    progressHandler?(GenerationProgress(stage: .decoding, stepIndex: request.steps, totalSteps: request.steps))
+    logger.info("Decoding with VAE...")
+
+    // Reshape packed latents back to spatial for VAE decode
+    // packed: (B, H'*W', 4*C) -> (B, 4*C, H', W')
+    let packedForVAE = latents
+      .reshaped(latents.shape[0], latentHeight, latentWidth, latents.shape[latents.ndim - 1])
+      .transposed(0, 3, 1, 2)
+
+    let decoded = components.vae.decodePackedLatents(packedForVAE)
+
+    // Denormalize from [-1, 1] to [0, 1]
+    let image = QwenImageIO.denormalizeFromDecoder(decoded)
+    let clipped = MLX.clip(image, min: 0, max: 1)
+    MLX.eval(clipped)
+
+    GPU.clearCache()
+    return clipped
+  }
+
+  // MARK: - Flux2 Sigma Schedule
+
+  /// Compute empirical mu for the Flux 2 exponential time shift.
+  ///
+  /// Ported from mflux `FlowMatchEulerDiscreteScheduler._compute_empirical_mu`.
+  /// The mu value controls the time shift applied to the sigma schedule,
+  /// varying based on image resolution (sequence length) and number of steps.
+  static func computeEmpiricalMu(imageSeqLen: Int, numSteps: Int) -> Float {
+    let a1: Float = 8.73809524e-05
+    let b1: Float = 1.89833333
+    let a2: Float = 0.00016927
+    let b2: Float = 0.45666666
+
+    if imageSeqLen > 4300 {
+      return a2 * Float(imageSeqLen) + b2
+    }
+
+    let m200 = a2 * Float(imageSeqLen) + b2
+    let m10 = a1 * Float(imageSeqLen) + b1
+    let a = (m200 - m10) / 190.0
+    let b = m200 - 200.0 * a
+    return a * Float(numSteps) + b
+  }
+
+  /// Compute the Flux 2 sigma schedule with exponential time shift.
+  ///
+  /// Ported from mflux `FlowMatchEulerDiscreteScheduler.get_timesteps_and_sigmas`.
+  /// Unlike the Flux 1 schedule, Flux 2 uses:
+  /// - Empirical mu (resolution + step dependent) instead of simple shift
+  /// - Exponential time shift: sigma = exp(mu) / (exp(mu) + (1/t - 1)^1)
+  static func computeFlux2Sigmas(
+    numSteps: Int,
+    mu: Float,
+    numTrainTimesteps: Int
+  ) -> [Float] {
+    // Linear sigmas from 1.0 down to 1/numSteps
+    let linearSigmas: [Float] = (0..<numSteps).map { i in
+      let t = Float(i) / Float(max(1, numSteps - 1))
+      return 1.0 - t * (1.0 - 1.0 / Float(numSteps))
+    }
+
+    // Apply exponential time shift
+    let expMu = exp(mu)
+    let shifted: [Float] = linearSigmas.map { t in
+      expMu / (expMu + pow(1.0 / t - 1.0, 1.0))
+    }
+
+    // Append trailing zero
+    var sigmas = shifted
+    sigmas.append(0.0)
+    return sigmas
+  }
+}

--- a/Sources/ZImage/Flux2/Flux2Pipeline.swift
+++ b/Sources/ZImage/Flux2/Flux2Pipeline.swift
@@ -233,7 +233,7 @@ public final class Flux2Pipeline {
 
     let doCFG = request.guidanceScale > 1.0
 
-    let (promptEmbeds, textIds) = Flux2PromptEncoder.encodePrompt(
+    let (promptEmbeds, textIds) = try Flux2PromptEncoder.encodePrompt(
       prompt: request.prompt,
       tokenizer: tokenizer,
       textEncoder: components.textEncoder,
@@ -246,7 +246,7 @@ public final class Flux2Pipeline {
     var negativeTextIds: MLXArray?
     if doCFG {
       let negPrompt = request.negativePrompt ?? " "
-      let (ne, nti) = Flux2PromptEncoder.encodePrompt(
+      let (ne, nti) = try Flux2PromptEncoder.encodePrompt(
         prompt: negPrompt,
         tokenizer: tokenizer,
         textEncoder: components.textEncoder,

--- a/Sources/ZImage/Flux2/TextEncoder/Flux2PromptEncoder.swift
+++ b/Sources/ZImage/Flux2/TextEncoder/Flux2PromptEncoder.swift
@@ -1,0 +1,117 @@
+// Flux2PromptEncoder.swift — Tokenization + encoding for Flux 2 Klein
+// Ported from mflux: prompt_encoder.py
+
+import MLX
+
+/// Encodes text prompts for the Flux 2 Klein diffusion model.
+///
+/// Tokenizes the input prompt using the existing `QwenTokenizer`, runs it
+/// through the `Qwen3TextEncoder`, and extracts multi-layer hidden states
+/// (layers 9, 18, 27) to produce prompt embeddings for the transformer.
+public enum Flux2PromptEncoder {
+
+  /// Default hidden state extraction layers for Flux 2 Klein.
+  public static let defaultOutputLayers: [Int] = [9, 18, 27]
+
+  /// Encode a text prompt into prompt embeddings and text coordinate IDs.
+  ///
+  /// - Parameters:
+  ///   - prompt: The text prompt (single string or array).
+  ///   - tokenizer: A `QwenTokenizer` loaded from the Flux 2 Klein model.
+  ///   - textEncoder: A `Qwen3TextEncoder` with loaded weights.
+  ///   - numImagesPerPrompt: Batch repeat factor (default 1).
+  ///   - maxSequenceLength: Maximum token sequence length (default 512).
+  ///   - textEncoderOutLayers: Layer indices for hidden state extraction.
+  /// - Returns: `(promptEmbeds, textIds)` where promptEmbeds is
+  ///   `[B, S, numLayers * hiddenDim]` and textIds is `[B, S, 4]`.
+  public static func encodePrompt(
+    prompt: String,
+    tokenizer: QwenTokenizer,
+    textEncoder: Qwen3TextEncoder,
+    numImagesPerPrompt: Int = 1,
+    maxSequenceLength: Int = 512,
+    textEncoderOutLayers: [Int] = defaultOutputLayers
+  ) -> (promptEmbeds: MLXArray, textIds: MLXArray) {
+    var promptEmbeds = getQwen3PromptEmbeds(
+      prompt: prompt,
+      tokenizer: tokenizer,
+      textEncoder: textEncoder,
+      maxSequenceLength: maxSequenceLength,
+      hiddenStateLayers: textEncoderOutLayers
+    )
+
+    if numImagesPerPrompt > 1 {
+      promptEmbeds = MLX.repeated(promptEmbeds, count: numImagesPerPrompt, axis: 0)
+    }
+
+    let textIds = prepareTextIds(promptEmbeds)
+    return (promptEmbeds, textIds)
+  }
+
+  /// Tokenize and encode a prompt, extracting multi-layer hidden states.
+  private static func getQwen3PromptEmbeds(
+    prompt: String,
+    tokenizer: QwenTokenizer,
+    textEncoder: Qwen3TextEncoder,
+    maxSequenceLength: Int,
+    hiddenStateLayers: [Int]
+  ) -> MLXArray {
+    let tokens = tokenizer.encodePlain(
+      prompts: [prompt],
+      maxLength: maxSequenceLength
+    )
+    return textEncoder.getPromptEmbeds(
+      inputIds: tokens.inputIds,
+      attentionMask: tokens.attentionMask,
+      hiddenStateLayers: hiddenStateLayers
+    )
+  }
+
+  /// Prepare text coordinate IDs for the transformer.
+  ///
+  /// Each token gets a 4D coordinate `[t, h, w, tokenIndex]` where `t`, `h`,
+  /// `w` are zero (text has no spatial position) and `tokenIndex` is the
+  /// sequential position within the sequence.
+  ///
+  /// - Parameters:
+  ///   - x: Prompt embeddings `[B, S, D]`, used only for shape.
+  ///   - tCoord: Optional per-batch temporal coordinate override.
+  /// - Returns: Text IDs `[B, S, 4]`.
+  public static func prepareTextIds(
+    _ x: MLXArray,
+    tCoord: MLXArray? = nil
+  ) -> MLXArray {
+    let batchSize = x.dim(0)
+    let seqLen = x.dim(1)
+
+    var outIds: [MLXArray] = []
+    outIds.reserveCapacity(batchSize)
+
+    for i in 0..<batchSize {
+      let t: MLXArray
+      if let tCoord {
+        let tc = tCoord[i]
+        if tc.ndim == 0 {
+          t = MLX.full([seqLen], values: tc, dtype: .int32)
+        } else if tc.dim(0) != seqLen {
+          t = MLX.broadcast(tc, to: [seqLen])
+        } else {
+          t = tc.asType(.int32)
+        }
+      } else {
+        t = MLX.zeros([seqLen], dtype: .int32)
+      }
+
+      let h = MLX.zeros([seqLen], dtype: .int32)
+      let w = MLX.zeros([seqLen], dtype: .int32)
+      let tokenIds = MLXArray(0..<seqLen)
+
+      // Stack [t, h, w, tokenIds] -> [S, 4]
+      let coords = MLX.stacked([t, h, w, tokenIds], axis: 1)
+      outIds.append(coords)
+    }
+
+    // Stack batches -> [B, S, 4]
+    return MLX.stacked(outIds, axis: 0)
+  }
+}

--- a/Sources/ZImage/Flux2/TextEncoder/Flux2PromptEncoder.swift
+++ b/Sources/ZImage/Flux2/TextEncoder/Flux2PromptEncoder.swift
@@ -31,8 +31,8 @@ public enum Flux2PromptEncoder {
     numImagesPerPrompt: Int = 1,
     maxSequenceLength: Int = 512,
     textEncoderOutLayers: [Int] = defaultOutputLayers
-  ) -> (promptEmbeds: MLXArray, textIds: MLXArray) {
-    var promptEmbeds = getQwen3PromptEmbeds(
+  ) throws -> (promptEmbeds: MLXArray, textIds: MLXArray) {
+    var promptEmbeds = try getQwen3PromptEmbeds(
       prompt: prompt,
       tokenizer: tokenizer,
       textEncoder: textEncoder,
@@ -55,8 +55,8 @@ public enum Flux2PromptEncoder {
     textEncoder: Qwen3TextEncoder,
     maxSequenceLength: Int,
     hiddenStateLayers: [Int]
-  ) -> MLXArray {
-    let tokens = tokenizer.encodePlain(
+  ) throws -> MLXArray {
+    let tokens = try tokenizer.encodeChat(
       prompts: [prompt],
       maxLength: maxSequenceLength
     )

--- a/Sources/ZImage/Flux2/TextEncoder/Qwen3RoPE.swift
+++ b/Sources/ZImage/Flux2/TextEncoder/Qwen3RoPE.swift
@@ -1,0 +1,70 @@
+// Qwen3RoPE.swift — Rotary position embeddings for Qwen3 text encoder
+// Ported from mflux: qwen3_text_rotary_embedding.py
+
+import MLX
+import MLXNN
+
+/// Rotary position embeddings for the Qwen3 text encoder.
+///
+/// Unlike the existing Flux 1 `RoPE` (which uses MLXFast), this implementation
+/// matches the mflux Qwen3TextRotaryEmbedding exactly: pre-computed inverse
+/// frequencies scaled by `scalingFactor`, returning `(cos, sin)` tuples that
+/// the attention layer applies via rotate-half.
+public final class Qwen3RoPE: Module {
+  let dim: Int
+  let maxPositionEmbeddings: Int
+  let base: Float
+  let scalingFactor: Float
+  let invFreq: MLXArray
+
+  public init(
+    dim: Int,
+    maxPositionEmbeddings: Int = 40_960,
+    base: Float = 1_000_000.0,
+    scalingFactor: Float = 1.0
+  ) {
+    self.dim = dim
+    self.maxPositionEmbeddings = maxPositionEmbeddings
+    self.base = base
+    self.scalingFactor = scalingFactor
+
+    // inv_freq = 1.0 / (base ** (arange(0, dim, 2) / dim))
+    let indices = MLXArray(stride(from: 0, to: dim, by: 2).map { Float($0) })
+    self.invFreq = 1.0 / MLX.pow(MLXArray(base), indices / Float(dim))
+  }
+
+  /// Compute rotary embeddings for the given hidden states and position IDs.
+  ///
+  /// - Parameters:
+  ///   - x: Hidden states, used only for dtype casting. Shape: `[B, S, H]`.
+  ///   - positionIds: Integer position IDs. Shape: `[B, S]` or `[S]`.
+  /// - Returns: `(cos, sin)` each of shape `[B, S, dim]`, cast to `x.dtype`.
+  public func callAsFunction(
+    _ x: MLXArray,
+    positionIds: MLXArray
+  ) -> (cos: MLXArray, sin: MLXArray) {
+    var ids = positionIds
+    if ids.ndim == 1 {
+      ids = ids.expandedDimensions(axis: 0)
+    }
+
+    // inv_freq: [dim/2] -> [1, 1, dim/2]
+    let invFreqExpanded = invFreq
+      .expandedDimensions(axis: 0)
+      .expandedDimensions(axis: 0)
+
+    // pos: [B, S] -> [B, S, 1]
+    let pos = ids.asType(.float32).expandedDimensions(axis: -1)
+
+    // freqs: [B, S, dim/2]
+    let freqs = pos * invFreqExpanded
+
+    // emb: [B, S, dim] (concatenate freqs with itself)
+    let emb = MLX.concatenated([freqs, freqs], axis: -1)
+
+    let cosValues = MLX.cos(emb) * scalingFactor
+    let sinValues = MLX.sin(emb) * scalingFactor
+
+    return (cosValues.asType(x.dtype), sinValues.asType(x.dtype))
+  }
+}

--- a/Sources/ZImage/Flux2/TextEncoder/Qwen3TextEncoder.swift
+++ b/Sources/ZImage/Flux2/TextEncoder/Qwen3TextEncoder.swift
@@ -1,0 +1,457 @@
+// Qwen3TextEncoder.swift — Qwen3 text encoder for Flux 2 Klein
+// Ported from mflux: qwen3_text_encoder.py, qwen3_vl_decoder_layer.py,
+//                     qwen3_vl_attention.py, qwen3_vl_mlp.py, qwen3_vl_rms_norm.py
+
+import MLX
+import MLXNN
+import MLXFast
+
+// MARK: - Configuration
+
+public struct Qwen3TextEncoderConfiguration {
+  public var vocabSize: Int
+  public var hiddenSize: Int
+  public var numHiddenLayers: Int
+  public var numAttentionHeads: Int
+  public var numKeyValueHeads: Int
+  public var intermediateSize: Int
+  public var maxPositionEmbeddings: Int
+  public var ropeTheta: Float
+  public var rmsNormEps: Float
+  public var headDim: Int
+  public var attentionBias: Bool
+  public var attentionScaling: Float
+
+  public init(
+    vocabSize: Int = 151_936,
+    hiddenSize: Int = 2560,
+    numHiddenLayers: Int = 36,
+    numAttentionHeads: Int = 32,
+    numKeyValueHeads: Int = 8,
+    intermediateSize: Int = 9_728,
+    maxPositionEmbeddings: Int = 40_960,
+    ropeTheta: Float = 1_000_000.0,
+    rmsNormEps: Float = 1e-6,
+    headDim: Int = 128,
+    attentionBias: Bool = false,
+    attentionScaling: Float = 1.0
+  ) {
+    self.vocabSize = vocabSize
+    self.hiddenSize = hiddenSize
+    self.numHiddenLayers = numHiddenLayers
+    self.numAttentionHeads = numAttentionHeads
+    self.numKeyValueHeads = numKeyValueHeads
+    self.intermediateSize = intermediateSize
+    self.maxPositionEmbeddings = maxPositionEmbeddings
+    self.ropeTheta = ropeTheta
+    self.rmsNormEps = rmsNormEps
+    self.headDim = headDim
+    self.attentionBias = attentionBias
+    self.attentionScaling = attentionScaling
+  }
+}
+
+// MARK: - RMS Norm (Qwen3VLRMSNorm port)
+
+/// RMSNorm matching the mflux Qwen3VLRMSNorm: casts to float32 for variance
+/// computation, applies learned weight, then casts back to input dtype.
+public final class Qwen3RMSNorm: Module {
+  @ModuleInfo(key: "weight") var weight: MLXArray
+  let eps: Float
+
+  public init(hiddenSize: Int, eps: Float = 1e-6) {
+    self.eps = eps
+    self._weight.wrappedValue = MLX.ones([hiddenSize])
+  }
+
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let inputDtype = x.dtype
+    let h = x.asType(.float32)
+    let variance = MLX.mean(h * h, axis: -1, keepDims: true)
+    let normed = h * MLX.rsqrt(variance + MLXArray(eps))
+    return (weight.asType(.float32) * normed).asType(inputDtype)
+  }
+}
+
+// MARK: - MLP (Qwen3VLMLP port)
+
+/// SwiGLU MLP: gate_proj -> silu, up_proj, multiply, down_proj.
+public final class Qwen3MLP: Module {
+  @ModuleInfo(key: "gate_proj") var gateProj: Linear
+  @ModuleInfo(key: "down_proj") var downProj: Linear
+  @ModuleInfo(key: "up_proj") var upProj: Linear
+
+  public init(hiddenSize: Int, intermediateSize: Int) {
+    self._gateProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+    self._downProj.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
+    self._upProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+  }
+
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    downProj(silu(gateProj(x)) * upProj(x))
+  }
+}
+
+// MARK: - Attention (Qwen3VLAttention port)
+
+/// Multi-head attention with grouped query attention and rotary position embeddings.
+/// Position embeddings are passed as `(cos, sin)` from the external `Qwen3RoPE`.
+public final class Qwen3Attention: Module {
+  let hiddenSize: Int
+  let numAttentionHeads: Int
+  let numKeyValueHeads: Int
+  let headDim: Int
+  let numKeyValueGroups: Int
+  let scaling: Float
+
+  @ModuleInfo(key: "q_proj") var qProj: Linear
+  @ModuleInfo(key: "k_proj") var kProj: Linear
+  @ModuleInfo(key: "v_proj") var vProj: Linear
+  @ModuleInfo(key: "o_proj") var oProj: Linear
+  @ModuleInfo(key: "q_norm") var qNorm: Qwen3RMSNorm
+  @ModuleInfo(key: "k_norm") var kNorm: Qwen3RMSNorm
+
+  public init(configuration: Qwen3TextEncoderConfiguration) {
+    self.hiddenSize = configuration.hiddenSize
+    self.numAttentionHeads = configuration.numAttentionHeads
+    self.numKeyValueHeads = configuration.numKeyValueHeads
+    self.headDim = configuration.headDim
+    self.numKeyValueGroups = configuration.numAttentionHeads / configuration.numKeyValueHeads
+    self.scaling = 1.0 / Float(configuration.headDim).squareRoot()
+
+    let bias = configuration.attentionBias
+    self._qProj.wrappedValue = Linear(hiddenSize, numAttentionHeads * headDim, bias: bias)
+    self._kProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: bias)
+    self._vProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: bias)
+    self._oProj.wrappedValue = Linear(numAttentionHeads * headDim, hiddenSize, bias: bias)
+    self._qNorm.wrappedValue = Qwen3RMSNorm(hiddenSize: headDim, eps: configuration.rmsNormEps)
+    self._kNorm.wrappedValue = Qwen3RMSNorm(hiddenSize: headDim, eps: configuration.rmsNormEps)
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Input tensor `[B, S, hiddenSize]`.
+  ///   - attentionMask: 4D additive mask `[B, 1, S, S]` (0 = attend, -inf = mask).
+  ///   - positionEmbeddings: `(cos, sin)` from `Qwen3RoPE`.
+  /// - Returns: `(output, (cachedKeys, cachedValues))`.
+  public func callAsFunction(
+    hiddenStates: MLXArray,
+    attentionMask: MLXArray?,
+    positionEmbeddings: (cos: MLXArray, sin: MLXArray)?
+  ) -> (MLXArray, (MLXArray, MLXArray)) {
+    let bsz = hiddenStates.dim(0)
+    let qLen = hiddenStates.dim(1)
+
+    // Project and reshape to [B, heads, S, headDim]
+    var queryStates = qProj(hiddenStates)
+      .reshaped(bsz, qLen, numAttentionHeads, headDim)
+    var keyStates = kProj(hiddenStates)
+      .reshaped(bsz, qLen, numKeyValueHeads, headDim)
+    var valueStates = vProj(hiddenStates)
+      .reshaped(bsz, qLen, numKeyValueHeads, headDim)
+
+    // QK norm
+    queryStates = qNorm(queryStates)
+    keyStates = kNorm(keyStates)
+
+    // Transpose to [B, heads, S, headDim]
+    queryStates = queryStates.transposed(0, 2, 1, 3)
+    keyStates = keyStates.transposed(0, 2, 1, 3)
+    valueStates = valueStates.transposed(0, 2, 1, 3)
+
+    // Apply rotary embeddings
+    if let (cos, sin) = positionEmbeddings {
+      let cosExpanded = cos.expandedDimensions(axis: 1) // [B, 1, S, dim]
+      let sinExpanded = sin.expandedDimensions(axis: 1)
+      queryStates = (queryStates * cosExpanded) + (Qwen3Attention.rotateHalf(queryStates) * sinExpanded)
+      keyStates = (keyStates * cosExpanded) + (Qwen3Attention.rotateHalf(keyStates) * sinExpanded)
+    }
+
+    // GQA: expand KV heads to match Q heads
+    if numKeyValueHeads != numAttentionHeads {
+      keyStates = Qwen3Attention.repeatKV(keyStates, nRep: numKeyValueGroups)
+      valueStates = Qwen3Attention.repeatKV(valueStates, nRep: numKeyValueGroups)
+    }
+
+    // Attention in float32
+    let qF32 = queryStates.asType(.float32)
+    let kF32 = keyStates.asType(.float32)
+    let vF32 = valueStates.asType(.float32)
+
+    var attnOutput = MLXFast.scaledDotProductAttention(
+      queries: qF32,
+      keys: kF32,
+      values: vF32,
+      scale: scaling,
+      mask: attentionMask.map { .array($0) } ?? .none
+    )
+
+    attnOutput = attnOutput.asType(queryStates.dtype)
+
+    // Reshape back to [B, S, hiddenSize]
+    attnOutput = attnOutput.transposed(0, 2, 1, 3).reshaped(bsz, qLen, numAttentionHeads * headDim)
+    let output = oProj(attnOutput)
+
+    return (output, (keyStates, valueStates))
+  }
+
+  // MARK: - Rotary helpers
+
+  /// Rotate the second half of the last dimension: [-x2, x1]
+  static func rotateHalf(_ x: MLXArray) -> MLXArray {
+    let halfDim = x.dim(-1) / 2
+    let x1 = x[.ellipsis, ..<halfDim]
+    let x2 = x[.ellipsis, halfDim...]
+    return MLX.concatenated([-x2, x1], axis: -1)
+  }
+
+  /// Expand KV heads by repeating along the head dimension.
+  static func repeatKV(_ x: MLXArray, nRep: Int) -> MLXArray {
+    guard nRep > 1 else { return x }
+    let shape = x.shape // [B, numKVHeads, S, headDim]
+    var expanded = x.expandedDimensions(axis: 2) // [B, numKVHeads, 1, S, headDim]
+    expanded = MLX.broadcast(expanded, to: [shape[0], shape[1], nRep, shape[2], shape[3]])
+    return expanded.reshaped(shape[0], shape[1] * nRep, shape[2], shape[3])
+  }
+}
+
+// MARK: - Decoder Layer (Qwen3VLDecoderLayer port)
+
+/// Single transformer decoder layer: layernorm -> attention -> residual -> layernorm -> MLP -> residual.
+public final class Qwen3DecoderLayer: Module {
+  @ModuleInfo(key: "input_layernorm") var inputLayerNorm: Qwen3RMSNorm
+  @ModuleInfo(key: "self_attn") var selfAttn: Qwen3Attention
+  @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: Qwen3RMSNorm
+  let mlp: Qwen3MLP
+
+  public init(configuration: Qwen3TextEncoderConfiguration) {
+    self._inputLayerNorm.wrappedValue = Qwen3RMSNorm(
+      hiddenSize: configuration.hiddenSize, eps: configuration.rmsNormEps)
+    self._selfAttn.wrappedValue = Qwen3Attention(configuration: configuration)
+    self._postAttentionLayerNorm.wrappedValue = Qwen3RMSNorm(
+      hiddenSize: configuration.hiddenSize, eps: configuration.rmsNormEps)
+    self.mlp = Qwen3MLP(
+      hiddenSize: configuration.hiddenSize, intermediateSize: configuration.intermediateSize)
+  }
+
+  /// - Returns: `(hiddenStates, (cachedKeys, cachedValues))`
+  public func callAsFunction(
+    _ hiddenStates: MLXArray,
+    attentionMask: MLXArray?,
+    positionEmbeddings: (cos: MLXArray, sin: MLXArray)?
+  ) -> (MLXArray, (MLXArray, MLXArray)) {
+    let residual = hiddenStates
+    let normed = inputLayerNorm(hiddenStates)
+    let (attnOutput, pastKV) = selfAttn(
+      hiddenStates: normed,
+      attentionMask: attentionMask,
+      positionEmbeddings: positionEmbeddings
+    )
+    var h = residual + attnOutput
+
+    let residual2 = h
+    h = postAttentionLayerNorm(h)
+    h = mlp(h)
+    h = residual2 + h
+
+    return (h, pastKV)
+  }
+}
+
+// MARK: - Qwen3 Text Encoder (top-level model)
+
+/// Full Qwen3 text encoder model for Flux 2 Klein.
+///
+/// Embeds input tokens, applies 36 transformer decoder layers with rotary
+/// position embeddings, and produces either the final hidden state or
+/// multi-layer prompt embeddings (layers 9, 18, 27) for the diffusion model.
+public final class Qwen3TextEncoder: Module {
+  public let configuration: Qwen3TextEncoderConfiguration
+
+  @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+  @ModuleInfo(key: "layers") var layers: [Qwen3DecoderLayer]
+  @ModuleInfo(key: "norm") var norm: Qwen3RMSNorm
+
+  let rotaryEmb: Qwen3RoPE
+
+  public init(configuration: Qwen3TextEncoderConfiguration = .init()) {
+    self.configuration = configuration
+
+    self._embedTokens.wrappedValue = Embedding(
+      embeddingCount: configuration.vocabSize,
+      dimensions: configuration.hiddenSize
+    )
+
+    self._layers.wrappedValue = (0..<configuration.numHiddenLayers).map { _ in
+      Qwen3DecoderLayer(configuration: configuration)
+    }
+
+    self._norm.wrappedValue = Qwen3RMSNorm(
+      hiddenSize: configuration.hiddenSize,
+      eps: configuration.rmsNormEps
+    )
+
+    self.rotaryEmb = Qwen3RoPE(
+      dim: configuration.headDim,
+      maxPositionEmbeddings: configuration.maxPositionEmbeddings,
+      base: configuration.ropeTheta,
+      scalingFactor: configuration.attentionScaling
+    )
+  }
+
+  /// Forward pass through the full encoder.
+  ///
+  /// - Parameters:
+  ///   - inputIds: Token IDs `[B, S]`.
+  ///   - attentionMask: Optional `[B, S]` mask (1 = attend, 0 = pad).
+  ///   - outputHiddenStates: When true, collects hidden states after each layer.
+  /// - Returns: `(lastHiddenState, hiddenStatesList)` where the list includes
+  ///   the embedding output at index 0 and each layer output at indices 1..N.
+  public func callAsFunction(
+    inputIds: MLXArray,
+    attentionMask: MLXArray? = nil,
+    outputHiddenStates: Bool = false
+  ) -> (lastHiddenState: MLXArray, hiddenStates: [MLXArray]?) {
+    let batchSize = inputIds.dim(0)
+    let seqLen = inputIds.dim(1)
+
+    var hiddenStates = embedTokens(inputIds)
+
+    // Build 4D causal + padding attention mask
+    let mask: MLXArray?
+    if let attentionMask {
+      mask = buildAttentionMask4D(
+        attentionMask: attentionMask,
+        batchSize: batchSize,
+        seqLen: seqLen,
+        dtype: hiddenStates.dtype
+      )
+    } else {
+      mask = buildCausalMask(batchSize: batchSize, seqLen: seqLen, dtype: hiddenStates.dtype)
+    }
+
+    // Position IDs: [B, S]
+    let posIds = MLX.broadcast(
+      MLXArray(0..<seqLen).expandedDimensions(axis: 0),
+      to: [batchSize, seqLen]
+    )
+    let positionEmbeddings = rotaryEmb(hiddenStates, positionIds: posIds)
+
+    // Collect hidden states (embedding output is index 0)
+    var hiddenStatesList: [MLXArray]? = outputHiddenStates ? [hiddenStates] : nil
+
+    for layer in layers {
+      let (output, _) = layer(
+        hiddenStates,
+        attentionMask: mask,
+        positionEmbeddings: positionEmbeddings
+      )
+      hiddenStates = output
+      if outputHiddenStates {
+        hiddenStatesList?.append(hiddenStates)
+      }
+    }
+
+    hiddenStates = norm(hiddenStates)
+
+    return (hiddenStates, hiddenStatesList)
+  }
+
+  /// Extract multi-layer prompt embeddings for the diffusion model.
+  ///
+  /// Runs the full encoder with hidden state collection, then stacks outputs
+  /// from the specified layers and interleaves them into a single embedding.
+  ///
+  /// - Parameters:
+  ///   - inputIds: Token IDs `[B, S]`.
+  ///   - attentionMask: Optional `[B, S]` mask.
+  ///   - hiddenStateLayers: Layer indices to extract (default: 9, 18, 27).
+  /// - Returns: Prompt embeddings `[B, S, numLayers * hiddenDim]`.
+  public func getPromptEmbeds(
+    inputIds: MLXArray,
+    attentionMask: MLXArray? = nil,
+    hiddenStateLayers: [Int] = [9, 18, 27]
+  ) -> MLXArray {
+    let (_, hiddenStatesList) = self(
+      inputIds: inputIds,
+      attentionMask: attentionMask,
+      outputHiddenStates: true
+    )
+
+    guard let allStates = hiddenStatesList else {
+      fatalError("Hidden states not available for prompt embedding")
+    }
+
+    // Stack selected layers: [B, numLayers, S, hiddenDim]
+    let selected = hiddenStateLayers.map { allStates[$0] }
+    let stacked = MLX.stacked(selected, axis: 1)
+
+    let batchSize = stacked.dim(0)
+    let numLayers = stacked.dim(1)
+    let seqLen = stacked.dim(2)
+    let hiddenDim = stacked.dim(3)
+
+    // Transpose to [B, S, numLayers, hiddenDim] then reshape to [B, S, numLayers * hiddenDim]
+    let transposed = stacked.transposed(0, 2, 1, 3)
+    return transposed.reshaped(batchSize, seqLen, numLayers * hiddenDim)
+  }
+
+  // MARK: - Mask construction
+
+  /// Build a combined causal + padding 4D attention mask.
+  ///
+  /// Matches the mflux Python implementation exactly:
+  /// - Padding mask: 0 where attend, -inf where pad, expanded to `[B, 1, 1, S]`
+  /// - Causal mask: upper triangular -inf, expanded to `[B, 1, S, S]`
+  /// - Combined: causal + padding
+  private func buildAttentionMask4D(
+    attentionMask: MLXArray,
+    batchSize: Int,
+    seqLen: Int,
+    dtype: DType
+  ) -> MLXArray {
+    let ones = MLX.zeros(attentionMask.shape, dtype: dtype)
+    let negInf = MLX.full(attentionMask.shape, values: MLXArray(-Float.infinity), dtype: dtype)
+    let keepMask = attentionMask .== MLXArray(1).asType(attentionMask.dtype)
+    var paddingMask = MLX.where(keepMask, ones, negInf)
+    // [B, S] -> [B, 1, 1, S]
+    paddingMask = paddingMask.expandedDimensions(axis: 1).expandedDimensions(axis: 1)
+
+    if seqLen == 1 {
+      return MLX.zeros([batchSize, 1, 1, 1], dtype: dtype)
+    }
+
+    // Causal triangular mask
+    let idx = MLXArray(0..<seqLen)
+    let j = idx.expandedDimensions(axis: 0) // [1, S]
+    let i = idx.expandedDimensions(axis: 1) // [S, 1]
+    let triBool = j .> i
+    let zeros2D = MLX.zeros([seqLen, seqLen], dtype: dtype)
+    let negInf2D = MLX.full([seqLen, seqLen], values: MLXArray(-Float.infinity), dtype: dtype)
+    var causalMask = MLX.where(triBool, negInf2D, zeros2D)
+    // [S, S] -> [1, 1, S, S] -> [B, 1, S, S]
+    causalMask = causalMask.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    causalMask = MLX.broadcast(causalMask, to: [batchSize, 1, seqLen, seqLen])
+
+    return causalMask + paddingMask
+  }
+
+  /// Build a causal-only mask (no padding) for when attentionMask is nil.
+  private func buildCausalMask(
+    batchSize: Int,
+    seqLen: Int,
+    dtype: DType
+  ) -> MLXArray? {
+    guard seqLen > 1 else { return nil }
+
+    let idx = MLXArray(0..<seqLen)
+    let j = idx.expandedDimensions(axis: 0)
+    let i = idx.expandedDimensions(axis: 1)
+    let triBool = j .> i
+    let zeros2D = MLX.zeros([seqLen, seqLen], dtype: dtype)
+    let negInf2D = MLX.full([seqLen, seqLen], values: MLXArray(-Float.infinity), dtype: dtype)
+    var causalMask = MLX.where(triBool, negInf2D, zeros2D)
+    causalMask = causalMask.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    causalMask = MLX.broadcast(causalMask, to: [batchSize, 1, seqLen, seqLen])
+    return causalMask
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2Attention.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Attention.swift
@@ -1,0 +1,166 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Cross-attention for Flux 2 double-stream transformer blocks.
+///
+/// Computes joint attention between image hidden states and encoder (text) hidden states.
+/// Both streams produce Q/K/V projections that are concatenated, RoPE-rotated, and
+/// attended jointly, then split back into separate image and encoder outputs.
+final class Flux2Attention: Module {
+  let heads: Int
+  let dimHead: Int
+  let innerDim: Int
+  let scale: Float
+
+  @ModuleInfo(key: "to_q") var toQ: Linear
+  @ModuleInfo(key: "to_k") var toK: Linear
+  @ModuleInfo(key: "to_v") var toV: Linear
+  @ModuleInfo(key: "norm_q") var normQ: RMSNorm
+  @ModuleInfo(key: "norm_k") var normK: RMSNorm
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  // Added KV projections for encoder hidden states
+  @ModuleInfo(key: "norm_added_q") var normAddedQ: RMSNorm
+  @ModuleInfo(key: "norm_added_k") var normAddedK: RMSNorm
+  @ModuleInfo(key: "add_q_proj") var addQProj: Linear
+  @ModuleInfo(key: "add_k_proj") var addKProj: Linear
+  @ModuleInfo(key: "add_v_proj") var addVProj: Linear
+  @ModuleInfo(key: "to_add_out") var toAddOut: Linear
+
+  init(dim: Int, heads: Int, dimHead: Int, addedKVProjDim: Int) {
+    self.heads = heads
+    self.dimHead = dimHead
+    self.innerDim = heads * dimHead
+    self.scale = 1.0 / sqrt(Float(dimHead))
+
+    self._toQ.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._toK.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._toV.wrappedValue = Linear(dim, innerDim, bias: false)
+    self._normQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._toOut.wrappedValue = Linear(innerDim, dim, bias: false)
+
+    self._normAddedQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normAddedK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._addQProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._addKProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._addVProj.wrappedValue = Linear(addedKVProjDim, innerDim, bias: false)
+    self._toAddOut.wrappedValue = Linear(innerDim, dim, bias: false)
+
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Image hidden states `[batch, imgSeq, dim]`.
+  ///   - encoderHiddenStates: Text hidden states `[batch, txtSeq, dim]`.
+  ///   - imageRotaryEmb: Tuple of `(cos, sin)` for RoPE.
+  /// - Returns: Tuple of `(imageOutput, encoderOutput)`.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> (MLXArray, MLXArray) {
+    let batch = hiddenStates.dim(0)
+    let encSeqLen = encoderHiddenStates.dim(1)
+
+    // Image Q/K/V
+    var query = processQKV(hiddenStates, proj: toQ, norm: normQ)
+    var key = processQKV(hiddenStates, proj: toK, norm: normK)
+    var value = reshapeBSHD(toV(hiddenStates), batch: batch)
+
+    // Encoder Q/K/V
+    let encQuery = processQKV(encoderHiddenStates, proj: addQProj, norm: normAddedQ)
+    let encKey = processQKV(encoderHiddenStates, proj: addKProj, norm: normAddedK)
+    let encValue = reshapeBSHD(addVProj(encoderHiddenStates), batch: batch)
+
+    // Concatenate: [enc, img] along sequence dimension
+    query = MLX.concatenated([encQuery, query], axis: 2)
+    key = MLX.concatenated([encKey, key], axis: 2)
+    value = MLX.concatenated([encValue, value], axis: 2)
+
+    // Apply RoPE
+    let (cos, sin) = imageRotaryEmb
+    (query, key) = Flux2AttentionUtils.applyRopeBSHD(query: query, key: key, cos: cos, sin: sin)
+
+    // Scaled dot-product attention
+    let attnOut = MLXFast.scaledDotProductAttention(
+      queries: query,
+      keys: key,
+      values: value,
+      scale: scale,
+      mask: nil
+    )
+    // [B, H, S, D] -> [B, S, H*D]
+    let combined = attnOut.transposed(0, 2, 1, 3).reshaped(batch, -1, innerDim)
+
+    // Split back into encoder and image
+    let encoderOut = toAddOut(combined[0..., ..<encSeqLen, 0...])
+    let imageOut = toOut(combined[0..., encSeqLen..., 0...])
+
+    return (imageOut, encoderOut)
+  }
+
+  /// Project, reshape to [B, H, S, D], normalize in float32.
+  private func processQKV(_ x: MLXArray, proj: Linear, norm: RMSNorm) -> MLXArray {
+    let batch = x.dim(0)
+    let seqLen = x.dim(1)
+    let projected = proj(x).reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    let origDtype = projected.dtype
+    return norm(projected.asType(.float32)).asType(origDtype)
+  }
+
+  /// Reshape [B, S, H*D] -> [B, H, S, D].
+  private func reshapeBSHD(_ x: MLXArray, batch: Int) -> MLXArray {
+    let seqLen = x.dim(1)
+    return x.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+  }
+}
+
+// MARK: - Flux2 RoPE Utilities
+
+/// Attention utilities specific to Flux 2's cos/sin RoPE format.
+///
+/// Flux 2 uses explicit (cos, sin) pairs rather than Flux 1's complex-valued table.
+/// The rotation formula is applied in the interleaved (real, imag) layout.
+enum Flux2AttentionUtils {
+
+  /// Apply rotary position embeddings in B,S,H,D layout using cos/sin pairs.
+  ///
+  /// - Parameters:
+  ///   - query: `[batch, heads, seq, headDim]`
+  ///   - key: `[batch, heads, seq, headDim]`
+  ///   - cos: `[seq, halfDim]`
+  ///   - sin: `[seq, halfDim]`
+  /// - Returns: Rotated `(query, key)`.
+  static func applyRopeBSHD(
+    query: MLXArray,
+    key: MLXArray,
+    cos: MLXArray,
+    sin: MLXArray
+  ) -> (MLXArray, MLXArray) {
+    let outDtype = query.dtype
+    let qf = query.asType(.float32)
+    let kf = key.asType(.float32)
+    // Broadcast cos/sin: [seq, halfDim] -> [1, 1, seq, halfDim]
+    let cosB = cos.reshaped(1, 1, cos.dim(0), cos.dim(1))
+    let sinB = sin.reshaped(1, 1, sin.dim(0), sin.dim(1))
+
+    return (mix(qf, cosB, sinB).asType(outDtype), mix(kf, cosB, sinB).asType(outDtype))
+  }
+
+  /// Rotate x using interleaved (real, imag) pairs.
+  private static func mix(_ x: MLXArray, _ cos: MLXArray, _ sin: MLXArray) -> MLXArray {
+    // x shape: [B, H, S, D] -> [B, H, S, D/2, 2]
+    var shape = x.shape
+    shape[shape.count - 1] = shape.last! / 2
+    shape.append(2)
+    let x2 = x.reshaped(shape)
+    let real = x2[0..., 0..., 0..., 0..., 0]
+    let imag = x2[0..., 0..., 0..., 0..., 1]
+    let out0 = real * cos + (-imag) * sin
+    let out1 = imag * cos + real * sin
+    return MLX.stacked([out0, out1], axis: -1).reshaped(x.shape)
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2FeedForward.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2FeedForward.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// SwiGLU activation for Flux 2.
+///
+/// Splits input in half along the last axis, applies SiLU to the first half,
+/// and element-wise multiplies with the second half.
+final class Flux2SwiGLU: Module {
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let chunks = MLX.split(x, parts: 2, axis: -1)
+    return silu(chunks[0]) * chunks[1]
+  }
+}
+
+/// Feed-forward network (SwiGLU) for Flux 2 double-stream transformer blocks.
+///
+/// Projects `dim` -> `innerDim * 2` (for SwiGLU gate+value), applies SwiGLU,
+/// then projects `innerDim` -> `dim`.
+final class Flux2FeedForward: Module {
+  @ModuleInfo(key: "linear_in") var linearIn: Linear
+  @ModuleInfo(key: "act") var act: Flux2SwiGLU
+  @ModuleInfo(key: "linear_out") var linearOut: Linear
+
+  init(dim: Int, mult: Float = 3.0) {
+    let innerDim = Int(Float(dim) * mult)
+    self._linearIn.wrappedValue = Linear(dim, innerDim * 2, bias: false)
+    self._act.wrappedValue = Flux2SwiGLU()
+    self._linearOut.wrappedValue = Linear(innerDim, dim, bias: false)
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    linearOut(act(linearIn(x)))
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2Modulation.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Modulation.swift
@@ -1,0 +1,49 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Adaptive modulation for Flux 2 transformer blocks.
+///
+/// Produces shift/scale/gate parameter sets from the timestep embedding.
+/// Double-stream blocks use `modParamSets=2` (one set per norm),
+/// single-stream blocks use `modParamSets=1`.
+final class Flux2Modulation: Module {
+  let modParamSets: Int
+
+  @ModuleInfo(key: "linear") var linear: Linear
+
+  init(dim: Int, modParamSets: Int = 2) {
+    self.modParamSets = modParamSets
+    self._linear.wrappedValue = Linear(dim, dim * 3 * modParamSets, bias: false)
+    super.init()
+  }
+
+  /// Compute modulation parameters from timestep embedding.
+  ///
+  /// - Parameter temb: Timestep embedding of shape `[batch, dim]`.
+  /// - Returns: Array of `modParamSets` tuples, each containing `(shift, scale, gate)`.
+  func callAsFunction(_ temb: MLXArray) -> [[(MLXArray)]] {
+    var mod = linear(silu(temb))
+    if mod.ndim == 2 {
+      mod = mod.expandedDimensions(axis: 1)
+    }
+
+    // Split into 3 * modParamSets chunks along last axis
+    let totalChunks = 3 * modParamSets
+    let chunkSize = mod.dim(-1) / totalChunks
+    var allParams: [MLXArray] = []
+    for c in 0..<totalChunks {
+      let start = c * chunkSize
+      let end = (c + 1) * chunkSize
+      allParams.append(mod[0..., 0..., start..<end])
+    }
+
+    // Group into sets of 3: (shift, scale, gate)
+    var result: [[(MLXArray)]] = []
+    for i in 0..<modParamSets {
+      let base = 3 * i
+      result.append([allParams[base], allParams[base + 1], allParams[base + 2]])
+    }
+    return result
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2ParallelSelfAttention.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2ParallelSelfAttention.swift
@@ -1,0 +1,90 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Parallel self-attention with fused QKV + MLP projection for Flux 2 single-stream blocks.
+///
+/// A single linear projection produces Q, K, V for attention AND the MLP hidden state
+/// simultaneously. After attention and SwiGLU, the outputs are concatenated and projected
+/// back to the model dimension. This fused approach is more efficient than separate
+/// attention + MLP passes.
+final class Flux2ParallelSelfAttention: Module {
+  let heads: Int
+  let dimHead: Int
+  let innerDim: Int
+  let mlpHiddenDim: Int
+  let scale: Float
+
+  @ModuleInfo(key: "to_qkv_mlp_proj") var toQkvMlpProj: Linear
+  @ModuleInfo(key: "norm_q") var normQ: RMSNorm
+  @ModuleInfo(key: "norm_k") var normK: RMSNorm
+  @ModuleInfo(key: "mlp_act") var mlpAct: Flux2SwiGLU
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  init(dim: Int, heads: Int, dimHead: Int, mlpRatio: Float = 3.0) {
+    self.heads = heads
+    self.dimHead = dimHead
+    self.innerDim = heads * dimHead
+    self.mlpHiddenDim = Int(Float(dim) * mlpRatio)
+    self.scale = 1.0 / sqrt(Float(dimHead))
+
+    // Single projection for Q + K + V + MLP gate + MLP value
+    self._toQkvMlpProj.wrappedValue = Linear(dim, innerDim * 3 + mlpHiddenDim * 2, bias: false)
+    self._normQ.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._normK.wrappedValue = RMSNorm(dimensions: dimHead, eps: 1e-5)
+    self._mlpAct.wrappedValue = Flux2SwiGLU()
+    self._toOut.wrappedValue = Linear(innerDim + mlpHiddenDim, dim, bias: false)
+    super.init()
+  }
+
+  func callAsFunction(_ hiddenStates: MLXArray, imageRotaryEmb: (MLXArray, MLXArray)) -> MLXArray {
+    let proj = toQkvMlpProj(hiddenStates)
+
+    // Split: [QKV | MLP_hidden]
+    let splits = MLX.split(proj, indices: [innerDim * 3], axis: -1)
+    let qkvPart = splits[0]
+    let mlpHidden = splits[1]
+
+    // Split QKV into Q, K, V
+    let qkvSplits = MLX.split(qkvPart, parts: 3, axis: -1)
+    let queryRaw = qkvSplits[0]
+    let keyRaw = qkvSplits[1]
+    let valueRaw = qkvSplits[2]
+
+    let batch = queryRaw.dim(0)
+    let seqLen = queryRaw.dim(1)
+
+    // Reshape to [B, H, S, D]
+    var query = queryRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    var key = keyRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+    let value = valueRaw.reshaped(batch, seqLen, heads, dimHead).transposed(0, 2, 1, 3)
+
+    // Normalize Q/K in float32
+    let qDtype = query.dtype
+    query = normQ(query.asType(.float32)).asType(qDtype)
+    key = normK(key.asType(.float32)).asType(qDtype)
+
+    // Apply RoPE
+    let (cos, sin) = imageRotaryEmb
+    (query, key) = Flux2AttentionUtils.applyRopeBSHD(query: query, key: key, cos: cos, sin: sin)
+
+    // Attention
+    let attnOut = MLXFast.scaledDotProductAttention(
+      queries: query,
+      keys: key,
+      values: value,
+      scale: scale,
+      mask: nil
+    )
+    // [B, H, S, D] -> [B, S, H*D]
+    var hiddenOut = attnOut.transposed(0, 2, 1, 3).reshaped(batch, seqLen, innerDim)
+
+    // Parallel MLP: SwiGLU on the MLP hidden part
+    let mlpOut = mlpAct(mlpHidden)
+
+    // Concatenate attention output and MLP output, project
+    hiddenOut = MLX.concatenated([hiddenOut, mlpOut], axis: -1)
+    return toOut(hiddenOut)
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2PosEmbed.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2PosEmbed.swift
@@ -1,0 +1,51 @@
+import Foundation
+import MLX
+
+/// Rotary position embeddings for Flux 2 transformer.
+///
+/// Unlike Flux 1's complex-valued RoPE table, Flux 2 uses explicit cos/sin pairs
+/// computed per-axis from position IDs, then concatenated across all axes.
+final class Flux2PosEmbed {
+  let theta: Int
+  let axesDim: [Int]
+
+  init(theta: Int = 2000, axesDim: [Int] = [32, 32, 32, 32]) {
+    self.theta = theta
+    self.axesDim = axesDim
+  }
+
+  /// Compute rotary embeddings for the given position IDs.
+  ///
+  /// - Parameter ids: Position IDs of shape `[seqLen, numAxes]`.
+  /// - Returns: Tuple of `(cos, sin)` each of shape `[seqLen, totalHalfDim]`.
+  func callAsFunction(_ ids: MLXArray) -> (MLXArray, MLXArray) {
+    let pos = ids.asType(.float32)
+    var cosOut: [MLXArray] = []
+    var sinOut: [MLXArray] = []
+
+    for (i, dim) in axesDim.enumerated() {
+      let (cos, sin) = get1dRope(dim: dim, pos: pos[0..., i])
+      cosOut.append(cos)
+      sinOut.append(sin)
+    }
+
+    let freqsCos = MLX.concatenated(cosOut, axis: -1)
+    let freqsSin = MLX.concatenated(sinOut, axis: -1)
+    return (freqsCos, freqsSin)
+  }
+
+  /// Compute 1D RoPE frequencies for a single axis.
+  private func get1dRope(dim: Int, pos: MLXArray) -> (MLXArray, MLXArray) {
+    // scale = arange(0, dim, 2) / dim
+    let scale = MLXArray(stride(from: 0, to: dim, by: 2).map { Float($0) / Float(dim) })
+    // omega = 1.0 / (theta ^ scale)
+    let omega = 1.0 / MLX.pow(MLXArray(Float(theta)), scale)
+
+    // [seqLen, 1] * [1, halfDim] -> [seqLen, halfDim]
+    let posExpanded = pos.expandedDimensions(axis: -1)
+    let omegaExpanded = omega.expandedDimensions(axis: 0)
+    let out = posExpanded * omegaExpanded
+
+    return (MLX.cos(out), MLX.sin(out))
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2SingleTransformerBlock.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2SingleTransformerBlock.swift
@@ -1,0 +1,41 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Single-stream transformer block for Flux 2.
+///
+/// After the double-stream blocks merge image and text into a single sequence,
+/// these blocks process the unified stream with parallel self-attention + MLP.
+/// Modulation (shift/scale/gate) from the timestep embedding is applied.
+final class Flux2SingleTransformerBlock: Module {
+  @ModuleInfo(key: "norm") var norm: LayerNorm
+  @ModuleInfo(key: "attn") var attn: Flux2ParallelSelfAttention
+
+  init(dim: Int, numAttentionHeads: Int, attentionHeadDim: Int, mlpRatio: Float = 3.0) {
+    self._norm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._attn.wrappedValue = Flux2ParallelSelfAttention(
+      dim: dim,
+      heads: numAttentionHeads,
+      dimHead: attentionHeadDim,
+      mlpRatio: mlpRatio
+    )
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Unified hidden states `[batch, seq, dim]`.
+  ///   - tembModParams: Single modulation set `(shift, scale, gate)`.
+  ///   - imageRotaryEmb: `(cos, sin)` for RoPE.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    tembModParams: (MLXArray, MLXArray, MLXArray),
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> MLXArray {
+    let (modShift, modScale, modGate) = tembModParams
+
+    var normHidden = norm(hiddenStates)
+    normHidden = (1 + modScale) * normHidden + modShift
+    let attnOutput = attn(normHidden, imageRotaryEmb: imageRotaryEmb)
+    return hiddenStates + modGate * attnOutput
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2TimestepEmbedding.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2TimestepEmbedding.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Timestep and optional guidance embeddings for Flux 2.
+///
+/// Computes sinusoidal frequency embeddings from scalar timestep values,
+/// projects through a 2-layer MLP (with SiLU activation), and optionally
+/// adds a guidance embedding computed through a parallel MLP.
+final class Flux2TimestepEmbedding: Module {
+  let inChannels: Int
+  let embeddingDim: Int
+  let guidanceEmbeds: Bool
+
+  @ModuleInfo(key: "linear_1") var linear1: Linear
+  @ModuleInfo(key: "linear_2") var linear2: Linear
+  @ModuleInfo(key: "guidance_linear_1") var guidanceLinear1: Linear?
+  @ModuleInfo(key: "guidance_linear_2") var guidanceLinear2: Linear?
+
+  init(inChannels: Int = 256, embeddingDim: Int = 6144, guidanceEmbeds: Bool = true) {
+    self.inChannels = inChannels
+    self.embeddingDim = embeddingDim
+    self.guidanceEmbeds = guidanceEmbeds
+
+    self._linear1.wrappedValue = Linear(inChannels, embeddingDim, bias: false)
+    self._linear2.wrappedValue = Linear(embeddingDim, embeddingDim, bias: false)
+
+    if guidanceEmbeds {
+      self._guidanceLinear1.wrappedValue = Linear(inChannels, embeddingDim, bias: false)
+      self._guidanceLinear2.wrappedValue = Linear(embeddingDim, embeddingDim, bias: false)
+    }
+
+    super.init()
+  }
+
+  func callAsFunction(timestep: MLXArray, guidance: MLXArray?) -> MLXArray {
+    let timestepEmb = Self.timestepEmbedding(timestep.asType(.float32), dim: inChannels)
+    let tEmb = linear2(silu(linear1(timestepEmb)))
+
+    if let guidance, let gLinear1 = guidanceLinear1, let gLinear2 = guidanceLinear2 {
+      let guidanceEmb = Self.timestepEmbedding(guidance.asType(.float32), dim: inChannels)
+      let gEmb = gLinear2(silu(gLinear1(guidanceEmb)))
+      return tEmb + gEmb
+    }
+
+    return tEmb
+  }
+
+  /// Compute sinusoidal timestep embeddings.
+  ///
+  /// Matches the diffusers convention: `flip_sin_to_cos=True` puts cos before sin.
+  static func timestepEmbedding(
+    _ timesteps: MLXArray,
+    dim: Int,
+    flipSinToCos: Bool = true
+  ) -> MLXArray {
+    let half = dim / 2
+    let freqs = MLX.exp(
+      MLXArray(-Foundation.log(10000.0))
+        * MLXArray(stride(from: 0, to: half, by: 1).map { Float($0) })
+        / MLXArray(Float(half))
+    )
+    let args = timesteps.expandedDimensions(axis: -1) * freqs.expandedDimensions(axis: 0)
+    var emb = MLX.concatenated([MLX.sin(args), MLX.cos(args)], axis: -1)
+
+    if flipSinToCos {
+      // Swap sin and cos halves
+      let cosHalf = emb[0..., half...]
+      let sinHalf = emb[0..., ..<half]
+      emb = MLX.concatenated([cosHalf, sinHalf], axis: -1)
+    }
+
+    if dim % 2 == 1 {
+      let pad = MLX.zeros([emb.dim(0), 1], dtype: emb.dtype)
+      emb = MLX.concatenated([emb, pad], axis: -1)
+    }
+
+    return emb
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2Transformer.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2Transformer.swift
@@ -1,0 +1,261 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Adaptive layer norm with continuous conditioning for the Flux 2 output projection.
+///
+/// Applies SiLU-activated linear projection of the conditioning signal to produce
+/// scale and shift parameters for layer normalization.
+final class Flux2AdaLayerNormContinuous: Module {
+  let embeddingDim: Int
+
+  @ModuleInfo(key: "linear") var linear: Linear
+  @ModuleInfo(key: "norm") var norm: LayerNorm
+
+  init(embeddingDim: Int, conditioningEmbeddingDim: Int) {
+    self.embeddingDim = embeddingDim
+    self._linear.wrappedValue = Linear(conditioningEmbeddingDim, embeddingDim * 2, bias: false)
+    self._norm.wrappedValue = LayerNorm(dimensions: embeddingDim, eps: 1e-6, affine: false)
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray, conditioning: MLXArray) -> MLXArray {
+    let mod = linear(silu(conditioning))
+    let chunkSize = embeddingDim
+    let scale = mod[0..., (0 * chunkSize)..<(1 * chunkSize)]
+    let shift = mod[0..., (1 * chunkSize)..<(2 * chunkSize)]
+    return norm(x) * (1 + scale).expandedDimensions(axis: 1) + shift.expandedDimensions(axis: 1)
+  }
+}
+
+// MARK: - Flux2Transformer Configuration
+
+/// Configuration for the Flux 2 transformer.
+public struct Flux2TransformerConfig {
+  public let patchSize: Int
+  public let inChannels: Int
+  public let outChannels: Int
+  public let numLayers: Int
+  public let numSingleLayers: Int
+  public let attentionHeadDim: Int
+  public let numAttentionHeads: Int
+  public let jointAttentionDim: Int
+  public let timestepGuidanceChannels: Int
+  public let mlpRatio: Float
+  public let axesDimsRope: [Int]
+  public let ropeTheta: Int
+  public let guidanceEmbeds: Bool
+
+  public init(
+    patchSize: Int = 1,
+    inChannels: Int = 128,
+    outChannels: Int? = nil,
+    numLayers: Int = 5,
+    numSingleLayers: Int = 20,
+    attentionHeadDim: Int = 128,
+    numAttentionHeads: Int = 24,
+    jointAttentionDim: Int = 7680,
+    timestepGuidanceChannels: Int = 256,
+    mlpRatio: Float = 3.0,
+    axesDimsRope: [Int] = [32, 32, 32, 32],
+    ropeTheta: Int = 2000,
+    guidanceEmbeds: Bool = false
+  ) {
+    self.patchSize = patchSize
+    self.inChannels = inChannels
+    self.outChannels = outChannels ?? inChannels
+    self.numLayers = numLayers
+    self.numSingleLayers = numSingleLayers
+    self.attentionHeadDim = attentionHeadDim
+    self.numAttentionHeads = numAttentionHeads
+    self.jointAttentionDim = jointAttentionDim
+    self.timestepGuidanceChannels = timestepGuidanceChannels
+    self.mlpRatio = mlpRatio
+    self.axesDimsRope = axesDimsRope
+    self.ropeTheta = ropeTheta
+    self.guidanceEmbeds = guidanceEmbeds
+  }
+}
+
+// MARK: - Flux2Transformer
+
+/// Flux 2 transformer — the denoising backbone for Flux 2 image generation.
+///
+/// Architecture:
+/// 1. Embed timestep (+ optional guidance) into a conditioning vector
+/// 2. Embed image latents and text embeddings into the model dimension
+/// 3. Compute RoPE for image and text positions
+/// 4. Run double-stream (joint) transformer blocks with cross-attention
+/// 5. Concatenate streams and run single-stream blocks with parallel self-attention
+/// 6. Apply adaptive layer norm and project to output
+public final class Flux2Transformer: Module {
+  public let config: Flux2TransformerConfig
+  let innerDim: Int
+
+  @ModuleInfo(key: "pos_embed") var posEmbed: Flux2PosEmbed
+  @ModuleInfo(key: "time_guidance_embed") var timeGuidanceEmbed: Flux2TimestepEmbedding
+  @ModuleInfo(key: "double_stream_modulation_img") var doubleStreamModulationImg: Flux2Modulation
+  @ModuleInfo(key: "double_stream_modulation_txt") var doubleStreamModulationTxt: Flux2Modulation
+  @ModuleInfo(key: "single_stream_modulation") var singleStreamModulation: Flux2Modulation
+
+  @ModuleInfo(key: "x_embedder") var xEmbedder: Linear
+  @ModuleInfo(key: "context_embedder") var contextEmbedder: Linear
+  @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [Flux2TransformerBlock]
+  @ModuleInfo(key: "single_transformer_blocks") var singleTransformerBlocks: [Flux2SingleTransformerBlock]
+  @ModuleInfo(key: "norm_out") var normOut: Flux2AdaLayerNormContinuous
+  @ModuleInfo(key: "proj_out") var projOut: Linear
+
+  public init(config: Flux2TransformerConfig = Flux2TransformerConfig()) {
+    self.config = config
+    self.innerDim = config.numAttentionHeads * config.attentionHeadDim
+
+    self._posEmbed.wrappedValue = Flux2PosEmbed(
+      theta: config.ropeTheta,
+      axesDim: config.axesDimsRope
+    )
+    self._timeGuidanceEmbed.wrappedValue = Flux2TimestepEmbedding(
+      inChannels: config.timestepGuidanceChannels,
+      embeddingDim: innerDim,
+      guidanceEmbeds: config.guidanceEmbeds
+    )
+    self._doubleStreamModulationImg.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 2)
+    self._doubleStreamModulationTxt.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 2)
+    self._singleStreamModulation.wrappedValue = Flux2Modulation(dim: innerDim, modParamSets: 1)
+
+    self._xEmbedder.wrappedValue = Linear(config.inChannels, innerDim, bias: false)
+    self._contextEmbedder.wrappedValue = Linear(config.jointAttentionDim, innerDim, bias: false)
+
+    var doubleBlocks: [Flux2TransformerBlock] = []
+    for _ in 0..<config.numLayers {
+      doubleBlocks.append(Flux2TransformerBlock(
+        dim: innerDim,
+        numAttentionHeads: config.numAttentionHeads,
+        attentionHeadDim: config.attentionHeadDim,
+        mlpRatio: config.mlpRatio
+      ))
+    }
+    self._transformerBlocks.wrappedValue = doubleBlocks
+
+    var singleBlocks: [Flux2SingleTransformerBlock] = []
+    for _ in 0..<config.numSingleLayers {
+      singleBlocks.append(Flux2SingleTransformerBlock(
+        dim: innerDim,
+        numAttentionHeads: config.numAttentionHeads,
+        attentionHeadDim: config.attentionHeadDim,
+        mlpRatio: config.mlpRatio
+      ))
+    }
+    self._singleTransformerBlocks.wrappedValue = singleBlocks
+
+    self._normOut.wrappedValue = Flux2AdaLayerNormContinuous(
+      embeddingDim: innerDim,
+      conditioningEmbeddingDim: innerDim
+    )
+    self._projOut.wrappedValue = Linear(
+      innerDim,
+      config.patchSize * config.patchSize * config.outChannels,
+      bias: false
+    )
+
+    super.init()
+  }
+
+  /// Run the Flux 2 transformer forward pass.
+  ///
+  /// - Parameters:
+  ///   - hiddenStates: Image latents `[batch, seq, inChannels]`.
+  ///   - encoderHiddenStates: Text embeddings `[batch, txtSeq, jointAttentionDim]`.
+  ///   - timestep: Scalar or `[batch]` timestep values.
+  ///   - imgIds: Image position IDs `[seqLen, numAxes]` or `[1, seqLen, numAxes]`.
+  ///   - txtIds: Text position IDs `[txtSeqLen, numAxes]` or `[1, txtSeqLen, numAxes]`.
+  ///   - guidance: Optional guidance scale (for distilled models).
+  /// - Returns: Denoised output `[batch, seq, outChannels]`.
+  public func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    timestep: MLXArray,
+    imgIds: MLXArray,
+    txtIds: MLXArray,
+    guidance: MLXArray? = nil
+  ) -> MLXArray {
+    let dtype = hiddenStates.dtype
+
+    // Prepare timestep: ensure [batch] shape, scale to [0, 1000] if needed
+    var t = timestep.ndim == 0
+      ? MLX.broadcast(timestep, to: [hiddenStates.dim(0)]).asType(dtype)
+      : timestep.asType(dtype)
+    let tScale = MLX.where(MLX.max(t) .<= 1.0, MLXArray(1000.0), MLXArray(1.0)).asType(dtype)
+    t = t * tScale
+
+    // Prepare guidance similarly
+    var g: MLXArray? = nil
+    if var guidance = guidance {
+      if guidance.ndim == 0 {
+        guidance = MLX.broadcast(guidance, to: [hiddenStates.dim(0)]).asType(dtype)
+      } else {
+        guidance = guidance.asType(dtype)
+      }
+      let gScale = MLX.where(MLX.max(guidance) .<= 1.0, MLXArray(1000.0), MLXArray(1.0)).asType(dtype)
+      g = guidance * gScale
+    }
+
+    // Timestep embedding
+    var temb = timeGuidanceEmbed(timestep: t, guidance: g)
+    temb = temb.asType(.bfloat16)
+
+    // Embed inputs
+    var hidden = xEmbedder(hiddenStates)
+    var encoder = contextEmbedder(encoderHiddenStates)
+
+    // Squeeze batch dimension from position IDs if present
+    let imgIdsFlat = imgIds.ndim == 3 ? imgIds[0] : imgIds
+    let txtIdsFlat = txtIds.ndim == 3 ? txtIds[0] : txtIds
+
+    // Compute RoPE
+    let imageRotaryEmb = posEmbed(imgIdsFlat)
+    let textRotaryEmb = posEmbed(txtIdsFlat)
+    let concatRotaryEmb = (
+      MLX.concatenated([textRotaryEmb.0, imageRotaryEmb.0], axis: 0),
+      MLX.concatenated([textRotaryEmb.1, imageRotaryEmb.1], axis: 0)
+    )
+
+    // Compute modulation params (shared across all blocks)
+    let tembModParamsImg = doubleStreamModulationImg(temb)
+    let tembModParamsTxt = doubleStreamModulationTxt(temb)
+
+    // Double-stream blocks
+    for block in transformerBlocks {
+      (encoder, hidden) = block(
+        hiddenStates: hidden,
+        encoderHiddenStates: encoder,
+        tembModParamsImg: tembModParamsImg,
+        tembModParamsTxt: tembModParamsTxt,
+        imageRotaryEmb: concatRotaryEmb
+      )
+    }
+
+    // Merge streams for single-stream blocks
+    hidden = MLX.concatenated([encoder, hidden], axis: 1)
+
+    // Single-stream modulation: extract the first (and only) set
+    let singleModParams = singleStreamModulation(temb)[0]
+    let singleMod = (singleModParams[0], singleModParams[1], singleModParams[2])
+
+    for block in singleTransformerBlocks {
+      hidden = block(
+        hiddenStates: hidden,
+        tembModParams: singleMod,
+        imageRotaryEmb: concatRotaryEmb
+      )
+    }
+
+    // Slice off encoder tokens, keep only image tokens
+    hidden = hidden[0..., encoder.dim(1)..., 0...]
+
+    // Final norm + projection
+    hidden = normOut(hidden, conditioning: temb)
+    hidden = projOut(hidden)
+
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/Transformer/Flux2TransformerBlock.swift
+++ b/Sources/ZImage/Flux2/Transformer/Flux2TransformerBlock.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Double-stream (joint) transformer block for Flux 2.
+///
+/// Processes image and text hidden states through parallel norm → attention → FFN paths.
+/// Both streams share the same attention computation (cross-attention via Flux2Attention)
+/// but have separate norms, modulation, and feed-forward networks.
+final class Flux2TransformerBlock: Module {
+  @ModuleInfo(key: "norm1") var norm1: LayerNorm
+  @ModuleInfo(key: "norm1_context") var norm1Context: LayerNorm
+  @ModuleInfo(key: "attn") var attn: Flux2Attention
+  @ModuleInfo(key: "norm2") var norm2: LayerNorm
+  @ModuleInfo(key: "ff") var ff: Flux2FeedForward
+  @ModuleInfo(key: "norm2_context") var norm2Context: LayerNorm
+  @ModuleInfo(key: "ff_context") var ffContext: Flux2FeedForward
+
+  init(dim: Int, numAttentionHeads: Int, attentionHeadDim: Int, mlpRatio: Float = 3.0) {
+    self._norm1.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._norm1Context.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._attn.wrappedValue = Flux2Attention(
+      dim: dim,
+      heads: numAttentionHeads,
+      dimHead: attentionHeadDim,
+      addedKVProjDim: dim
+    )
+    self._norm2.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._ff.wrappedValue = Flux2FeedForward(dim: dim, mult: mlpRatio)
+    self._norm2Context.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+    self._ffContext.wrappedValue = Flux2FeedForward(dim: dim, mult: mlpRatio)
+    super.init()
+  }
+
+  /// - Parameters:
+  ///   - hiddenStates: Image hidden states `[batch, imgSeq, dim]`.
+  ///   - encoderHiddenStates: Text hidden states `[batch, txtSeq, dim]`.
+  ///   - tembModParamsImg: Modulation params for image stream: `[[shift, scale, gate], [shift, scale, gate]]`.
+  ///   - tembModParamsTxt: Modulation params for text stream: `[[shift, scale, gate], [shift, scale, gate]]`.
+  ///   - imageRotaryEmb: `(cos, sin)` for RoPE.
+  /// - Returns: `(encoderHiddenStates, hiddenStates)`.
+  func callAsFunction(
+    hiddenStates: MLXArray,
+    encoderHiddenStates: MLXArray,
+    tembModParamsImg: [[MLXArray]],
+    tembModParamsTxt: [[MLXArray]],
+    imageRotaryEmb: (MLXArray, MLXArray)
+  ) -> (MLXArray, MLXArray) {
+    // Image modulation params
+    let (shiftMSA, scaleMSA, gateMSA) = (tembModParamsImg[0][0], tembModParamsImg[0][1], tembModParamsImg[0][2])
+    let (shiftMLP, scaleMLP, gateMLP) = (tembModParamsImg[1][0], tembModParamsImg[1][1], tembModParamsImg[1][2])
+    // Text modulation params
+    let (cShiftMSA, cScaleMSA, cGateMSA) = (tembModParamsTxt[0][0], tembModParamsTxt[0][1], tembModParamsTxt[0][2])
+    let (cShiftMLP, cScaleMLP, cGateMLP) = (tembModParamsTxt[1][0], tembModParamsTxt[1][1], tembModParamsTxt[1][2])
+
+    // Normalize and modulate image
+    var normHidden = norm1(hiddenStates)
+    normHidden = (1 + scaleMSA) * normHidden + shiftMSA
+
+    // Normalize and modulate text
+    var normEncoder = norm1Context(encoderHiddenStates)
+    normEncoder = (1 + cScaleMSA) * normEncoder + cShiftMSA
+
+    // Joint attention
+    let (attnOutput, encoderAttnOutput) = attn(
+      hiddenStates: normHidden,
+      encoderHiddenStates: normEncoder,
+      imageRotaryEmb: imageRotaryEmb
+    )
+
+    // Residual + gating for attention
+    var hidden = hiddenStates + gateMSA * attnOutput
+    var encoder = encoderHiddenStates + cGateMSA * encoderAttnOutput
+
+    // FFN for image
+    var normHidden2 = norm2(hidden)
+    normHidden2 = (1 + scaleMLP) * normHidden2 + shiftMLP
+    hidden = hidden + gateMLP * ff(normHidden2)
+
+    // FFN for text
+    var normEncoder2 = norm2Context(encoder)
+    normEncoder2 = (1 + cScaleMLP) * normEncoder2 + cShiftMLP
+    encoder = encoder + cGateMLP * ffContext(normEncoder2)
+
+    return (encoder, hidden)
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2BatchNormStats.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2BatchNormStats.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Pre-computed batch normalization statistics for the Flux2 VAE packed latent pipeline.
+///
+/// Unlike standard BatchNorm, this module does not learn gamma/beta parameters.
+/// It stores only running mean and variance loaded from model weights, used to
+/// un-normalize packed latents before decoding.
+///
+/// ## Weight Keys
+///
+/// - `running_mean`: Shape `(num_features,)` -- loaded from checkpoint
+/// - `running_var`: Shape `(num_features,)` -- loaded from checkpoint
+public final class Flux2BatchNormStats: Module {
+
+  /// Running mean loaded from checkpoint. Shape `(num_features,)`.
+  @ModuleInfo(key: "running_mean") var runningMean: MLXArray
+
+  /// Running variance loaded from checkpoint. Shape `(num_features,)`.
+  @ModuleInfo(key: "running_var") var runningVar: MLXArray
+
+  /// Small constant for numerical stability.
+  public let eps: Float
+
+  /// Creates a batch norm statistics container.
+  ///
+  /// - Parameters:
+  ///   - numFeatures: Number of channels/features.
+  ///   - eps: Epsilon for numerical stability. Default `1e-4`.
+  public init(numFeatures: Int, eps: Float = 1e-4) {
+    self.eps = eps
+    self._runningMean.wrappedValue = MLXArray.zeros([numFeatures])
+    self._runningVar.wrappedValue = MLXArray.ones([numFeatures])
+    super.init()
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Decoder.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Decoder.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Up-decoder block for the Flux2 VAE.
+///
+/// Contains a sequence of ResNet blocks followed by an optional upsampler.
+/// All operations use NHWC layout.
+private final class Flux2UpDecoderBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "upsamplers") var upsamplers: [Flux2Upsample]
+
+  /// Creates an up-decoder block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of ResNet blocks. Default `3`.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addUpsample: Whether to add an upsampler. Default `true`.
+  init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 3,
+    groups: Int = 32,
+    eps: Float = 1e-6,
+    addUpsample: Bool = true
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      Flux2ResnetBlock(
+        inChannels: i == 0 ? inChannels : outChannels,
+        outChannels: outChannels,
+        groups: groups,
+        eps: eps)
+    }
+    self._upsamplers.wrappedValue = addUpsample
+      ? [Flux2Upsample(channels: outChannels, outChannels: outChannels)]
+      : []
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for upsampler in upsamplers {
+      hidden = upsampler(hidden)
+    }
+    return hidden
+  }
+}
+
+/// Decoder for the Flux2 VAE.
+///
+/// Takes latent features in NHWC layout and reconstructs an image. The architecture
+/// mirrors the encoder: conv_in, mid block, a series of up-decoder blocks,
+/// normalization, and conv_out.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H/8, W/8, 32)
+///   -> Conv2d(32 -> 512, k=3, p=1)            // conv_in
+///   -> MidBlock(512, attention)
+///   -> UpBlock(512 -> 512, upsample)
+///   -> UpBlock(512 -> 512, upsample)
+///   -> UpBlock(512 -> 256, upsample)
+///   -> UpBlock(256 -> 128, no upsample)        // final block
+///   -> GroupNorm(32, 128)
+///   -> SiLU
+///   -> Conv2d(128 -> 3, k=3, p=1)             // conv_out
+///   -> Output (B, H, W, 3)
+/// ```
+public final class Flux2Decoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: Conv2d
+  @ModuleInfo(key: "mid_block") var midBlock: Flux2MidBlock
+  @ModuleInfo(key: "up_blocks") fileprivate var upBlocks: [Flux2UpDecoderBlock]
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+  @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+  /// Creates a Flux2 VAE decoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of latent channels. Default `32`.
+  ///   - outChannels: Number of output channels (RGB = 3). Default `3`.
+  ///   - blockOutChannels: Channel counts per stage (in encoder order). Default `[128, 256, 512, 512]`.
+  ///   - layersPerBlock: Number of ResNet blocks per stage (decoder adds 1). Default `2`.
+  ///   - normNumGroups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - midBlockAddAttention: Whether the mid block includes attention. Default `true`.
+  public init(
+    inChannels: Int = 32,
+    outChannels: Int = 3,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 2,
+    normNumGroups: Int = 32,
+    eps: Float = 1e-6,
+    midBlockAddAttention: Bool = true
+  ) {
+    // Decoder processes channels in reverse order
+    let reversedChannels = Array(blockOutChannels.reversed())
+
+    self._convIn.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: reversedChannels[0],
+      kernelSize: 3, stride: 1, padding: 1)
+
+    self._midBlock.wrappedValue = Flux2MidBlock(
+      channels: reversedChannels[0],
+      groups: normNumGroups,
+      eps: eps,
+      addAttention: midBlockAddAttention)
+
+    var ups: [Flux2UpDecoderBlock] = []
+    for (i, outCh) in reversedChannels.enumerated() {
+      let prevOutCh = i == 0 ? outCh : reversedChannels[i - 1]
+      let isFinal = i == reversedChannels.count - 1
+      ups.append(Flux2UpDecoderBlock(
+        inChannels: prevOutCh,
+        outChannels: outCh,
+        numLayers: layersPerBlock + 1,
+        groups: normNumGroups,
+        eps: eps,
+        addUpsample: !isFinal))
+    }
+    self._upBlocks.wrappedValue = ups
+
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: normNumGroups, dimensions: blockOutChannels[0],
+      eps: eps, pytorchCompatible: true)
+
+    self._convOut.wrappedValue = Conv2d(
+      inputChannels: blockOutChannels[0], outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    super.init()
+  }
+
+  /// Decodes latent features into an image.
+  ///
+  /// - Parameter x: Latent tensor in NHWC layout `(B, H/8, W/8, latent_channels)`.
+  /// - Returns: Decoded image in NHWC layout `(B, H, W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = convIn(x)
+    hidden = midBlock(hidden)
+    for block in upBlocks {
+      hidden = block(hidden)
+    }
+    hidden = convNormOut(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Downsample.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Downsample.swift
@@ -1,0 +1,45 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Stride-2 convolution downsampling for the Flux2 VAE encoder.
+///
+/// Uses a 3x3 convolution with stride 2 to halve spatial dimensions.
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> pad (right and bottom by 1)
+///   -> Conv2d(C -> C, k=3, s=2, p=0)
+///   -> Output (B, H/2, W/2, C)
+/// ```
+///
+/// Note: The Python source uses `padding=0` for the downsample conv, which
+/// means asymmetric padding (pad-then-conv) is needed to match behavior.
+public final class Flux2Downsample: Module {
+
+  @ModuleInfo(key: "conv") var conv: Conv2d
+
+  /// Creates a Flux2 stride-2 downsampling layer.
+  ///
+  /// - Parameter channels: Number of input/output channels.
+  public init(channels: Int) {
+    // Python uses padding=0 on the conv, with asymmetric pad before
+    self._conv.wrappedValue = Conv2d(
+      inputChannels: channels, outputChannels: channels,
+      kernelSize: 3, stride: 2)
+    super.init()
+  }
+
+  /// Applies stride-2 downsampling.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H/2, W/2, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // Pad right and bottom by 1 (NHWC: pad H and W dims)
+    let padded = padded(x, widths: [[0, 0], [0, 1], [0, 1], [0, 0]])
+    return conv(padded)
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Encoder.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Encoder.swift
@@ -1,0 +1,154 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Down-encoder block for the Flux2 VAE.
+///
+/// Contains a sequence of ResNet blocks followed by an optional downsampler.
+/// All operations use NHWC layout.
+private final class Flux2DownEncoderBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "downsamplers") var downsamplers: [Flux2Downsample]
+
+  /// Creates a down-encoder block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - numLayers: Number of ResNet blocks. Default `2`.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addDownsample: Whether to add a downsampler. Default `true`.
+  init(
+    inChannels: Int,
+    outChannels: Int,
+    numLayers: Int = 2,
+    groups: Int = 32,
+    eps: Float = 1e-6,
+    addDownsample: Bool = true
+  ) {
+    self._resnets.wrappedValue = (0..<numLayers).map { i in
+      Flux2ResnetBlock(
+        inChannels: i == 0 ? inChannels : outChannels,
+        outChannels: outChannels,
+        groups: groups,
+        eps: eps)
+    }
+    self._downsamplers.wrappedValue = addDownsample
+      ? [Flux2Downsample(channels: outChannels)]
+      : []
+    super.init()
+  }
+
+  func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = x
+    for resnet in resnets {
+      hidden = resnet(hidden)
+    }
+    for downsampler in downsamplers {
+      hidden = downsampler(hidden)
+    }
+    return hidden
+  }
+}
+
+/// Encoder for the Flux2 VAE.
+///
+/// Takes an image in NHWC layout and produces latent features. The architecture
+/// follows a standard VAE encoder pattern: conv_in, a series of down-encoder
+/// blocks, a mid block, normalization, and conv_out.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, 3)
+///   -> Conv2d(3 -> 128, k=3, p=1)           // conv_in
+///   -> DownBlock(128 -> 128, downsample)
+///   -> DownBlock(128 -> 256, downsample)
+///   -> DownBlock(256 -> 512, downsample)
+///   -> DownBlock(512 -> 512, no downsample)  // final block
+///   -> MidBlock(512, attention)
+///   -> GroupNorm(32, 512)
+///   -> SiLU
+///   -> Conv2d(512 -> 64, k=3, p=1)          // conv_out (2 * latent_channels)
+///   -> Output (B, H/8, W/8, 64)
+/// ```
+public final class Flux2Encoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: Conv2d
+  @ModuleInfo(key: "down_blocks") fileprivate var downBlocks: [Flux2DownEncoderBlock]
+  @ModuleInfo(key: "mid_block") var midBlock: Flux2MidBlock
+  @ModuleInfo(key: "conv_norm_out") var convNormOut: GroupNorm
+  @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+  /// Creates a Flux2 VAE encoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels (RGB = 3). Default `3`.
+  ///   - outChannels: Number of latent channels. Default `32`.
+  ///   - blockOutChannels: Channel counts per stage. Default `[128, 256, 512, 512]`.
+  ///   - layersPerBlock: Number of ResNet blocks per stage. Default `2`.
+  ///   - normNumGroups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - midBlockAddAttention: Whether the mid block includes attention. Default `true`.
+  public init(
+    inChannels: Int = 3,
+    outChannels: Int = 32,
+    blockOutChannels: [Int] = [128, 256, 512, 512],
+    layersPerBlock: Int = 2,
+    normNumGroups: Int = 32,
+    eps: Float = 1e-6,
+    midBlockAddAttention: Bool = true
+  ) {
+    self._convIn.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: blockOutChannels[0],
+      kernelSize: 3, stride: 1, padding: 1)
+
+    var downs: [Flux2DownEncoderBlock] = []
+    for (i, outCh) in blockOutChannels.enumerated() {
+      let inCh = i > 0 ? blockOutChannels[i - 1] : blockOutChannels[0]
+      let isFinal = i == blockOutChannels.count - 1
+      downs.append(Flux2DownEncoderBlock(
+        inChannels: inCh,
+        outChannels: outCh,
+        numLayers: layersPerBlock,
+        groups: normNumGroups,
+        eps: eps,
+        addDownsample: !isFinal))
+    }
+    self._downBlocks.wrappedValue = downs
+
+    self._midBlock.wrappedValue = Flux2MidBlock(
+      channels: blockOutChannels.last!,
+      groups: normNumGroups,
+      eps: eps,
+      addAttention: midBlockAddAttention)
+
+    self._convNormOut.wrappedValue = GroupNorm(
+      groupCount: normNumGroups, dimensions: blockOutChannels.last!,
+      eps: eps, pytorchCompatible: true)
+
+    self._convOut.wrappedValue = Conv2d(
+      inputChannels: blockOutChannels.last!, outputChannels: 2 * outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    super.init()
+  }
+
+  /// Encodes an image into latent features.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C_in)`.
+  /// - Returns: Encoded features in NHWC layout `(B, H/8, W/8, 2*latent_channels)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = convIn(x)
+    for block in downBlocks {
+      hidden = block(hidden)
+    }
+    hidden = midBlock(hidden)
+    hidden = convNormOut(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = convOut(hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2MidBlock.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2MidBlock.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// UNet-style mid block for the Flux2 VAE encoder and decoder.
+///
+/// Contains two ResNet blocks with an optional attention block between them.
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> ResNet(C -> C)
+///   -> [Attention(C)]   (optional)
+///   -> ResNet(C -> C)
+///   -> Output (B, H, W, C)
+/// ```
+public final class Flux2MidBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [Flux2ResnetBlock]
+  @ModuleInfo(key: "attentions") var attentions: [Flux2VAEAttention]
+
+  /// Creates a Flux2 VAE mid block.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of channels (constant through the block).
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  ///   - addAttention: Whether to include an attention block. Default `true`.
+  public init(channels: Int, groups: Int = 32, eps: Float = 1e-6, addAttention: Bool = true) {
+    self._resnets.wrappedValue = [
+      Flux2ResnetBlock(inChannels: channels, outChannels: channels, groups: groups, eps: eps),
+      Flux2ResnetBlock(inChannels: channels, outChannels: channels, groups: groups, eps: eps),
+    ]
+    self._attentions.wrappedValue = addAttention
+      ? [Flux2VAEAttention(channels: channels, groups: groups, eps: eps)]
+      : []
+    super.init()
+  }
+
+  /// Applies the mid block.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var hidden = resnets[0](x)
+    if !attentions.isEmpty {
+      hidden = attentions[0](hidden)
+    }
+    hidden = resnets[1](hidden)
+    return hidden
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2ResnetBlock.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2ResnetBlock.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// ResNet block for the Flux2 VAE encoder and decoder.
+///
+/// Two group-norm + SiLU + conv layers with a residual connection.
+/// When input and output channel counts differ, a 1x1 shortcut convolution
+/// adapts the residual path.
+///
+/// All operations use NHWC layout (the native layout for MLX Conv2d / GroupNorm).
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C_in)
+///   |-- GroupNorm(32, C_in) -> SiLU -> Conv2d(C_in -> C_out, k=3, p=1)
+///   |-- GroupNorm(32, C_out) -> SiLU -> Conv2d(C_out -> C_out, k=3, p=1)
+///   |-- + residual (with optional 1x1 shortcut if C_in != C_out)
+///   --> Output (B, H, W, C_out)
+/// ```
+public final class Flux2ResnetBlock: Module {
+
+  @ModuleInfo(key: "norm1") var norm1: GroupNorm
+  @ModuleInfo(key: "norm2") var norm2: GroupNorm
+  @ModuleInfo(key: "conv1") var conv1: Conv2d
+  @ModuleInfo(key: "conv2") var conv2: Conv2d
+  @ModuleInfo(key: "conv_shortcut") var convShortcut: Conv2d?
+
+  /// Whether a shortcut convolution is needed.
+  public let hasShortcut: Bool
+
+  /// Creates a Flux2 ResNet block.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  public init(inChannels: Int, outChannels: Int, groups: Int = 32, eps: Float = 1e-6) {
+    self.hasShortcut = inChannels != outChannels
+
+    self._norm1.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: inChannels, eps: eps, pytorchCompatible: true)
+    self._norm2.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: outChannels, eps: eps, pytorchCompatible: true)
+    self._conv1.wrappedValue = Conv2d(
+      inputChannels: inChannels, outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+    self._conv2.wrappedValue = Conv2d(
+      inputChannels: outChannels, outputChannels: outChannels,
+      kernelSize: 3, stride: 1, padding: 1)
+
+    if hasShortcut {
+      self._convShortcut.wrappedValue = Conv2d(
+        inputChannels: inChannels, outputChannels: outChannels,
+        kernelSize: 1, stride: 1)
+    }
+
+    super.init()
+  }
+
+  /// Applies the residual block.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C_in)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let residual = hasShortcut ? convShortcut!(x) : x
+
+    var hidden = norm1(x.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = conv1(hidden)
+    hidden = norm2(hidden.asType(.float32)).asType(x.dtype)
+    hidden = silu(hidden)
+    hidden = conv2(hidden)
+
+    return hidden + residual
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2Upsample.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2Upsample.swift
@@ -1,0 +1,43 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// 2x nearest-neighbor upsampling followed by a 3x3 convolution for the Flux2 VAE decoder.
+///
+/// All operations use NHWC layout.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   -> nearest-neighbor 2x upsample -> (B, 2H, 2W, C)
+///   -> Conv2d(C -> C_out, k=3, p=1)
+///   -> Output (B, 2H, 2W, C_out)
+/// ```
+public final class Flux2Upsample: Module {
+
+  @ModuleInfo(key: "conv") var conv: Conv2d
+
+  /// Creates a Flux2 2x upsampling layer.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input channels.
+  ///   - outChannels: Number of output channels. If `nil`, uses `channels`.
+  public init(channels: Int, outChannels: Int? = nil) {
+    let out = outChannels ?? channels
+    self._conv.wrappedValue = Conv2d(
+      inputChannels: channels, outputChannels: out,
+      kernelSize: 3, stride: 1, padding: 1)
+    super.init()
+  }
+
+  /// Applies 2x nearest-neighbor upsampling and convolution.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, 2H, 2W, C_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // Nearest-neighbor 2x upsample using MLXNN.Upsample
+    let upsampled = Upsample(scaleFactor: .array([2.0, 2.0]), mode: .nearest)(x)
+    return conv(upsampled)
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2VAE.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2VAE.swift
@@ -1,0 +1,186 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Top-level VAE for the Flux2 image generation model.
+///
+/// The Flux2 VAE is a completely different architecture from the Flux1 AutoencoderKL.
+/// It uses batch normalization statistics for packed latent decoding, different block
+/// structures, and 32 latent channels (vs 16 for Flux1).
+///
+/// ## Key Differences from Flux1
+///
+/// | Feature | Flux1 (AutoencoderKL) | Flux2 (Flux2VAE) |
+/// |---------|----------------------|------------------|
+/// | Latent channels | 16 | 32 |
+/// | Scaling factor | 0.3611 | 1.0 |
+/// | Shift factor | 0.1159 | 0.0 |
+/// | Packed latents | No | Yes (decode_packed_latents) |
+/// | Batch norm stats | No | Yes (for unpacking) |
+/// | quant_conv / post_quant_conv | No | Yes (1x1 convolutions) |
+///
+/// ## Decode Pipeline
+///
+/// The primary decode path for generation is `decodePackedLatents`:
+///
+/// ```
+/// Packed latents (B, 4*C, H/2, W/2) in NCHW
+///   -> un-normalize using batch norm stats (mean + std)
+///   -> unpatchify: (B, 4*C, H/2, W/2) -> (B, C, H, W)
+///   -> scale/shift: (x / scaling_factor) + shift_factor
+///   -> NCHW -> NHWC transpose
+///   -> post_quant_conv (1x1)
+///   -> NHWC -> NCHW transpose (for decoder entry in Python; we stay NHWC)
+///   -> decoder
+///   -> NCHW -> NHWC transpose (Python output; we're already NHWC)
+///   -> Output image (B, H, W, 3) in NHWC
+/// ```
+public final class Flux2VAE: Module, VAEImageDecoding {
+
+  /// Scaling factor for latents. Flux2 uses 1.0 (no scaling).
+  public let scalingFactor: Float = 1.0
+
+  /// Shift factor for latents. Flux2 uses 0.0 (no shift).
+  public let shiftFactor: Float = 0.0
+
+  /// Number of latent channels.
+  public let latentChannels: Int = 32
+
+  @ModuleInfo(key: "encoder") var encoder: Flux2Encoder
+  @ModuleInfo(key: "decoder") var decoder: Flux2Decoder
+  @ModuleInfo(key: "quant_conv") var quantConv: Conv2d
+  @ModuleInfo(key: "post_quant_conv") var postQuantConv: Conv2d
+  @ModuleInfo(key: "bn") var bn: Flux2BatchNormStats
+
+  /// Creates a Flux2 VAE.
+  public override init() {
+    self._encoder.wrappedValue = Flux2Encoder(
+      inChannels: 3, outChannels: 32,
+      blockOutChannels: [128, 256, 512, 512])
+    self._decoder.wrappedValue = Flux2Decoder(
+      inChannels: 32, outChannels: 3,
+      blockOutChannels: [128, 256, 512, 512])
+    self._quantConv.wrappedValue = Conv2d(
+      inputChannels: 2 * 32, outputChannels: 2 * 32,
+      kernelSize: 1, stride: 1)
+    self._postQuantConv.wrappedValue = Conv2d(
+      inputChannels: 32, outputChannels: 32,
+      kernelSize: 1, stride: 1)
+    self._bn.wrappedValue = Flux2BatchNormStats(numFeatures: 4 * 32, eps: 1e-4)
+    super.init()
+  }
+
+  /// Encodes an image into latent space.
+  ///
+  /// - Parameter image: Image tensor in NCHW layout `(B, 3, H, W)` or `(B, 3, 1, H, W)`.
+  /// - Returns: Latent tensor in NCHW layout `(B, latent_channels, H/8, W/8)`.
+  public func encode(_ image: MLXArray) -> MLXArray {
+    var x = image
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // NCHW -> NHWC for encoder
+    x = x.transposed(0, 2, 3, 1)
+    x = encoder(x)
+
+    // NHWC -> NCHW for quant_conv, then back to NHWC
+    x = x.transposed(0, 3, 1, 2)
+    x = x.transposed(0, 2, 3, 1)
+    x = quantConv(x)
+    x = x.transposed(0, 3, 1, 2)
+
+    // Split mean/logvar, keep mean
+    let parts = split(x, parts: 2, axis: 1)
+    let mean = parts[0]
+
+    // Apply scaling
+    return (mean - shiftFactor) * scalingFactor
+  }
+
+  /// Decodes latent features into an image.
+  ///
+  /// This implements the standard VAE decode path (not packed latents).
+  ///
+  /// - Parameter latents: Latent tensor in NCHW layout `(B, latent_channels, H/8, W/8)`.
+  /// - Returns: Decoded image in NCHW layout `(B, 3, H, W)`.
+  public func decodeLatents(_ latents: MLXArray) -> MLXArray {
+    var x = latents
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // Un-scale
+    x = (x / scalingFactor) + shiftFactor
+
+    // NCHW -> NHWC for post_quant_conv
+    x = x.transposed(0, 2, 3, 1)
+    x = postQuantConv(x)
+
+    // Decode (stays in NHWC)
+    x = decoder(x)
+
+    // NHWC -> NCHW for output
+    return x.transposed(0, 3, 1, 2)
+  }
+
+  /// Decodes packed latents into an image.
+  ///
+  /// This is the primary decode path used during Flux2 image generation.
+  /// Packed latents have their channels patchified (4x channels, half spatial size)
+  /// and are normalized by batch norm statistics.
+  ///
+  /// - Parameter packedLatents: Packed latent tensor in NCHW layout
+  ///   `(B, 4*latent_channels, H/16, W/16)` or with temporal dim `(B, 4*C, 1, H/16, W/16)`.
+  /// - Returns: Decoded image in NCHW layout `(B, 3, H, W)`.
+  public func decodePackedLatents(_ packedLatents: MLXArray) -> MLXArray {
+    var x = packedLatents
+    // Remove temporal dimension if present
+    if x.ndim == 5 {
+      x = x.squeezed(axis: 2)
+    }
+
+    // Un-normalize using batch norm running statistics
+    // bn_mean: (1, num_features, 1, 1), bn_std: (1, num_features, 1, 1)
+    let bnMean = bn.runningMean.reshaped(1, -1, 1, 1)
+    let bnStd = sqrt(bn.runningVar.reshaped(1, -1, 1, 1) + bn.eps)
+    x = x * bnStd + bnMean
+
+    // Unpatchify: (B, 4*C, H/2, W/2) -> (B, C, H, W)
+    x = Flux2VAE.unpatchifyLatents(x)
+
+    // Standard decode
+    return decodeLatents(x)
+  }
+
+  /// VAEImageDecoding conformance -- delegates to standard latent decode.
+  ///
+  /// - Parameters:
+  ///   - latents: Latent tensor in NCHW layout.
+  ///   - return_dict: Ignored (kept for protocol conformance).
+  /// - Returns: Tuple of decoded image and empty dict.
+  public func decode(_ latents: MLXArray, return_dict: Bool = false) -> (MLXArray, Any) {
+    let decoded = decodeLatents(latents)
+    return (decoded, [:] as [String: Int])
+  }
+
+  /// Unpatchifies latents from packed format to standard spatial layout.
+  ///
+  /// Converts `(B, 4*C, H, W)` -> `(B, C, 2*H, 2*W)` by rearranging the
+  /// channel dimension into 2x2 spatial patches.
+  ///
+  /// - Parameter latents: Packed latent tensor `(B, 4*C, H, W)` in NCHW.
+  /// - Returns: Unpatchified tensor `(B, C, 2*H, 2*W)` in NCHW.
+  static func unpatchifyLatents(_ latents: MLXArray) -> MLXArray {
+    let (batch, numChannels, height, width) = (latents.shape[0], latents.shape[1], latents.shape[2], latents.shape[3])
+    // (B, 4C, H, W) -> (B, C, 2, 2, H, W)
+    var x = latents.reshaped(batch, numChannels / 4, 2, 2, height, width)
+    // (B, C, 2, 2, H, W) -> (B, C, H, 2, W, 2)
+    x = x.transposed(0, 1, 4, 2, 5, 3)
+    // (B, C, H, 2, W, 2) -> (B, C, 2H, 2W)
+    x = x.reshaped(batch, numChannels / 4, height * 2, width * 2)
+    return x
+  }
+}

--- a/Sources/ZImage/Flux2/VAE/Flux2VAEAttention.swift
+++ b/Sources/ZImage/Flux2/VAE/Flux2VAEAttention.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Self-attention block used in the Flux2 VAE mid-block.
+///
+/// Applies group normalization, then single-head scaled dot-product attention
+/// over the spatial dimensions, followed by a linear projection. Connected
+/// by a residual shortcut.
+///
+/// All operations use NHWC layout internally.
+///
+/// ## Architecture
+///
+/// ```
+/// Input (B, H, W, C)
+///   |-- GroupNorm(32, C)
+///   |-- to_q, to_k, to_v: Linear(C -> C)
+///   |-- reshape to (B, 1, H*W, C) -> scaled_dot_product_attention
+///   |-- to_out: Linear(C -> C)
+///   |-- + residual
+///   --> Output (B, H, W, C)
+/// ```
+public final class Flux2VAEAttention: Module {
+
+  @ModuleInfo(key: "group_norm") var groupNorm: GroupNorm
+  @ModuleInfo(key: "to_q") var toQ: Linear
+  @ModuleInfo(key: "to_k") var toK: Linear
+  @ModuleInfo(key: "to_v") var toV: Linear
+  @ModuleInfo(key: "to_out") var toOut: Linear
+
+  /// Creates a Flux2 VAE attention block.
+  ///
+  /// - Parameters:
+  ///   - channels: Number of input/output channels.
+  ///   - groups: Number of groups for GroupNorm. Default `32`.
+  ///   - eps: Epsilon for GroupNorm. Default `1e-6`.
+  public init(channels: Int, groups: Int = 32, eps: Float = 1e-6) {
+    self._groupNorm.wrappedValue = GroupNorm(
+      groupCount: groups, dimensions: channels, eps: eps, pytorchCompatible: true)
+    self._toQ.wrappedValue = Linear(channels, channels)
+    self._toK.wrappedValue = Linear(channels, channels)
+    self._toV.wrappedValue = Linear(channels, channels)
+    self._toOut.wrappedValue = Linear(channels, channels)
+    super.init()
+  }
+
+  /// Applies self-attention over spatial dimensions.
+  ///
+  /// - Parameter x: Input tensor in NHWC layout `(B, H, W, C)`.
+  /// - Returns: Output tensor in NHWC layout `(B, H, W, C)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let (batch, height, width, channels) = (x.shape[0], x.shape[1], x.shape[2], x.shape[3])
+
+    let normed = groupNorm(x.asType(.float32)).asType(x.dtype)
+
+    // Project to Q, K, V and reshape for single-head attention
+    // Shape: (B, H*W, C) -> (B, H*W, 1, C) -> (B, 1, H*W, C)
+    var q = toQ(normed).reshaped(batch, height * width, 1, channels)
+    var k = toK(normed).reshaped(batch, height * width, 1, channels)
+    var v = toV(normed).reshaped(batch, height * width, 1, channels)
+
+    q = q.transposed(0, 2, 1, 3)
+    k = k.transposed(0, 2, 1, 3)
+    v = v.transposed(0, 2, 1, 3)
+
+    let scale = 1.0 / sqrt(Float(channels))
+
+    let attended = MLXFast.scaledDotProductAttention(
+      queries: q, keys: k, values: v, scale: scale, mask: nil)
+
+    // Reshape back to spatial: (B, 1, H*W, C) -> (B, H, W, C)
+    let reshaped = attended.transposed(0, 2, 1, 3).reshaped(batch, height, width, channels)
+    let projected = toOut(reshaped)
+
+    return x + projected
+  }
+}

--- a/Sources/ZImage/Flux2/Weights/Flux2LoRAMapping.swift
+++ b/Sources/ZImage/Flux2/Weights/Flux2LoRAMapping.swift
@@ -1,0 +1,23 @@
+// Flux2LoRAMapping.swift — LoRA weight mapping for Flux 2 Klein
+//
+// Deferred to post-integration PR. The full Flux 2 LoRA mapping
+// (from mflux flux2_lora_mapping.py, ~915 lines) covers:
+//   - Global targets (x_embedder, context_embedder)
+//   - Double-stream block targets (attn Q/K/V/out, FF in/out, context FF)
+//   - Single-stream block targets (fused QKV+MLP proj, out)
+//   - BFL/ComfyUI-style naming conventions (qkv split patterns)
+//
+// This will be implemented when LoRA support is integrated into
+// the Flux 2 pipeline.
+
+import Foundation
+
+/// Placeholder for Flux 2 Klein LoRA weight mapping.
+///
+/// The full implementation maps LoRA adapter weights (lora_A/lora_B pairs)
+/// from various naming conventions (diffusers, BFL, ComfyUI, kohya) to
+/// the Flux2Transformer module paths.
+public enum Flux2LoRAMapping {
+  // Deferred to post-integration PR.
+  // See mflux flux2_lora_mapping.py for the full mapping specification.
+}

--- a/Sources/ZImage/Flux2/Weights/Flux2WeightDefinition.swift
+++ b/Sources/ZImage/Flux2/Weights/Flux2WeightDefinition.swift
@@ -1,0 +1,69 @@
+// Flux2WeightDefinition.swift — Defines which safetensors files contain which components
+// Ported from mflux: flux2_weight_definition.py
+
+import Foundation
+
+/// Defines the safetensors weight file layout for Flux 2 Klein models.
+///
+/// Flux 2 Klein models store weights in three component subdirectories:
+///   - `vae/` — VAE encoder/decoder weights
+///   - `transformer/` — Transformer denoising backbone weights
+///   - `text_encoder/` — Qwen3 text encoder weights
+///
+/// Each subdirectory contains one or more `.safetensors` shards plus a
+/// `config.json` describing the component's architecture.
+public enum Flux2WeightDefinition {
+
+  /// Known Flux 2 Klein model identifiers on HuggingFace.
+  public enum ModelID: String {
+    case klein4B = "black-forest-labs/FLUX.2-klein-4B"
+    case klein9B = "black-forest-labs/FLUX.2-klein-9B"
+  }
+
+  /// Component subdirectory names within the model snapshot.
+  public enum Component: String, CaseIterable {
+    case vae = "vae"
+    case transformer = "transformer"
+    case textEncoder = "text_encoder"
+  }
+
+  /// File patterns to download for a complete Flux 2 Klein model.
+  public static let downloadPatterns: [String] = [
+    "vae/*.safetensors",
+    "vae/*.json",
+    "transformer/*.safetensors",
+    "transformer/*.json",
+    "text_encoder/*.safetensors",
+    "text_encoder/*.json",
+    "tokenizer/**",
+    "added_tokens.json",
+    "chat_template.jinja",
+  ]
+
+  /// Resolve weight shard files for a given component within a snapshot directory.
+  ///
+  /// Uses the same shard resolution logic as the existing `ZImageFiles` for consistency:
+  /// checks index JSON, then scans directory for `.safetensors` files.
+  ///
+  /// - Parameters:
+  ///   - component: Which model component to resolve.
+  ///   - snapshot: Root URL of the model snapshot.
+  /// - Returns: Array of URLs pointing to safetensors shard files.
+  public static func resolveWeightFiles(
+    for component: Component,
+    at snapshot: URL
+  ) -> [URL] {
+    let componentDir = snapshot.appendingPathComponent(component.rawValue)
+    return ZImageFiles.resolveWeightFiles(in: componentDir, componentName: component.rawValue)
+  }
+
+  /// Check whether a snapshot directory contains all required Flux 2 components.
+  ///
+  /// - Parameter snapshot: Root URL of the model snapshot.
+  /// - Returns: `true` if all three component directories contain safetensors files.
+  public static func hasAllComponents(at snapshot: URL) -> Bool {
+    Component.allCases.allSatisfy { component in
+      !resolveWeightFiles(for: component, at: snapshot).isEmpty
+    }
+  }
+}

--- a/Sources/ZImage/Flux2/Weights/Flux2WeightMapping.swift
+++ b/Sources/ZImage/Flux2/Weights/Flux2WeightMapping.swift
@@ -1,0 +1,202 @@
+// Flux2WeightMapping.swift — Maps safetensors key names to model parameter paths
+// Ported from mflux: flux2_weight_mapping.py
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Maps HuggingFace safetensors weight keys to the Flux2 Swift module parameter paths.
+///
+/// The Flux 2 Klein model stores weights using diffusers-convention keys in safetensors
+/// files. This mapper translates those keys into the paths expected by the MLXNN module
+/// hierarchy (as defined by `@ModuleInfo(key:)` annotations).
+///
+/// ## Component weight flows
+///
+/// **Transformer:** safetensors keys map directly — most Flux 2 transformer keys
+/// already match the Swift module paths thanks to the `@ModuleInfo` keys matching
+/// the diffusers naming convention.
+///
+/// **VAE:** Conv2d weights need a `[N,C,H,W] -> [N,H,W,C]` transpose because MLX
+/// Conv2d expects `NHWC` layout while PyTorch stores `NCHW`.
+///
+/// **Text Encoder:** The `model.` prefix in safetensors keys maps to the `encoder.`
+/// module prefix in the Swift hierarchy (matching the existing Z-Image convention).
+public enum Flux2WeightMapping {
+
+  // MARK: - Transformer
+
+  /// Load and map transformer weights from safetensors files.
+  ///
+  /// - Parameters:
+  ///   - files: URLs to transformer safetensors shards.
+  ///   - dtype: Target dtype for weight conversion (default `.bfloat16`).
+  /// - Returns: Mapped weights keyed by module parameter path.
+  public static func loadTransformerWeights(
+    from files: [URL],
+    dtype: DType = .bfloat16
+  ) throws -> [String: MLXArray] {
+    var weights: [String: MLXArray] = [:]
+    for file in files {
+      let reader = try SafeTensorsReader(fileURL: file)
+      for meta in reader.allMetadata() {
+        var tensor = try reader.tensor(named: meta.name)
+        if tensor.dtype != dtype {
+          tensor = tensor.asType(dtype)
+        }
+        // Map diffusers key to module path
+        let mappedKey = mapTransformerKey(meta.name)
+        weights[mappedKey] = tensor
+      }
+    }
+    return weights
+  }
+
+  /// Map a single HuggingFace transformer weight key to the Swift module path.
+  ///
+  /// Most Flux 2 transformer keys map directly because the `@ModuleInfo` keys
+  /// match the diffusers convention. The only notable remapping is
+  /// `attn.to_out.0.weight` -> `attn.to_out.weight` (PyTorch wraps the output
+  /// projection in a `nn.Sequential`).
+  static func mapTransformerKey(_ hfKey: String) -> String {
+    // to_out.0.weight -> to_out.weight (unwrap Sequential wrapper)
+    var key = hfKey
+    key = key.replacingOccurrences(of: ".to_out.0.", with: ".to_out.")
+    // time_guidance_embed.timestep_embedder.linear_X -> time_guidance_embed.linear_X
+    key = key.replacingOccurrences(
+      of: "time_guidance_embed.timestep_embedder.",
+      with: "time_guidance_embed."
+    )
+    return key
+  }
+
+  // MARK: - VAE
+
+  /// Load and map VAE weights from safetensors files.
+  ///
+  /// Conv2d weight tensors are transposed from PyTorch `NCHW` to MLX `NHWC` layout.
+  ///
+  /// - Parameters:
+  ///   - files: URLs to VAE safetensors shards.
+  ///   - dtype: Target dtype for weight conversion (default `.bfloat16`).
+  /// - Returns: Mapped weights keyed by module parameter path.
+  public static func loadVAEWeights(
+    from files: [URL],
+    dtype: DType = .bfloat16
+  ) throws -> [String: MLXArray] {
+    var weights: [String: MLXArray] = [:]
+    for file in files {
+      let reader = try SafeTensorsReader(fileURL: file)
+      for meta in reader.allMetadata() {
+        var tensor = try reader.tensor(named: meta.name)
+        // Transpose conv2d weights: PyTorch NCHW -> MLX NHWC
+        if meta.name.contains(".conv") && meta.name.hasSuffix(".weight") && tensor.ndim == 4 {
+          tensor = tensor.transposed(0, 2, 3, 1)
+        }
+        if tensor.dtype != dtype {
+          tensor = tensor.asType(dtype)
+        }
+        // Map diffusers key to module path
+        let mappedKey = mapVAEKey(meta.name)
+        weights[mappedKey] = tensor
+      }
+    }
+    return weights
+  }
+
+  /// Map a single HuggingFace VAE weight key to the Swift module path.
+  ///
+  /// Most VAE keys map directly. The `to_out.0.` -> `to_out.` remapping
+  /// handles the mid-block attention output projection Sequential wrapper.
+  static func mapVAEKey(_ hfKey: String) -> String {
+    var key = hfKey
+    // to_out.0.weight -> to_out.weight (mid-block attention)
+    key = key.replacingOccurrences(of: ".to_out.0.", with: ".to_out.")
+    return key
+  }
+
+  // MARK: - Text Encoder
+
+  /// Load and map text encoder weights from safetensors files.
+  ///
+  /// HuggingFace keys use `model.` prefix which maps to the `encoder.` module
+  /// prefix in the Swift Qwen3TextEncoder hierarchy.
+  ///
+  /// - Parameters:
+  ///   - files: URLs to text encoder safetensors shards.
+  ///   - dtype: Target dtype for weight conversion (default `.bfloat16`).
+  /// - Returns: Mapped weights keyed by module parameter path.
+  public static func loadTextEncoderWeights(
+    from files: [URL],
+    dtype: DType = .bfloat16
+  ) throws -> [String: MLXArray] {
+    var weights: [String: MLXArray] = [:]
+    for file in files {
+      let reader = try SafeTensorsReader(fileURL: file)
+      for meta in reader.allMetadata() {
+        var tensor = try reader.tensor(named: meta.name)
+        if tensor.dtype != dtype {
+          tensor = tensor.asType(dtype)
+        }
+        let mappedKey = mapTextEncoderKey(meta.name)
+        weights[mappedKey] = tensor
+      }
+    }
+    return weights
+  }
+
+  /// Map a single HuggingFace text encoder weight key to the Swift module path.
+  ///
+  /// The `model.` prefix is stripped (the MLXNN Qwen3TextEncoder uses top-level
+  /// module keys like `embed_tokens`, `layers`, `norm`).
+  static func mapTextEncoderKey(_ hfKey: String) -> String {
+    if hfKey.hasPrefix("model.") {
+      return String(hfKey.dropFirst("model.".count))
+    }
+    return hfKey
+  }
+
+  // MARK: - Weight Application
+
+  /// Apply mapped weights to a Flux2 transformer module.
+  ///
+  /// Handles the MLXNN `Module.update(parameters:)` flow: flattens the weight
+  /// dictionary, checks shapes, and applies via `ModuleParameters.unflattened`.
+  ///
+  /// - Parameters:
+  ///   - weights: Mapped weight dictionary from `loadTransformerWeights`.
+  ///   - transformer: The `Flux2Transformer` module to load weights into.
+  public static func applyTransformerWeights(
+    _ weights: [String: MLXArray],
+    to transformer: Module
+  ) throws {
+    let params = ModuleParameters.unflattened(weights)
+    try transformer.update(parameters: params, verify: [.shapeMismatch])
+  }
+
+  /// Apply mapped weights to a Flux2 VAE module.
+  ///
+  /// - Parameters:
+  ///   - weights: Mapped weight dictionary from `loadVAEWeights`.
+  ///   - vae: The `Flux2VAE` module to load weights into.
+  public static func applyVAEWeights(
+    _ weights: [String: MLXArray],
+    to vae: Module
+  ) throws {
+    let params = ModuleParameters.unflattened(weights)
+    try vae.update(parameters: params, verify: [.shapeMismatch])
+  }
+
+  /// Apply mapped weights to a Qwen3 text encoder module.
+  ///
+  /// - Parameters:
+  ///   - weights: Mapped weight dictionary from `loadTextEncoderWeights`.
+  ///   - textEncoder: The `Qwen3TextEncoder` module to load weights into.
+  public static func applyTextEncoderWeights(
+    _ weights: [String: MLXArray],
+    to textEncoder: Module
+  ) throws {
+    let params = ModuleParameters.unflattened(weights)
+    try textEncoder.update(parameters: params, verify: [.shapeMismatch])
+  }
+}

--- a/Sources/ZImage/Flux2/Weights/Flux2WeightMapping.swift
+++ b/Sources/ZImage/Flux2/Weights/Flux2WeightMapping.swift
@@ -90,7 +90,7 @@ public enum Flux2WeightMapping {
       for meta in reader.allMetadata() {
         var tensor = try reader.tensor(named: meta.name)
         // Transpose conv2d weights: PyTorch NCHW -> MLX NHWC
-        if meta.name.contains(".conv") && meta.name.hasSuffix(".weight") && tensor.ndim == 4 {
+        if meta.name.hasSuffix(".weight") && tensor.ndim == 4 && (meta.name.contains(".conv") || meta.name.contains("quant_conv") || meta.name.contains("post_quant_conv")) {
           tensor = tensor.transposed(0, 2, 3, 1)
         }
         if tensor.dtype != dtype {

--- a/Sources/ZImage/Tokenizer/Tokenizer.swift
+++ b/Sources/ZImage/Tokenizer/Tokenizer.swift
@@ -427,6 +427,11 @@ public final class QwenTokenizer {
   /// read-only snapshot mount or a model whose chat_template must not be
   /// augmented).
   ///
+  /// Handles HuggingFace cache symlinks: snapshot files are typically symlinks
+  /// to content-addressed blobs. Writing through a symlink mutates the shared
+  /// blob and corrupts the backup. This function resolves symlinks first,
+  /// removes the symlink, and writes a real file in its place.
+  ///
   /// Errors are swallowed by the caller — a failure here degrades to the
   /// pre-existing `missingChatTemplate` error at `applyChatTemplate` time,
   /// which is strictly no worse than the status quo.
@@ -442,44 +447,101 @@ public final class QwenTokenizer {
     let jinjaURL = tokenizerDirectory.appending(path: "chat_template.jinja")
     let fm = FileManager.default
 
-    guard fm.fileExists(atPath: configURL.path),
-          fm.fileExists(atPath: jinjaURL.path) else {
-      // Nothing to do — either the config is missing (caller will surface a
-      // clearer error) or there is no sidecar to merge.
+    // Clean up orphaned .tmp files from previous failed patch attempts.
+    if let contents = try? fm.contentsOfDirectory(
+      at: tokenizerDirectory,
+      includingPropertiesForKeys: nil
+    ) {
+      for url in contents where url.lastPathComponent.contains(".patch.") && url.pathExtension == "tmp" {
+        try? fm.removeItem(at: url)
+      }
+    }
+
+    guard fm.fileExists(atPath: configURL.path) else {
+      // Config missing — caller will surface a clearer error downstream.
       return
     }
 
-    let configData = try Data(contentsOf: configURL)
-    guard var configJSON = try JSONSerialization.jsonObject(with: configData, options: []) as? [String: Any] else {
+    // Read the config, resolving through symlinks so we get actual content.
+    let resolvedConfigURL = configURL.resolvingSymlinksInPath()
+    let configData = try Data(contentsOf: resolvedConfigURL)
+    guard var configJSON = try JSONSerialization.jsonObject(
+      with: configData, options: []
+    ) as? [String: Any] else {
       return
     }
 
-    // Already inlined — no-op. We treat any non-empty string as "inlined",
+    // Already inlined — no-op.  Any non-empty string counts as "present",
     // matching what swift-transformers will accept downstream.
     if let existing = configJSON["chat_template"] as? String, !existing.isEmpty {
       return
     }
 
-    let jinjaTemplate = try String(contentsOf: jinjaURL, encoding: .utf8)
-    guard !jinjaTemplate.isEmpty else { return }
+    // No inline chat_template.  Try the jinja sidecar.
+    guard fm.fileExists(atPath: jinjaURL.path) else {
+      FileHandle.standardError.write(Data(
+        "[zimage] warning: tokenizer_config.json has no chat_template and no chat_template.jinja sidecar found in \(tokenizerDirectory.path) — applyChatTemplate will fail\n".utf8
+      ))
+      return
+    }
+
+    let resolvedJinjaURL = jinjaURL.resolvingSymlinksInPath()
+    let jinjaTemplate = try String(contentsOf: resolvedJinjaURL, encoding: .utf8)
+    guard !jinjaTemplate.isEmpty else {
+      FileHandle.standardError.write(Data(
+        "[zimage] warning: chat_template.jinja is empty in \(tokenizerDirectory.path)\n".utf8
+      ))
+      return
+    }
 
     configJSON["chat_template"] = jinjaTemplate
 
-    // Write backup on first patch (never overwrite an existing .bak).
+    // Back up the original config (actual content, not the symlink).
+    // Never overwrite an existing backup that contains real content.
     let backupURL = configURL.appendingPathExtension("bak")
-    if !fm.fileExists(atPath: backupURL.path) {
-      try? fm.copyItem(at: configURL, to: backupURL)
+    let backupExists = fm.fileExists(atPath: backupURL.path)
+    if backupExists {
+      // If the backup is a symlink (from a previous broken run that copied
+      // the symlink instead of the content), replace it with real content.
+      let backupAttrs = try? fm.attributesOfItem(atPath: backupURL.path)
+      if backupAttrs?[.type] as? FileAttributeType == .typeSymbolicLink {
+        try? fm.removeItem(at: backupURL)
+        try? configData.write(to: backupURL, options: .atomic)
+      }
+    } else {
+      try? configData.write(to: backupURL, options: .atomic)
     }
 
-    // Atomic write via temp sibling + rename, so readers never see a
-    // torn file. .sortedKeys for stable diffs on subsequent patches.
-    let tmpURL = configURL.appendingPathExtension("patch.\(UUID().uuidString).tmp")
+    // Serialize the patched config.
     let patchedData = try JSONSerialization.data(
       withJSONObject: configJSON,
       options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     )
-    try patchedData.write(to: tmpURL, options: [.atomic])
-    _ = try fm.replaceItemAt(configURL, withItemAt: tmpURL)
+
+    // If tokenizer_config.json is a symlink, remove it first.  Writing
+    // through a symlink would mutate the shared content-addressed blob in
+    // the HuggingFace cache, which is both destructive and makes the .bak
+    // backup point at the already-modified blob (useless).
+    let configAttrs = try fm.attributesOfItem(atPath: configURL.path)
+    if configAttrs[.type] as? FileAttributeType == .typeSymbolicLink {
+      try fm.removeItem(at: configURL)
+    }
+
+    // Atomic write via temp sibling + rename, so readers never see a
+    // torn file.  .sortedKeys for stable diffs on subsequent patches.
+    let tmpURL = configURL.appendingPathExtension("patch.\(UUID().uuidString).tmp")
+    do {
+      try patchedData.write(to: tmpURL, options: .atomic)
+      if fm.fileExists(atPath: configURL.path) {
+        _ = try fm.replaceItemAt(configURL, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: configURL)
+      }
+    } catch {
+      // Clean up temp file on failure.
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
 
     FileHandle.standardError.write(Data(
       "[zimage] inlined chat_template.jinja (\(jinjaTemplate.count) chars) into \(configURL.path); backup at \(backupURL.lastPathComponent)\n".utf8

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -79,6 +79,7 @@ struct ZImageCLI {
     var imagePath: String?
     var imageStrength: Float?
     var imageCreativity: Float?
+    var modelFamily: String?
 
     let args = Array(CommandLine.arguments.dropFirst())
     var iterator = args.makeIterator()
@@ -176,6 +177,8 @@ struct ZImageCLI {
         imageStrength = floatValue(for: arg, iterator: &iterator, fallback: 0.3)
       case "--creativity":
         imageCreativity = floatValue(for: arg, iterator: &iterator, fallback: 0.7)
+      case "--model-family":
+        modelFamily = nextValue(for: arg, iterator: &iterator)
       case "--help", "-h":
         printUsage()
         return
@@ -564,6 +567,89 @@ struct ZImageCLI {
       return
     }
 
+    // === FLUX 2 KLEIN PATH ===
+    // Auto-detect or explicitly route to Flux 2 pipeline
+    let isFlux2: Bool
+    if let family = modelFamily {
+      isFlux2 = (family.lowercased() == "flux2")
+    } else if let modelSpec = model {
+      // Check HF model ID first, then check local directory
+      if Flux2ModelDetection.isKnownFlux2Model(modelSpec) {
+        isFlux2 = true
+      } else {
+        let localURL = URL(fileURLWithPath: modelSpec)
+        if FileManager.default.fileExists(atPath: localURL.path) {
+          isFlux2 = Flux2ModelDetection.detect(at: localURL) != nil
+        } else {
+          isFlux2 = false
+        }
+      }
+    } else {
+      isFlux2 = false
+    }
+
+    if isFlux2 {
+      let flux2Request = Flux2GenerationRequest(
+        prompt: prompt,
+        negativePrompt: negativePrompt,
+        width: width,
+        height: height,
+        steps: steps,
+        guidanceScale: guidance,
+        seed: seed,
+        outputPath: URL(fileURLWithPath: outputPath),
+        maxSequenceLength: maxSequenceLength
+      )
+
+      nonisolated(unsafe) let flux2Semaphore = DispatchSemaphore(value: 0)
+      let capturedModel = model
+      let useBar = !noProgress && (isatty(STDERR_FILENO) != 0)
+      let bar = useBar ? ProgressBar(total: steps) : nil
+      Task {
+        do {
+          // Resolve model snapshot
+          let modelSpec = capturedModel ?? "black-forest-labs/FLUX.2-klein-4B"
+          let snapshot = try await ModelResolution.resolve(modelSpec: modelSpec)
+
+          // Detect model config from snapshot
+          guard let detected = Flux2ModelDetection.detect(at: snapshot) else {
+            logger.error("Model at \(snapshot.path) is not a Flux 2 Klein model")
+            flux2Semaphore.signal()
+            return
+          }
+          logger.info("Detected Flux 2 Klein \(detected.variant)")
+
+          let flux2Pipeline = Flux2Pipeline(logger: logger)
+          try flux2Pipeline.loadModel(
+            from: snapshot,
+            config: detected.transformerConfig,
+            textEncoderConfig: detected.textEncoderConfig
+          )
+
+          _ = try await flux2Pipeline.generate(flux2Request, progressHandler: { progress in
+            guard !noProgress else { return }
+            guard progress.stage == .denoising else { return }
+            let completed = min(progress.totalSteps, max(0, progress.stepIndex))
+            if let bar {
+              bar.update(completed: completed)
+              if completed == progress.totalSteps {
+                bar.finish(forceNewline: true)
+              }
+            } else {
+              PlainProgress.shared.report(completed: completed, total: progress.totalSteps)
+            }
+          })
+          if let bar { bar.finish(forceNewline: true) }
+        } catch {
+          logger.error("Flux 2 generation failed: \(error)")
+          if let bar { bar.finish(forceNewline: true) }
+        }
+        flux2Semaphore.signal()
+      }
+      flux2Semaphore.wait()
+      return
+    }
+
     // === SINGLE IMAGE PATH ===
     let request = ZImageGenerationRequest(
       prompt: prompt,
@@ -742,6 +828,7 @@ struct ZImageCLI {
       --seed                 Random seed
       --output, -o           Output path (default z-image.png)
       --model, -m            Model path or HuggingFace ID (default: \(ZImageRepository.id))
+      --model-family         Model family: flux1 or flux2 (default: auto-detect from model config)
       --text-encoder-path    Override text encoder directory (CLI > ZIMAGE_ENCODER_PATH > auto-detect > default)
       --force-transformer-override-only  Treat a local .safetensors as transformer-only override (disable AIO auto-detect)
       --cache-limit          GPU memory cache limit in MB (default: unlimited)


### PR DESCRIPTION
Fixes silent failure in ensureInlineChatTemplate. Three bugs: symlink backup, HF cache blob corruption, no cleanup. Now resolves symlinks, writes real files, cleans orphans.