### PR TITLE
feat(flux2): add Klein Base (non-distilled) model support with guidance embeddings

### DIFF
--- a/Sources/ZImage/Flux2/Flux2ModelDetection.swift
+++ b/Sources/ZImage/Flux2/Flux2ModelDetection.swift
@@ -10,8 +10,10 @@ public enum ZImageModelFamily: String, Sendable {
 
 /// Detected Flux 2 Klein model variant with its configuration.
 public struct Flux2DetectedModel {
-  /// The model variant (e.g., "klein-4b", "klein-9b").
+  /// The model variant (e.g., "klein-4b", "klein-base-4b").
   public let variant: String
+  /// Whether this is a base (non-distilled) model that supports guidance > 1.0.
+  public let isBaseModel: Bool
   /// Transformer config parsed from the model directory.
   public let transformerConfig: Flux2TransformerConfig
   /// Text encoder config inferred from the model directory.
@@ -81,16 +83,21 @@ public enum Flux2ModelDetection {
     // Parse text encoder config if available
     let textEncoderConfig = parseTextEncoderConfig(at: snapshot) ?? Qwen3TextEncoderConfiguration()
 
-    // Determine variant from model dimensions
+    // Determine variant from model dimensions and whether it's a base model.
+    // Base (non-distilled) models are detected by "base" in the directory path,
+    // matching mflux behavior (is_distilled = "base" not in model_name.lower()).
+    // The config.json guidance_embeds field is false for both distilled and base.
+    let isBase = snapshot.path.lowercased().contains("base")
     let variant: String
     if numLayers == 8 && numSingleLayers == 24 && numAttentionHeads == 32 {
-      variant = "klein-9b"
+      variant = isBase ? "klein-base-9b" : "klein-9b"
     } else {
-      variant = "klein-4b"
+      variant = isBase ? "klein-base-4b" : "klein-4b"
     }
 
     return Flux2DetectedModel(
       variant: variant,
+      isBaseModel: isBase,
       transformerConfig: transformerConfig,
       textEncoderConfig: textEncoderConfig
     )

--- a/Sources/ZImage/Flux2/Flux2Pipeline.swift
+++ b/Sources/ZImage/Flux2/Flux2Pipeline.swift
@@ -108,6 +108,20 @@ public final class Flux2Pipeline {
   // Model configs for current loaded model
   private var transformerConfig: Flux2TransformerConfig?
   private var textEncoderConfig: Qwen3TextEncoderConfiguration?
+  private var _isBaseModel: Bool = false
+
+  /// Whether the loaded model is a base (non-distilled) variant.
+  /// Base models support guidance > 1.0 and default to 50 steps.
+  public var isBaseModel: Bool { _isBaseModel }
+
+  /// Whether the loaded model is a distilled (few-step) variant.
+  public var isDistilled: Bool { !_isBaseModel }
+
+  /// Default inference steps for the loaded model.
+  /// Base models default to 50 steps; distilled models default to 4.
+  public var defaultSteps: Int {
+    _isBaseModel ? 50 : 4
+  }
 
   public init(logger: Logger = Logger(label: "z-image.flux2-pipeline")) {
     self.logger = logger
@@ -123,6 +137,7 @@ public final class Flux2Pipeline {
     modelSnapshot = nil
     transformerConfig = nil
     textEncoderConfig = nil
+    _isBaseModel = false
     isLoaded = false
     GPU.clearCache()
     logger.info("Flux 2 model unloaded")
@@ -134,11 +149,14 @@ public final class Flux2Pipeline {
   ///   - snapshot: Root URL of the model snapshot directory.
   ///   - config: Transformer config for this model variant. Defaults to Klein 4B.
   ///   - textEncoderConfig: Text encoder config. Defaults to Klein 4B Qwen3 config.
+  ///   - isBase: Whether this is a base (non-distilled) model. Base models support
+  ///     guidance > 1.0 and default to 50 inference steps.
   ///   - progressHandler: Optional progress callback.
   public func loadModel(
     from snapshot: URL,
     config: Flux2TransformerConfig = Flux2TransformerConfig(),
     textEncoderConfig: Qwen3TextEncoderConfiguration = Qwen3TextEncoderConfiguration(),
+    isBase: Bool = false,
     progressHandler: ProgressHandler? = nil
   ) throws {
     if isLoaded && modelSnapshot == snapshot { return }
@@ -162,10 +180,12 @@ public final class Flux2Pipeline {
     self.modelSnapshot = snapshot
     self.transformerConfig = config
     self.textEncoderConfig = textEncoderConfig
+    self._isBaseModel = isBase
     self.isLoaded = true
 
     progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 1, totalSteps: 1))
-    logger.info("Flux 2 Klein model loaded from \(snapshot.path)")
+    let modelKind = isBase ? "base (non-distilled)" : "distilled"
+    logger.info("Flux 2 Klein model loaded from \(snapshot.path) [\(modelKind)]")
   }
 
   /// Generate an image and save it to disk.
@@ -295,6 +315,13 @@ public final class Flux2Pipeline {
 
       let timestep = sigmas[stepIndex]
 
+      // Guidance embedding: pass the guidance scale to the transformer when the
+      // model is a base (non-distilled) variant.
+      // For distilled models, pass nil (guidance embeddings are unused).
+      let guidanceForTransformer: MLXArray? = _isBaseModel
+        ? MLXArray(request.guidanceScale)
+        : nil
+
       // Forward pass through transformer
       let noisePred = components.transformer(
         hiddenStates: latents,
@@ -302,7 +329,7 @@ public final class Flux2Pipeline {
         timestep: timestep,
         imgIds: latentIds,
         txtIds: textIds,
-        guidance: nil
+        guidance: guidanceForTransformer
       )
 
       // Apply CFG if guidance > 1.0
@@ -314,7 +341,7 @@ public final class Flux2Pipeline {
           timestep: timestep,
           imgIds: latentIds,
           txtIds: nti,
-          guidance: nil
+          guidance: guidanceForTransformer
         )
         guidedNoise = negativeNoisePred + request.guidanceScale * (noisePred - negativeNoisePred)
       } else {

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -389,8 +389,11 @@ public final class WarmServer {
       resolvedGuidance = 0.0                        // Z-Image Turbo: designed for cfg=0
       resolvedNegativePrompt = nil                  // Negative prompts crash broadcast_shapes
     case .flux2:
+      // Base (non-distilled) models support guidance > 1.0 and default to 50 steps;
+      // distilled models default to 4 steps and guidance 1.0.
+      let isBaseModel = await coordinator.isFlux2BaseModel
       resolvedSteps = request.steps                 // Klein: no step clamp
-      resolvedGuidance = 1.0                        // Klein: default guidance 1.0
+      resolvedGuidance = isBaseModel ? request.guidance : 1.0
       resolvedNegativePrompt = nil                  // Klein: CFG only when guidance > 1.0
     }
 
@@ -606,17 +609,19 @@ private actor WarmServerCoordinator {
       // Log memory estimate
       let estimatedGB: String
       switch detected.variant {
-      case "klein-4b": estimatedGB = "~15GB"
-      case "klein-9b": estimatedGB = "~25GB"
+      case "klein-4b", "klein-base-4b": estimatedGB = "~15GB"
+      case "klein-9b", "klein-base-9b": estimatedGB = "~25GB"
       default: estimatedGB = "unknown"
       }
-      logger.info("Detected Flux 2 Klein \(detected.variant) — estimated GPU memory: \(estimatedGB)")
+      let modelType = detected.isBaseModel ? "base (non-distilled)" : "distilled"
+      logger.info("Detected Flux 2 Klein \(detected.variant) [\(modelType)] — estimated GPU memory: \(estimatedGB)")
 
       let f2 = Flux2Pipeline(logger: logger)
       try f2.loadModel(
         from: snapshot,
         config: detected.transformerConfig,
-        textEncoderConfig: detected.textEncoderConfig
+        textEncoderConfig: detected.textEncoderConfig,
+        isBase: detected.isBaseModel
       )
       flux2Pipeline = f2
       pipelinePrepared = true
@@ -639,6 +644,11 @@ private actor WarmServerCoordinator {
   /// Expose the current model family for routing decisions outside the actor.
   var modelFamily: WarmModelFamily {
     currentModelFamily
+  }
+
+  /// Whether the loaded Flux 2 model is a base (non-distilled) variant.
+  var isFlux2BaseModel: Bool {
+    detectedFlux2Model?.isBaseModel ?? false
   }
 
   func enqueueGenerate(
@@ -825,14 +835,17 @@ private actor WarmServerCoordinator {
       }
 
       // Map GeneratePayload fields to Flux2GenerationRequest.
-      // Klein defaults: 4 steps, guidance 1.0.
+      // Base models: 50 steps, guidance configurable.
+      // Distilled models: 4 steps, guidance 1.0.
+      let defaultSteps = f2.defaultSteps
+      let defaultGuidance: Float = f2.isDistilled ? 1.0 : 3.5
       let flux2Request = Flux2GenerationRequest(
         prompt: payload.prompt,
         negativePrompt: payload.negativePrompt,
         width: payload.width ?? 1024,
         height: payload.height ?? 1024,
-        steps: payload.steps ?? 4,
-        guidanceScale: payload.guidance ?? 1.0,
+        steps: payload.steps ?? defaultSteps,
+        guidanceScale: payload.guidance ?? defaultGuidance,
         seed: payload.seed,
         outputPath: outputURL,
         maxSequenceLength: configuration.maxSequenceLength

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -589,18 +589,6 @@ struct ZImageCLI {
     }
 
     if isFlux2 {
-      let flux2Request = Flux2GenerationRequest(
-        prompt: prompt,
-        negativePrompt: negativePrompt,
-        width: width,
-        height: height,
-        steps: steps,
-        guidanceScale: guidance,
-        seed: seed,
-        outputPath: URL(fileURLWithPath: outputPath),
-        maxSequenceLength: maxSequenceLength
-      )
-
       nonisolated(unsafe) let flux2Semaphore = DispatchSemaphore(value: 0)
       let capturedModel = model
       let useBar = !noProgress && (isatty(STDERR_FILENO) != 0)
@@ -623,7 +611,26 @@ struct ZImageCLI {
           try flux2Pipeline.loadModel(
             from: snapshot,
             config: detected.transformerConfig,
-            textEncoderConfig: detected.textEncoderConfig
+            textEncoderConfig: detected.textEncoderConfig,
+            isBase: detected.isBaseModel
+          )
+
+          // Validate guidance for distilled models
+          if flux2Pipeline.isDistilled && guidance != 1.0 && guidance != ZImageModelMetadata.recommendedGuidanceScale {
+            logger.warning("Guidance scale \(guidance) has no effect on distilled Klein models (forcing 1.0)")
+          }
+
+          // Override request defaults based on detected model type
+          let flux2Request = Flux2GenerationRequest(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            width: width,
+            height: height,
+            steps: steps == ZImageModelMetadata.recommendedInferenceSteps ? flux2Pipeline.defaultSteps : steps,
+            guidanceScale: flux2Pipeline.isDistilled ? 1.0 : guidance,
+            seed: seed,
+            outputPath: URL(fileURLWithPath: outputPath),
+            maxSequenceLength: maxSequenceLength
           )
 
           _ = try await flux2Pipeline.generate(flux2Request, progressHandler: { progress in
@@ -1720,6 +1727,9 @@ struct ZImageCLI {
       ModelFamily(family: "redux", variant: "encoder", directoryName: "redux-encoder", huggingFaceId: "DiffSynth-Studio/General-Image-Encoders"),
       ModelFamily(family: "kontext", variant: "default", directoryName: "kontext", huggingFaceId: nil),
       ModelFamily(family: "flux2", variant: "klein-4b", directoryName: "flux2-klein-4b", huggingFaceId: "black-forest-labs/FLUX.2-klein-4B"),
+      ModelFamily(family: "flux2", variant: "klein-9b", directoryName: "flux2-klein-9b", huggingFaceId: "black-forest-labs/FLUX.2-klein-9B"),
+      ModelFamily(family: "flux2", variant: "klein-base-4b", directoryName: "flux2-klein-base-4b", huggingFaceId: "black-forest-labs/FLUX.2-klein-base-4B"),
+      ModelFamily(family: "flux2", variant: "klein-base-9b", directoryName: "flux2-klein-base-9b", huggingFaceId: "black-forest-labs/FLUX.2-klein-base-9B"),
       ModelFamily(family: "qwen", variant: "default", directoryName: "qwen", huggingFaceId: nil),
     ]
   }


### PR DESCRIPTION
Adds klein-base-4b and klein-base-9b variants. Path-based detection, guidance passthrough to transformer, 50-step default. Tested at 512x512.