### PR TITLE
feat(pipeline): add Z-Image Base (non-distilled) model support with CFG guidance

### DIFF
--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -385,9 +385,18 @@ public final class WarmServer {
 
     switch family {
     case .flux1:
-      resolvedSteps = min(request.steps, 9)        // Z-Image Turbo: optimal at 9 steps
-      resolvedGuidance = 0.0                        // Z-Image Turbo: designed for cfg=0
-      resolvedNegativePrompt = nil                  // Negative prompts crash broadcast_shapes
+      let zimageVariant = await coordinator.currentZImageVariant
+      if zimageVariant == .base {
+        // Z-Image Base: non-distilled, supports CFG guidance and negative prompts
+        resolvedSteps = request.steps
+        resolvedGuidance = request.guidance > 0 ? request.guidance : ZImageModelMetadata.Base.recommendedGuidanceScale
+        resolvedNegativePrompt = request.negativePrompt
+      } else {
+        // Z-Image Turbo: distilled, optimal at 9 steps, no CFG, no negative prompts
+        resolvedSteps = min(request.steps, 9)
+        resolvedGuidance = 0.0
+        resolvedNegativePrompt = nil
+      }
     case .flux2:
       // Base (non-distilled) models support guidance > 1.0 and default to 50 steps;
       // distilled models default to 4 steps and guidance 1.0.
@@ -551,6 +560,8 @@ private actor WarmServerCoordinator {
   private var currentModelFamily: WarmModelFamily = .flux1
   /// Detected Flux 2 model info (variant, configs) — nil when running Flux 1.
   private var detectedFlux2Model: Flux2DetectedModel?
+  /// Detected Z-Image variant (Base vs Turbo) — only set when running Flux 1 (Z-Image).
+  private var zimageVariant: ZImageVariant = .turbo
   /// Lazy-initialized ControlNet pipeline — only created when first ControlNet request arrives.
   private var controlPipeline: ZImageControlPipeline?
   private let startTime = Date()
@@ -627,9 +638,25 @@ private actor WarmServerCoordinator {
       pipelinePrepared = true
       logger.info("Warm server pipeline ready (Flux 2 Klein \(detected.variant))")
     } else {
-      // --- Flux 1 / Z-Image-Turbo path (existing behavior) ---
+      // --- Flux 1 / Z-Image path ---
       currentModelFamily = .flux1
-      logger.info("Preloading warm server pipeline (Flux 1)")
+
+      // Detect Z-Image variant (Base vs Turbo)
+      if let spec = modelSpec, let variant = ZImageVariant.fromModelSpec(spec) {
+        zimageVariant = variant
+      } else if let resolvedSnapshot = snapshotURL {
+        zimageVariant = ZImageVariant.fromSnapshot(at: resolvedSnapshot)
+      } else if let spec = modelSpec {
+        // Resolve and detect from snapshot if not already resolved
+        if let resolved = try? await ModelResolution.resolveOrDefault(
+          modelSpec: spec,
+          filePatterns: ["*.safetensors", "*.json", "tokenizer/*"]
+        ) {
+          zimageVariant = ZImageVariant.fromSnapshot(at: resolved)
+        }
+      }
+      let variantLabel = zimageVariant == .base ? "Base (non-distilled)" : "Turbo (distilled)"
+      logger.info("Preloading warm server pipeline (Flux 1 / Z-Image \(variantLabel))")
       try await pipeline.prepare(
         modelSpec: modelSpec,
         textEncoderPath: configuration.textEncoderPath,
@@ -637,7 +664,7 @@ private actor WarmServerCoordinator {
         forceTransformerOverrideOnly: configuration.forceTransformerOverrideOnly
       )
       pipelinePrepared = true
-      logger.info("Warm server pipeline ready (Flux 1)")
+      logger.info("Warm server pipeline ready (Flux 1 / Z-Image \(zimageVariant.rawValue))")
     }
   }
 
@@ -649,6 +676,11 @@ private actor WarmServerCoordinator {
   /// Whether the loaded Flux 2 model is a base (non-distilled) variant.
   var isFlux2BaseModel: Bool {
     detectedFlux2Model?.isBaseModel ?? false
+  }
+
+  /// The detected Z-Image variant (Base vs Turbo) for Flux 1 models.
+  var currentZImageVariant: ZImageVariant {
+    zimageVariant
   }
 
   func enqueueGenerate(
@@ -716,7 +748,7 @@ private actor WarmServerCoordinator {
       status: shuttingDown ? "shutting_down" : "ok",
       model: configuration.modelSpec ?? ZImageRepository.id,
       modelFamily: currentModelFamily.rawValue,
-      modelVariant: detectedFlux2Model?.variant,
+      modelVariant: currentModelFamily == .flux1 ? zimageVariant.rawValue : detectedFlux2Model?.variant,
       textEncoderPath: configuration.textEncoderPath,
       loaded: pipelinePrepared,
       loras: activeLoRAs.map(LoRAState.init),

--- a/Sources/ZImage/Support/ModelMetadata.swift
+++ b/Sources/ZImage/Support/ModelMetadata.swift
@@ -17,6 +17,13 @@ public enum ZImageModelMetadata {
   public static let recommendedInferenceSteps = 9 // gives 8 DiT forwards
   public static let recommendedGuidanceScale: Float = 0.0 // Turbo is distilled for zero CFG
 
+  /// Z-Image Base (non-distilled) defaults — supports full CFG guidance.
+  public enum Base {
+    public static let repository = "Tongyi-MAI/Z-Image"
+    public static let recommendedInferenceSteps = 50
+    public static let recommendedGuidanceScale: Float = 4.0
+  }
+
   public enum VAE {
     public static let latentChannels = 16
     public static let scalingFactor: Float = 0.3611

--- a/Sources/ZImage/Weights/ModelPaths.swift
+++ b/Sources/ZImage/Weights/ModelPaths.swift
@@ -4,10 +4,79 @@ import Foundation
 /// so the rest of the pipeline can assemble download/caching steps.
 public enum ZImageRepository {
   public static let id = "Tongyi-MAI/Z-Image-Turbo"
+  public static let baseId = "Tongyi-MAI/Z-Image"
   public static let revision = "main"
 
   public static func defaultCacheDirectory(base: URL = URL(fileURLWithPath: "models")) -> URL {
     base.appendingPathComponent("z-image-turbo")
+  }
+
+  /// Known Z-Image HuggingFace model IDs (both Turbo and Base).
+  public static let knownModelIds: [String] = [
+    "Tongyi-MAI/Z-Image-Turbo",
+    "Tongyi-MAI/Z-Image",
+  ]
+
+  /// Check whether a model spec refers to the Z-Image Base (non-distilled) model.
+  public static func isBaseModel(_ modelSpec: String) -> Bool {
+    let normalized = modelSpec.lowercased()
+    // Match "Tongyi-MAI/Z-Image" but NOT "Tongyi-MAI/Z-Image-Turbo"
+    return normalized == "tongyi-mai/z-image"
+      || (normalized.hasSuffix("/z-image") && !normalized.contains("turbo"))
+  }
+}
+
+/// Z-Image model variant: Turbo (distilled, zero CFG) or Base (non-distilled, CFG-guided).
+public enum ZImageVariant: String, Sendable {
+  case turbo  // Distilled, guidance=0.0, 9 steps, no negative prompts
+  case base   // Non-distilled, guidance=4.0, 50 steps, supports negative prompts
+
+  /// Whether this variant supports classifier-free guidance (guidance > 1.0).
+  public var supportsGuidance: Bool {
+    switch self {
+    case .turbo: return false
+    case .base: return true
+    }
+  }
+
+  /// Default inference steps for this variant.
+  public var defaultSteps: Int {
+    switch self {
+    case .turbo: return ZImageModelMetadata.recommendedInferenceSteps
+    case .base: return ZImageModelMetadata.Base.recommendedInferenceSteps
+    }
+  }
+
+  /// Default guidance scale for this variant.
+  public var defaultGuidance: Float {
+    switch self {
+    case .turbo: return ZImageModelMetadata.recommendedGuidanceScale
+    case .base: return ZImageModelMetadata.Base.recommendedGuidanceScale
+    }
+  }
+
+  /// Detect variant from a model spec string (HuggingFace ID or path).
+  /// Returns nil if the spec doesn't clearly indicate a variant.
+  public static func fromModelSpec(_ modelSpec: String) -> ZImageVariant? {
+    if ZImageRepository.isBaseModel(modelSpec) {
+      return .base
+    }
+    let normalized = modelSpec.lowercased()
+    if normalized.contains("z-image-turbo") || normalized.contains("z_image_turbo") {
+      return .turbo
+    }
+    return nil
+  }
+
+  /// Detect variant from a snapshot directory.
+  /// Base model has no `scheduler/scheduler_config.json`.
+  /// Turbo model has `scheduler/scheduler_config.json`.
+  public static func fromSnapshot(at snapshot: URL) -> ZImageVariant {
+    let schedulerConfig = snapshot.appendingPathComponent(ZImageFiles.schedulerConfig)
+    if FileManager.default.fileExists(atPath: schedulerConfig.path) {
+      return .turbo
+    }
+    return .base
   }
 }
 

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -266,6 +266,31 @@ struct ZImageCLI {
       logger.info("Loaded generation config from: \(metadataPath)")
     }
 
+    // Resolve model aliases to HuggingFace IDs
+    if let m = model {
+      switch m.lowercased() {
+      case "z-image-base", "zimage-base":
+        model = ZImageRepository.baseId
+      case "z-image-turbo", "zimage-turbo", "z-image":
+        // "z-image" without qualifier defaults to Turbo for backwards compat
+        if m.lowercased() == "z-image" || m.lowercased() == "zimage-turbo" || m.lowercased() == "z-image-turbo" {
+          model = ZImageRepository.id
+        }
+      default:
+        break
+      }
+    }
+
+    // When Z-Image Base is selected, override defaults if user didn't specify them
+    if let m = model, ZImageRepository.isBaseModel(m) {
+      if steps == ZImageModelMetadata.recommendedInferenceSteps {
+        steps = ZImageModelMetadata.Base.recommendedInferenceSteps
+      }
+      if guidance == ZImageModelMetadata.recommendedGuidanceScale {
+        guidance = ZImageModelMetadata.Base.recommendedGuidanceScale
+      }
+    }
+
     guard let prompt else {
       printUsage()
       return
@@ -389,7 +414,7 @@ struct ZImageCLI {
                 pipeline: .txt2img,
                 model: ModelInfo(
                   family: "zimage",
-                  variant: "turbo",
+                  variant: (capturedModel.map { ZImageRepository.isBaseModel($0) ? "base" : "turbo" }) ?? "turbo",
                   path: capturedModel ?? ZImageRepository.id
                 ),
                 parameters: GenerationParameters(
@@ -835,6 +860,7 @@ struct ZImageCLI {
       --seed                 Random seed
       --output, -o           Output path (default z-image.png)
       --model, -m            Model path or HuggingFace ID (default: \(ZImageRepository.id))
+                             Aliases: z-image-base (Base, CFG-guided), z-image-turbo (Turbo, distilled)
       --model-family         Model family: flux1 or flux2 (default: auto-detect from model config)
       --text-encoder-path    Override text encoder directory (CLI > ZIMAGE_ENCODER_PATH > auto-detect > default)
       --force-transformer-override-only  Treat a local .safetensors as transformer-only override (disable AIO auto-detect)
@@ -1730,6 +1756,7 @@ struct ZImageCLI {
       ModelFamily(family: "flux2", variant: "klein-9b", directoryName: "flux2-klein-9b", huggingFaceId: "black-forest-labs/FLUX.2-klein-9B"),
       ModelFamily(family: "flux2", variant: "klein-base-4b", directoryName: "flux2-klein-base-4b", huggingFaceId: "black-forest-labs/FLUX.2-klein-base-4B"),
       ModelFamily(family: "flux2", variant: "klein-base-9b", directoryName: "flux2-klein-base-9b", huggingFaceId: "black-forest-labs/FLUX.2-klein-base-9B"),
+      ModelFamily(family: "z-image", variant: "base", directoryName: "z-image-base", huggingFaceId: "Tongyi-MAI/Z-Image"),
       ModelFamily(family: "qwen", variant: "default", directoryName: "qwen", huggingFaceId: nil),
     ]
   }


### PR DESCRIPTION
Adds z-image-base alias for Tongyi-MAI/Z-Image. Variant detection (scheduler_config presence), Base defaults (50 steps, guidance 4.0), WarmServer routing, CLI alias. +143 lines.