### PR TITLE
feat(fibo): Phase 3 — Wan 2.2 VAE with CausalConv3d and per-channel normalization

### DIFF
--- a/Sources/ZImage/Fibo/FiboWeightMapping.swift
+++ b/Sources/ZImage/Fibo/FiboWeightMapping.swift
@@ -161,11 +161,15 @@ public enum FiboWeightMapping {
 
   /// Map a HuggingFace VAE key to the model parameter path.
   ///
-  /// VAE keys pass through directly -- the model hierarchy matches the
-  /// safetensors naming. The `.gamma` norm naming is preserved.
+  /// Remappings:
+  /// - `.resample.1.` -> `.resample_conv.` (unwrap diffusers Sequential wrapper)
+  /// - All other keys pass through directly
+  /// - `.gamma` norm naming is preserved (model uses @ModuleInfo(key: "gamma"))
   static func mapVAEKey(_ hfKey: String) -> String {
-    // VAE keys map directly (no prefix stripping, no sequential unwrapping)
-    return hfKey
+    var key = hfKey
+    // Unwrap diffusers Sequential: resample.1.weight -> resample_conv.weight
+    key = key.replacingOccurrences(of: ".resample.1.", with: ".resample_conv.")
+    return key
   }
 
   // MARK: - Weight Verification

--- a/Sources/ZImage/Fibo/VAE/FiboCausalConv3d.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboCausalConv3d.swift
@@ -1,0 +1,118 @@
+// CausalConv3d.swift — 3D causal convolution for the Wan 2.2 VAE
+// Ported from mflux: wan_2_2_causal_conv_3d.py
+//
+// Wan 2.2's CausalConv3d is simpler than SeedVR2's: it always uses causal
+// temporal padding (pad past, not future) and does not support frame replication.
+// Instead it uses explicit mx.pad with (2*pad_t, 0) on the temporal axis.
+//
+// For image generation (T=1), the causal padding adds 2 zero-frames before the
+// single frame, which the 3D convolution consumes to produce a single output frame.
+//
+// Weight layout: MLX Conv3d expects (C_out, K_t, K_h, K_w, C_in) after the
+// transposition done by FiboWeightMapping during loading.
+
+import MLX
+import MLXNN
+
+/// A 3D convolution with causal temporal padding for the Wan 2.2 VAE.
+///
+/// Temporal causality is enforced by padding `(2 * padding, 0)` on the temporal
+/// axis — all padding goes before the first frame, none after the last. Spatial
+/// padding is symmetric `(pad_h, pad_h)` and `(pad_w, pad_w)`.
+///
+/// ## Differences from SeedVR2's CausalConv3d
+///
+/// - No frame replication — uses zero-padding via `mx.pad`
+/// - Scalar kernel/stride/padding (not tuple) — Wan 2.2 VAE uses uniform 3x3x3
+///   or 1x1x1 kernels exclusively
+/// - Causal pad formula: `2 * pad_t` prepended on temporal axis
+///
+/// ## Input/Output Layout
+///
+/// External interface: `(B, C, T, H, W)` (channels-first, matching mflux convention).
+/// The convolution internally transposes to `(B, T, H, W, C)` for MLX's channels-last
+/// `convGeneral`, then transposes back.
+public final class FiboCausalConv3d: Module {
+
+  /// Convolution kernel weights: shape `(C_out, K_t, K_h, K_w, C_in)`.
+  public var weight: MLXArray
+
+  /// Bias vector: shape `(C_out,)`.
+  public var bias: MLXArray
+
+  /// Spatial and temporal padding value. Applied as `(2*padding, 0)` temporally
+  /// and `(padding, padding)` spatially.
+  public let padding: Int
+
+  /// Convolution stride (uniform across all 3 dimensions).
+  public let stride: Int
+
+  /// Convolution kernel size (uniform across all 3 dimensions).
+  public let kernelSize: Int
+
+  /// Creates a Wan 2.2 causal 3D convolution layer.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels.
+  ///   - outChannels: Number of output channels.
+  ///   - kernelSize: Uniform kernel size for all 3 dimensions. Default `3`.
+  ///   - stride: Uniform stride for all 3 dimensions. Default `1`.
+  ///   - padding: Padding value. Applied causally on temporal axis. Default `1`.
+  public init(
+    inChannels: Int,
+    outChannels: Int,
+    kernelSize: Int = 3,
+    stride: Int = 1,
+    padding: Int = 1
+  ) {
+    self.kernelSize = kernelSize
+    self.stride = stride
+    self.padding = padding
+
+    // Initialize with zeros — will be overwritten by weight loading
+    self.weight = MLXArray.zeros([outChannels, kernelSize, kernelSize, kernelSize, inChannels])
+    self.bias = MLXArray.zeros([outChannels])
+
+    super.init()
+  }
+
+  /// Applies the causal 3D convolution.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C_out, T_out, H_out, W_out)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var input = x
+
+    // Apply causal padding: (2*pad, 0) on temporal, (pad, pad) on spatial
+    if padding > 0 {
+      input = MLX.padded(
+        input,
+        widths: [
+          IntOrPair((0, 0)),      // batch
+          IntOrPair((0, 0)),      // channels
+          IntOrPair((2 * padding, 0)),  // temporal: causal (pad before, none after)
+          IntOrPair((padding, padding)),  // height: symmetric
+          IntOrPair((padding, padding)),  // width: symmetric
+        ]
+      )
+    }
+
+    // Transpose BCTHW -> BTHWC for convGeneral
+    input = input.transposed(0, 2, 3, 4, 1)
+
+    // 3D convolution with no additional padding (already applied above)
+    var out = convGeneral(
+      input, weight,
+      strides: IntOrArray([stride, stride, stride]),
+      padding: IntOrArray([0, 0, 0])
+    )
+
+    // Add bias
+    out = out + bias
+
+    // Transpose BTHWC -> BCTHW
+    out = out.transposed(0, 4, 1, 2, 3)
+
+    return out
+  }
+}

--- a/Sources/ZImage/Fibo/VAE/FiboVAE.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboVAE.swift
@@ -1,0 +1,224 @@
+// FiboVAE.swift — Top-level Wan 2.2 VAE for the FIBO model
+// Ported from mflux: wan_2_2_vae.py
+//
+// The Wan 2.2 VAE is a 3D video autoencoder repurposed for image generation.
+// It differs from Flux's AutoencoderKL in several fundamental ways:
+//
+// - 48 latent channels (vs 16 for Flux 1, 64 for Flux 2)
+// - 3D convolutions with causal temporal padding (vs 2D)
+// - RMSNorm with L2-based normalization (vs GroupNorm)
+// - Spatial patchification (patch_size=2, folding 2x2 patches into channels)
+// - Per-channel latent normalization (48 mean + 48 std values)
+// - quant_conv and post_quant_conv layers in the latent space
+//
+// For image generation (not video), the temporal dimension is always 1.
+// The VAE adds this dimension automatically for 4D inputs and preserves it
+// throughout the pipeline. The CausalConv3d layers handle T=1 correctly
+// via their causal padding scheme.
+//
+// Encode pipeline: image → patchify → encoder → quant_conv → normalize
+// Decode pipeline: denormalize → post_quant_conv → decoder → unpatchify
+
+import MLX
+import MLXNN
+
+/// Top-level Wan 2.2 VAE (AutoencoderKLWan) for the FIBO model.
+///
+/// Provides encode and decode operations for mapping between RGB image tensors
+/// and the 48-channel latent space used by the FIBO diffusion transformer.
+///
+/// ## Encode
+///
+/// ```
+/// Input (B, 3, H, W) or (B, 3, T, H, W)
+///   → add temporal dim if 4D: (B, 3, 1, H, W)
+///   → patchify: (B, 12, 1, H/2, W/2)
+///   → encoder: (B, 96, 1, H/16, W/16)
+///   → quant_conv: (B, 96, 1, H/16, W/16)
+///   → take first 48 channels (mean): (B, 48, 1, H/16, W/16)
+///   → normalize per-channel: (B, 48, 1, H/16, W/16)
+/// ```
+///
+/// ## Decode
+///
+/// ```
+/// Input (B, 48, H/16, W/16) or (B, 48, 1, H/16, W/16)
+///   → add temporal dim if 4D: (B, 48, 1, H/16, W/16)
+///   → denormalize per-channel
+///   → post_quant_conv: (B, 48, 1, H/16, W/16)
+///   → decoder: (B, 12, 1, H/2, W/2)
+///   → unpatchify: (B, 3, 1, H, W)
+/// ```
+///
+/// ## Spatial Scale
+///
+/// The VAE provides a 16x spatial reduction (vs 8x for Flux/SeedVR2).
+/// An H x W input produces H/16 x W/16 latents.
+public final class FiboVAE: Module {
+
+  /// Number of latent channels.
+  public static let zDim = 48
+
+  /// Spatial downsampling factor.
+  public static let spatialScale = 16
+
+  /// Spatial patch size for patchify/unpatchify.
+  public static let patchSize = 2
+
+  /// Per-channel normalization means for the 48 latent channels.
+  public static let latentsMean: [Float] = [
+    -0.2289, -0.0052, -0.1323, -0.2339, -0.2799,  0.0174,  0.1838,  0.1557,
+    -0.1382,  0.0542,  0.2813,  0.0891,  0.1570, -0.0098,  0.0375, -0.1825,
+    -0.2246, -0.1207, -0.0698,  0.5109,  0.2665, -0.2108, -0.2158,  0.2502,
+    -0.2055, -0.0322,  0.1109,  0.1567, -0.0729,  0.0899, -0.2799, -0.1230,
+    -0.0313, -0.1649,  0.0117,  0.0723, -0.2839, -0.2083, -0.0520,  0.3748,
+     0.0152,  0.1957,  0.1433, -0.2944,  0.3573, -0.0548, -0.1681, -0.0667,
+  ]
+
+  /// Per-channel normalization standard deviations for the 48 latent channels.
+  public static let latentsStd: [Float] = [
+    0.4765, 1.0364, 0.4514, 1.1677, 0.5313, 0.4990, 0.4818, 0.5013,
+    0.8158, 1.0344, 0.5894, 1.0901, 0.6885, 0.6165, 0.8454, 0.4978,
+    0.5759, 0.3523, 0.7135, 0.6804, 0.5833, 1.4146, 0.8986, 0.5659,
+    0.7069, 0.5338, 0.4889, 0.4917, 0.4069, 0.4999, 0.6866, 0.4093,
+    0.5709, 0.6065, 0.6415, 0.4944, 0.5726, 1.2042, 0.5458, 1.6887,
+    0.3971, 1.0600, 0.3943, 0.5537, 0.5444, 0.4089, 0.7468, 0.7744,
+  ]
+
+  /// The 3D encoder.
+  @ModuleInfo(key: "encoder") var encoder: FiboVAEEncoder
+
+  /// The 3D decoder.
+  @ModuleInfo(key: "decoder") var decoder: FiboVAEDecoder
+
+  /// Quantization convolution (encoder output → latent space).
+  @ModuleInfo(key: "quant_conv") var quantConv: FiboCausalConv3d
+
+  /// Post-quantization convolution (latent space → decoder input).
+  @ModuleInfo(key: "post_quant_conv") var postQuantConv: FiboCausalConv3d
+
+  /// Creates the Wan 2.2 VAE with default FIBO configuration.
+  public override init() {
+    self._encoder.wrappedValue = FiboVAEEncoder(
+      inChannels: 12,
+      dim: 160,
+      zDim: Self.zDim * 2,  // 96 (mean + logvar)
+      dimMult: [1, 2, 4, 4],
+      numResBlocks: 2,
+      temporalDownsample: [false, true, true]
+    )
+
+    self._quantConv.wrappedValue = FiboCausalConv3d(
+      inChannels: Self.zDim * 2,
+      outChannels: Self.zDim * 2,
+      kernelSize: 1,
+      padding: 0
+    )
+
+    self._decoder.wrappedValue = FiboVAEDecoder(
+      dim: 256,
+      zDim: Self.zDim,
+      dimMult: [1, 2, 4, 4],
+      numResBlocks: 2,
+      temporalUpsample: [],  // No temporal upsampling for image gen
+      outChannels: 12
+    )
+
+    self._postQuantConv.wrappedValue = FiboCausalConv3d(
+      inChannels: Self.zDim,
+      outChannels: Self.zDim,
+      kernelSize: 1,
+      padding: 0
+    )
+
+    super.init()
+  }
+
+  // MARK: - Encode
+
+  /// Encodes an image into the normalized latent space.
+  ///
+  /// - Parameter images: Image tensor of shape `(B, 3, H, W)` or `(B, 3, T, H, W)`.
+  /// - Returns: Normalized latent tensor of shape `(B, 48, T_lat, H/16, W/16)`.
+  public func encode(_ images: MLXArray) -> MLXArray {
+    // Ensure 5D: (B, C, T, H, W)
+    var x: MLXArray
+    if images.ndim == 4 {
+      x = images.reshaped(images.dim(0), images.dim(1), 1, images.dim(2), images.dim(3))
+    } else if images.ndim == 5 {
+      x = images
+    } else {
+      fatalError("FiboVAE.encode: expected 4D or 5D input, got \(images.ndim)D")
+    }
+
+    // Patchify: (B, 3, T, H, W) → (B, 12, T, H/2, W/2)
+    x = FiboVAEPatchify.patchify(x, patchSize: Self.patchSize)
+
+    // Encode
+    let h = encoder(x)
+
+    // Quant conv
+    let quantized = quantConv(h)
+
+    // Take mean (first z_dim channels), discard logvar
+    let mean = quantized[0..., ..<Self.zDim, 0..., 0..., 0...]
+
+    // Normalize per-channel
+    return normalizeLatents(mean)
+  }
+
+  // MARK: - Decode
+
+  /// Decodes a latent tensor back to an image.
+  ///
+  /// - Parameter latents: Latent tensor of shape `(B, 48, H/16, W/16)` or
+  ///   `(B, 48, T_lat, H/16, W/16)`.
+  /// - Returns: Decoded image tensor of shape `(B, 3, T, H, W)`.
+  public func decode(_ latents: MLXArray) -> MLXArray {
+    // Ensure 5D
+    var z: MLXArray
+    if latents.ndim == 4 {
+      z = latents.reshaped(latents.dim(0), latents.dim(1), 1, latents.dim(2), latents.dim(3))
+    } else {
+      z = latents
+    }
+
+    // Denormalize per-channel
+    z = denormalizeLatents(z)
+
+    // Post-quant conv
+    z = postQuantConv(z)
+
+    // Decode
+    let decoded = decoder(z)
+
+    // Unpatchify: (B, 12, T, H/2, W/2) → (B, 3, T, H, W)
+    return FiboVAEPatchify.unpatchify(decoded, patchSize: Self.patchSize)
+  }
+
+  // MARK: - Latent Normalization
+
+  /// Normalizes latents using per-channel mean and std.
+  ///
+  /// Applied after encoding: `(latents - mean) / std`
+  ///
+  /// - Parameter latents: Raw latent tensor of shape `(B, 48, ...)`.
+  /// - Returns: Normalized latent tensor.
+  public func normalizeLatents(_ latents: MLXArray) -> MLXArray {
+    let mean = MLXArray(Self.latentsMean).reshaped(1, Self.zDim, 1, 1, 1)
+    let std = MLXArray(Self.latentsStd).reshaped(1, Self.zDim, 1, 1, 1)
+    return (latents - mean) / std
+  }
+
+  /// Denormalizes latents using per-channel mean and std.
+  ///
+  /// Applied before decoding: `latents * std + mean`
+  ///
+  /// - Parameter latents: Normalized latent tensor of shape `(B, 48, ...)`.
+  /// - Returns: Denormalized latent tensor.
+  public func denormalizeLatents(_ latents: MLXArray) -> MLXArray {
+    let mean = MLXArray(Self.latentsMean).reshaped(1, Self.zDim, 1, 1, 1)
+    let std = MLXArray(Self.latentsStd).reshaped(1, Self.zDim, 1, 1, 1)
+    return latents * std + mean
+  }
+}

--- a/Sources/ZImage/Fibo/VAE/FiboVAEBlocks.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboVAEBlocks.swift
@@ -1,0 +1,568 @@
+// FiboVAEBlocks.swift — Shared building blocks for the Wan 2.2 VAE
+// Ported from mflux:
+//   - wan_2_2_rms_norm.py
+//   - wan_2_2_residual_block.py
+//   - wan_2_2_attention_block.py
+//   - wan_2_2_mid_block.py
+//   - wan_2_2_resample.py
+//   - wan_2_2_avg_down_3d.py
+//   - wan_2_2_dup_up_3d.py
+//
+// These differ from both the Flux VAE blocks (which use GroupNorm + Conv2d)
+// and SeedVR2 blocks (which use GroupNorm + CausalConv3d with frame replication):
+// - RMSNorm with L2-norm-based normalization (not variance-based)
+// - Weight parameter named .gamma in safetensors (loaded via FiboWeightMapping)
+// - All convolutions are FiboCausalConv3d (3D with causal temporal padding)
+// - Attention collapses temporal dim, operates on 2D spatial with Conv2d
+
+import MLX
+import MLXFast
+import MLXNN
+
+// MARK: - RMS Norm (Wan 2.2 Style)
+
+/// RMS normalization for the Wan 2.2 VAE.
+///
+/// Unlike standard RMSNorm (which uses variance along the last dim), this
+/// uses L2 norm along the channel axis (axis=1) and scales by sqrt(dim).
+/// The weight parameter is stored as `.gamma` in safetensors.
+///
+/// Two modes:
+/// - `images=true`: weight shape `(dim, 1, 1)` — for 2D spatial attention
+/// - `images=false`: weight shape `(dim, 1, 1, 1)` — for 3D volume data
+///
+/// Both modes normalize along axis 1 (channels) and broadcast the weight.
+public final class FiboVAERMSNorm: Module {
+
+  /// Learned scale parameter. Named `.gamma` in safetensors,
+  /// loaded as `.weight` by the weight mapping.
+  @ModuleInfo(key: "gamma") var gamma: MLXArray
+
+  let eps: Float
+  let scale: Float
+  let images: Bool
+
+  /// Creates a Wan 2.2 RMSNorm layer.
+  ///
+  /// - Parameters:
+  ///   - dim: Number of channels to normalize over.
+  ///   - eps: Numerical stability constant. Default `1e-12`.
+  ///   - images: If true, weight is `(dim, 1, 1)` for 2D data.
+  ///     If false, weight is `(dim, 1, 1, 1)` for 3D data. Default `false`.
+  public init(dim: Int, eps: Float = 1e-12, images: Bool = false) {
+    self.eps = eps
+    self.scale = Float(dim).squareRoot()
+    self.images = images
+
+    if images {
+      self._gamma.wrappedValue = MLX.ones([dim, 1, 1])
+    } else {
+      self._gamma.wrappedValue = MLX.ones([dim, 1, 1, 1])
+    }
+
+    super.init()
+  }
+
+  /// Applies L2-based RMS normalization.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, ...)`.
+  /// - Returns: Normalized tensor of the same shape.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    // L2 norm along channel axis
+    let sumSq = MLX.sum(x * x, axis: 1, keepDims: true)
+    let l2Norm = MLX.sqrt(sumSq)
+    let denom = MLX.maximum(l2Norm, MLXArray(eps, dtype: l2Norm.dtype))
+    let normalized = x / denom
+
+    // Reshape weight for broadcasting
+    let w: MLXArray
+    if x.ndim == 5 && !images {
+      w = gamma.reshaped(1, -1, 1, 1, 1)
+    } else if x.ndim == 4 && images {
+      w = gamma.reshaped(1, -1, 1, 1)
+    } else if x.ndim == 5 {
+      w = gamma.reshaped(1, -1, 1, 1, 1)
+    } else if x.ndim == 4 {
+      w = gamma.reshaped(1, -1, 1, 1)
+    } else {
+      w = gamma
+    }
+
+    return normalized * scale * w
+  }
+}
+
+// MARK: - Residual Block
+
+/// Residual block for the Wan 2.2 VAE.
+///
+/// Uses RMSNorm (not GroupNorm) and CausalConv3d (not Conv2d). The residual
+/// connection uses a 1x1x1 convolution when input and output dims differ.
+///
+/// ```
+/// x ──→ norm1 → SiLU → conv1 → norm2 → SiLU → conv2 → (+) → out
+///  └──────────────── conv_shortcut (if dims differ) ──────┘
+/// ```
+public final class FiboVAEResidualBlock: Module {
+
+  @ModuleInfo(key: "norm1") var norm1: FiboVAERMSNorm
+  @ModuleInfo(key: "conv1") var conv1: FiboCausalConv3d
+  @ModuleInfo(key: "norm2") var norm2: FiboVAERMSNorm
+  @ModuleInfo(key: "conv2") var conv2: FiboCausalConv3d
+  @ModuleInfo(key: "conv_shortcut") var convShortcut: FiboCausalConv3d?
+
+  /// Creates a residual block.
+  ///
+  /// - Parameters:
+  ///   - inDim: Input channel dimension.
+  ///   - outDim: Output channel dimension.
+  public init(inDim: Int, outDim: Int) {
+    self._norm1.wrappedValue = FiboVAERMSNorm(dim: inDim, images: false)
+    self._conv1.wrappedValue = FiboCausalConv3d(inChannels: inDim, outChannels: outDim, kernelSize: 3, padding: 1)
+    self._norm2.wrappedValue = FiboVAERMSNorm(dim: outDim, images: false)
+    self._conv2.wrappedValue = FiboCausalConv3d(inChannels: outDim, outChannels: outDim, kernelSize: 3, padding: 1)
+
+    if inDim != outDim {
+      self._convShortcut.wrappedValue = FiboCausalConv3d(
+        inChannels: inDim, outChannels: outDim, kernelSize: 1, padding: 0
+      )
+    } else {
+      self._convShortcut.wrappedValue = nil
+    }
+
+    super.init()
+  }
+
+  /// Applies the residual block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C_out, T, H, W)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let h = (convShortcut != nil) ? convShortcut!(x) : x
+    var out = norm1(x)
+    out = silu(out)
+    out = conv1(out)
+    out = norm2(out)
+    out = silu(out)
+    out = conv2(out)
+    return out + h
+  }
+}
+
+// MARK: - Attention Block
+
+/// Spatial self-attention block for the Wan 2.2 VAE.
+///
+/// Operates on 2D spatial dimensions by collapsing the temporal axis into batch.
+/// Uses Conv2d for Q/K/V projections and output projection. RMSNorm is applied
+/// in `images=true` mode (2D spatial data).
+///
+/// ```
+/// x (B, C, T, H, W) → collapse T into B → (B*T, C, H, W)
+///   → RMSNorm → Conv2d(C → 3C) → split Q/K/V
+///   → scaled_dot_product_attention
+///   → Conv2d(C → C) → restore T → (B, C, T, H, W) → + identity
+/// ```
+public final class FiboVAEAttentionBlock: Module {
+
+  let dim: Int
+
+  @ModuleInfo(key: "norm") var norm: FiboVAERMSNorm
+  @ModuleInfo(key: "to_qkv") var toQKV: Conv2d
+  @ModuleInfo(key: "proj") var proj: Conv2d
+
+  /// Creates an attention block.
+  ///
+  /// - Parameter dim: Channel dimension for Q/K/V projections.
+  public init(dim: Int) {
+    self.dim = dim
+    self._norm.wrappedValue = FiboVAERMSNorm(dim: dim, images: true)
+    self._toQKV.wrappedValue = Conv2d(
+      inputChannels: dim, outputChannels: dim * 3,
+      kernelSize: 1
+    )
+    self._proj.wrappedValue = Conv2d(
+      inputChannels: dim, outputChannels: dim,
+      kernelSize: 1
+    )
+
+    super.init()
+  }
+
+  /// Applies spatial self-attention.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C, T, H, W)` with attention residual.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let identity = x
+    let (batchSize, channels, time, height, width) = (
+      x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4)
+    )
+
+    // Collapse temporal into batch: (B, C, T, H, W) -> (B*T, C, H, W)
+    var h = x.transposed(0, 2, 1, 3, 4)
+    h = h.reshaped(batchSize * time, channels, height, width)
+
+    // RMSNorm on spatial data
+    h = norm(h)
+
+    // Transpose to NHWC for Conv2d
+    h = h.transposed(0, 2, 3, 1)
+
+    // QKV projection
+    var qkv = toQKV(h)
+
+    // Transpose back to NCHW
+    qkv = qkv.transposed(0, 3, 1, 2)
+
+    // Reshape for attention: (B*T, 1, C*3, H*W) -> (B*T, 1, H*W, C*3)
+    qkv = qkv.reshaped(batchSize * time, 1, channels * 3, height * width)
+    qkv = qkv.transposed(0, 1, 3, 2)
+
+    // Split into Q, K, V
+    let parts = split(qkv, parts: 3, axis: 3)
+    let q = parts[0]
+    let k = parts[1]
+    let v = parts[2]
+
+    // Scaled dot-product attention
+    let scale = 1.0 / Float(channels).squareRoot()
+    var attnOut = MLXFast.scaledDotProductAttention(
+      queries: q, keys: k, values: v,
+      scale: scale, mask: nil
+    )
+
+    // Reshape back: (B*T, 1, H*W, C) -> (B*T, C, H, W)
+    attnOut = attnOut.reshaped(batchSize * time, height * width, channels)
+    attnOut = attnOut.transposed(0, 2, 1)
+    attnOut = attnOut.reshaped(batchSize * time, channels, height, width)
+
+    // Output projection: NCHW -> NHWC -> Conv2d -> NCHW
+    attnOut = attnOut.transposed(0, 2, 3, 1)
+    attnOut = proj(attnOut)
+    attnOut = attnOut.transposed(0, 3, 1, 2)
+
+    // Restore temporal: (B*T, C, H, W) -> (B, T, C, H, W) -> (B, C, T, H, W)
+    attnOut = attnOut.reshaped(batchSize, time, channels, height, width)
+    attnOut = attnOut.transposed(0, 2, 1, 3, 4)
+
+    return attnOut + identity
+  }
+}
+
+// MARK: - Mid Block
+
+/// Mid-block (bottleneck) for the Wan 2.2 VAE encoder and decoder.
+///
+/// Consists of an initial residual block, then alternating attention and
+/// residual blocks. For the Wan 2.2 VAE, `numLayers=1` gives:
+///   resnet[0] → attention[0] → resnet[1]
+public final class FiboVAEMidBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [FiboVAEResidualBlock]
+  @ModuleInfo(key: "attentions") var attentions: [FiboVAEAttentionBlock]
+
+  /// Creates a mid-block.
+  ///
+  /// - Parameters:
+  ///   - dim: Channel dimension for all blocks.
+  ///   - numLayers: Number of attention + residual pairs after the initial
+  ///     residual block. Default `1`.
+  public init(dim: Int, numLayers: Int = 1) {
+    var resnetList: [FiboVAEResidualBlock] = [FiboVAEResidualBlock(inDim: dim, outDim: dim)]
+    var attnList: [FiboVAEAttentionBlock] = []
+
+    for _ in 0..<numLayers {
+      attnList.append(FiboVAEAttentionBlock(dim: dim))
+      resnetList.append(FiboVAEResidualBlock(inDim: dim, outDim: dim))
+    }
+
+    self._resnets.wrappedValue = resnetList
+    self._attentions.wrappedValue = attnList
+
+    super.init()
+  }
+
+  /// Applies the mid-block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor of shape `(B, C, T, H, W)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var h = resnets[0](x)
+    for (attn, resnet) in zip(attentions, resnets.dropFirst()) {
+      h = attn(h)
+      h = resnet(h)
+    }
+    return h
+  }
+}
+
+// MARK: - Resample (Up/Down)
+
+/// Spatial resampling module for the Wan 2.2 VAE.
+///
+/// Supports four modes:
+/// - `downsample2d`: 2x spatial downsampling via strided Conv2d
+/// - `downsample3d`: Same as downsample2d (temporal handled by AvgDown3D)
+/// - `upsample2d`: 2x spatial upsampling via nearest-neighbor + Conv2d
+/// - `upsample3d`: Not used for FIBO image generation (temporal_upsample is empty)
+///
+/// The module collapses the temporal dimension into batch, operates in 2D,
+/// then restores the temporal dimension.
+public final class FiboVAEResample: Module {
+
+  /// Resampling mode.
+  public enum Mode: String {
+    case upsample2d
+    case upsample3d
+    case downsample2d
+    case downsample3d
+  }
+
+  let mode: Mode
+
+  @ModuleInfo(key: "resample_conv") var resampleConv: Conv2d
+
+  /// Creates a resampling module.
+  ///
+  /// - Parameters:
+  ///   - dim: Input channel dimension.
+  ///   - mode: Resampling mode.
+  ///   - upsampleOutDim: Output channels for upsample modes. Default `nil`
+  ///     (uses `dim / 2` for upsample, `dim` for downsample).
+  public init(dim: Int, mode: Mode, upsampleOutDim: Int? = nil) {
+    self.mode = mode
+    let outDim = upsampleOutDim ?? (mode == .upsample2d || mode == .upsample3d ? dim / 2 : dim)
+
+    switch mode {
+    case .upsample2d, .upsample3d:
+      self._resampleConv.wrappedValue = Conv2d(
+        inputChannels: dim, outputChannels: outDim,
+        kernelSize: 3, stride: 1, padding: 1
+      )
+    case .downsample2d, .downsample3d:
+      self._resampleConv.wrappedValue = Conv2d(
+        inputChannels: dim, outputChannels: dim,
+        kernelSize: 3, stride: 2, padding: 0
+      )
+    }
+
+    super.init()
+  }
+
+  /// Applies the resampling operation.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Output tensor with modified spatial dimensions.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let (b, c, t, h, w) = (x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4))
+
+    switch mode {
+    case .upsample2d, .upsample3d:
+      return upsample(x, b: b, c: c, t: t, h: h, w: w)
+    case .downsample2d, .downsample3d:
+      return downsample(x, b: b, c: c, t: t, h: h, w: w)
+    }
+  }
+
+  private func upsample(_ x: MLXArray, b: Int, c: Int, t: Int, h: Int, w: Int) -> MLXArray {
+    // Collapse temporal: (B, C, T, H, W) -> (B*T, C, H, W) -> (B*T, H, W, C)
+    var out = x.transposed(0, 2, 1, 3, 4)
+    out = out.reshaped(b * t, c, h, w)
+    out = out.transposed(0, 2, 3, 1)
+
+    // Nearest-neighbor 2x upsample: repeat each pixel 2x in H and W
+    out = MLX.repeated(out, count: 2, axis: 1)
+    out = MLX.repeated(out, count: 2, axis: 2)
+
+    // Conv2d (already in NHWC)
+    out = resampleConv(out)
+
+    // Restore: NHWC -> NCHW -> (B, T, C', H', W') -> (B, C', T, H', W')
+    out = out.transposed(0, 3, 1, 2)
+    let newC = out.dim(1)
+    let newH = out.dim(2)
+    let newW = out.dim(3)
+    out = out.reshaped(b, t, newC, newH, newW)
+    out = out.transposed(0, 2, 1, 3, 4)
+    return out
+  }
+
+  private func downsample(_ x: MLXArray, b: Int, c: Int, t: Int, h: Int, w: Int) -> MLXArray {
+    // Collapse temporal: (B, C, T, H, W) -> (B*T, C, H, W) -> (B*T, H, W, C)
+    var out = x.transposed(0, 2, 1, 3, 4)
+    out = out.reshaped(b * t, c, h, w)
+    out = out.transposed(0, 2, 3, 1)
+
+    // Pad (0, 1) on H and W for strided conv (matching mflux)
+    out = MLX.padded(out, widths: [IntOrPair((0, 0)), IntOrPair((0, 1)), IntOrPair((0, 1)), IntOrPair((0, 0))])
+
+    // Strided Conv2d (already in NHWC)
+    out = resampleConv(out)
+
+    // Restore: NHWC -> NCHW -> (B, T, C', H', W') -> (B, C', T, H', W')
+    out = out.transposed(0, 3, 1, 2)
+    let newC = out.dim(1)
+    let newH = out.dim(2)
+    let newW = out.dim(3)
+    out = out.reshaped(b, t, newC, newH, newW)
+    out = out.transposed(0, 2, 1, 3, 4)
+    return out
+  }
+}
+
+// MARK: - AvgDown3D (Encoder Shortcut)
+
+/// Average-pool downsampling for the Wan 2.2 VAE encoder shortcut path.
+///
+/// Reshapes the input to expose spatial (and optionally temporal) sub-pixels,
+/// then averages groups of channels to produce the target output dimension.
+/// This is the residual shortcut in each encoder down block.
+///
+/// For image generation (T=1, factor_t=1 in most blocks):
+///   - Spatial-only: reshapes (B, C, 1, H, W) to expose 2x2 patches,
+///     channel-interleaves them, and averages groups to produce out_channels.
+public final class FiboVAEAvgDown3D: Module {
+
+  let inChannels: Int
+  let outChannels: Int
+  let factorT: Int
+  let factorS: Int
+  let factor: Int
+  let groupSize: Int
+
+  /// Creates an AvgDown3D layer.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Input channel count.
+  ///   - outChannels: Output channel count.
+  ///   - factorT: Temporal downsampling factor. Default `1`.
+  ///   - factorS: Spatial downsampling factor. Default `1`.
+  public init(inChannels: Int, outChannels: Int, factorT: Int, factorS: Int = 1) {
+    self.inChannels = inChannels
+    self.outChannels = outChannels
+    self.factorT = factorT
+    self.factorS = factorS
+    self.factor = factorT * factorS * factorS
+    self.groupSize = inChannels * factor / outChannels
+
+    super.init()
+  }
+
+  /// Applies average-pool downsampling.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Downsampled tensor.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var input = x
+
+    // Pad temporal axis if needed
+    let padT = (factorT - input.dim(2) % factorT) % factorT
+    if padT > 0 {
+      input = MLX.padded(input, widths: [
+        IntOrPair((0, 0)),    // batch
+        IntOrPair((0, 0)),    // channels
+        IntOrPair((padT, 0)), // time (pad before)
+        IntOrPair((0, 0)),    // height
+        IntOrPair((0, 0)),    // width
+      ])
+    }
+
+    let (b, c, t, h, w) = (input.dim(0), input.dim(1), input.dim(2), input.dim(3), input.dim(4))
+
+    // Reshape to expose sub-pixels
+    input = input.reshaped(
+      b, c,
+      t / factorT, factorT,
+      h / factorS, factorS,
+      w / factorS, factorS
+    )
+
+    // Reorder to interleave spatial/temporal factors into channels
+    input = input.transposed(0, 1, 3, 5, 7, 2, 4, 6)
+    input = input.reshaped(
+      b, c * factor,
+      t / factorT,
+      h / factorS,
+      w / factorS
+    )
+
+    // Group and average
+    input = input.reshaped(
+      b, outChannels, groupSize,
+      t / factorT,
+      h / factorS,
+      w / factorS
+    )
+    input = MLX.mean(input, axis: 2)
+
+    return input
+  }
+}
+
+// MARK: - DupUp3D (Decoder Shortcut)
+
+/// Duplication-based upsampling for the Wan 2.2 VAE decoder shortcut path.
+///
+/// The inverse of AvgDown3D: repeats channels to fill the spatial (and optionally
+/// temporal) expansion, then reshapes to the upsampled dimensions. This is the
+/// residual shortcut in each decoder up block.
+public final class FiboVAEDupUp3D: Module {
+
+  let inChannels: Int
+  let outChannels: Int
+  let factorT: Int
+  let factorS: Int
+  let factor: Int
+  let repeats: Int
+
+  /// Creates a DupUp3D layer.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Input channel count.
+  ///   - outChannels: Output channel count.
+  ///   - factorT: Temporal upsampling factor. Default `1`.
+  ///   - factorS: Spatial upsampling factor. Default `1`.
+  public init(inChannels: Int, outChannels: Int, factorT: Int, factorS: Int = 1) {
+    self.inChannels = inChannels
+    self.outChannels = outChannels
+    self.factorT = factorT
+    self.factorS = factorS
+    self.factor = factorT * factorS * factorS
+    self.repeats = outChannels * factor / inChannels
+
+    super.init()
+  }
+
+  /// Applies duplication-based upsampling.
+  ///
+  /// - Parameters:
+  ///   - x: Input tensor of shape `(B, C, T, H, W)`.
+  ///   - firstChunk: If true and factorT > 1, trims the leading temporal
+  ///     frames that result from causal padding. Default `false`.
+  /// - Returns: Upsampled tensor.
+  public func callAsFunction(_ x: MLXArray, firstChunk: Bool = false) -> MLXArray {
+    let (b, _, t, h, w) = (x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4))
+
+    // Repeat channels
+    var out = MLX.repeated(x, count: repeats, axis: 1)
+
+    // Reshape to separate upsampling factors
+    out = out.reshaped(
+      b, outChannels, factorT, factorS, factorS, t, h, w
+    )
+
+    // Interleave factors back into spatial/temporal dimensions
+    out = out.transposed(0, 1, 5, 2, 6, 3, 7, 4)
+    out = out.reshaped(
+      b, outChannels, t * factorT, h * factorS, w * factorS
+    )
+
+    // Trim leading temporal frame for causal alignment
+    if firstChunk && factorT > 1 {
+      out = out[0..., 0..., (factorT - 1)..., 0..., 0...]
+    }
+
+    return out
+  }
+}

--- a/Sources/ZImage/Fibo/VAE/FiboVAEDecoder.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboVAEDecoder.swift
@@ -1,0 +1,228 @@
+// FiboVAEDecoder.swift — Wan 2.2 VAE decoder (upsampling path)
+// Ported from mflux:
+//   - wan_2_2_decoder_3d.py
+//   - wan_2_2_residual_up_block.py
+//   - wan_2_2_up_block.py
+//
+// The decoder maps latent (B, z_dim, T_lat, H_lat, W_lat) back to pixel space
+// (B, out_channels, T, H/2, W/2) through progressive upsampling.
+//
+// Architecture:
+//   conv_in → mid_block → up_blocks[0..3] → norm_out → SiLU → conv_out
+//
+// Each residual up block has:
+//   - Residual blocks (num_res_blocks + 1)
+//   - A main-path upsampler (Resample) for all but the last block
+//   - A shortcut-path upsampler (DupUp3D) for all but the last block
+//   - The block output is: main_path(x) + shortcut(x_copy)
+//
+// For FIBO image generation (temporal_upsample=[]):
+//   - No temporal upsampling — all blocks use upsample2d mode
+//   - DupUp3D uses factor_t=1
+
+import MLX
+import MLXNN
+
+// MARK: - Residual Up Block
+
+/// Decoder up block with residual shortcut for the Wan 2.2 VAE.
+///
+/// Uses DupUp3D for the shortcut path (inverse of AvgDown3D in the encoder).
+/// The main path has residual blocks followed by spatial upsampling.
+public final class FiboVAEResidualUpBlock: Module {
+
+  let inDim: Int
+  let outDim: Int
+
+  @ModuleInfo(key: "resnets") var resnets: [FiboVAEResidualBlock]
+  @ModuleInfo(key: "upsampler") var upsampler: FiboVAEResample?
+  @ModuleInfo(key: "avg_shortcut") var avgShortcut: FiboVAEDupUp3D?
+
+  /// Creates a residual up block.
+  ///
+  /// - Parameters:
+  ///   - inDim: Input channel dimension.
+  ///   - outDim: Output channel dimension.
+  ///   - numResBlocks: Number of residual blocks (total = numResBlocks + 1).
+  ///   - temporalUpsample: Whether to also upsample temporally.
+  ///   - upFlag: If true, adds upsampler and shortcut. False for the last block.
+  public init(
+    inDim: Int,
+    outDim: Int,
+    numResBlocks: Int,
+    temporalUpsample: Bool = false,
+    upFlag: Bool = false
+  ) {
+    self.inDim = inDim
+    self.outDim = outDim
+
+    // Shortcut path
+    if upFlag {
+      self._avgShortcut.wrappedValue = FiboVAEDupUp3D(
+        inChannels: inDim,
+        outChannels: outDim,
+        factorT: temporalUpsample ? 2 : 1,
+        factorS: 2
+      )
+    } else {
+      self._avgShortcut.wrappedValue = nil
+    }
+
+    // Residual blocks: num_res_blocks + 1 (matching mflux)
+    var resnetList: [FiboVAEResidualBlock] = []
+    var currentDim = inDim
+    for _ in 0..<(numResBlocks + 1) {
+      resnetList.append(FiboVAEResidualBlock(inDim: currentDim, outDim: outDim))
+      currentDim = outDim
+    }
+    self._resnets.wrappedValue = resnetList
+
+    // Main path upsampler
+    if upFlag {
+      let mode: FiboVAEResample.Mode = temporalUpsample ? .upsample3d : .upsample2d
+      self._upsampler.wrappedValue = FiboVAEResample(
+        dim: outDim, mode: mode, upsampleOutDim: outDim
+      )
+    } else {
+      self._upsampler.wrappedValue = nil
+    }
+
+    super.init()
+  }
+
+  /// Applies the up block.
+  ///
+  /// - Parameters:
+  ///   - x: Input tensor of shape `(B, C, T, H, W)`.
+  ///   - firstChunk: Passed to DupUp3D for temporal trim. Default `false`.
+  /// - Returns: Upsampled tensor.
+  public func callAsFunction(_ x: MLXArray, firstChunk: Bool = false) -> MLXArray {
+    let xCopy = x
+
+    var h = x
+    for resnet in resnets {
+      h = resnet(h)
+    }
+
+    if let us = upsampler {
+      h = us(h)
+    }
+
+    if let shortcut = avgShortcut {
+      h = h + shortcut(xCopy, firstChunk: firstChunk)
+    }
+
+    return h
+  }
+}
+
+// MARK: - Decoder 3D
+
+/// Full decoder for the Wan 2.2 VAE.
+///
+/// Progressive upsampling from latent space back to pixel space:
+///
+/// ```
+/// Input (B, 48, T_lat, H_lat, W_lat)    — after post_quant_conv
+///   ├─ conv_in:       CausalConv3d(48 → 1024, k=3)
+///   ├─ mid_block:     MidBlock(1024)
+///   ├─ up_blocks[0]:  ResidualUpBlock(1024 → 640, upsample)
+///   ├─ up_blocks[1]:  ResidualUpBlock(640 → 512, upsample)
+///   ├─ up_blocks[2]:  ResidualUpBlock(512 → 256, upsample)
+///   ├─ up_blocks[3]:  ResidualUpBlock(256 → 256, no upsample, is_last)
+///   ├─ norm_out:      RMSNorm(256) → SiLU
+///   ├─ conv_out:      CausalConv3d(256 → 12, k=3)
+///   └─ Output (B, 12, T, H/2, W/2)
+/// ```
+///
+/// The output has `out_channels=12` which is then unpatchified to `(B, 3, T, H, W)`.
+public final class FiboVAEDecoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: FiboCausalConv3d
+  @ModuleInfo(key: "mid_block") var midBlock: FiboVAEMidBlock
+  @ModuleInfo(key: "up_blocks") var upBlocks: [FiboVAEResidualUpBlock]
+  @ModuleInfo(key: "norm_out") var normOut: FiboVAERMSNorm
+  @ModuleInfo(key: "conv_out") var convOut: FiboCausalConv3d
+
+  /// Creates a Wan 2.2 VAE decoder.
+  ///
+  /// - Parameters:
+  ///   - dim: Base channel dimension. Default `256`.
+  ///   - zDim: Latent channel dimension. Default `48`.
+  ///   - dimMult: Channel multipliers. Default `[1, 2, 4, 4]`.
+  ///   - numResBlocks: Residual blocks per stage. Default `2`.
+  ///   - temporalUpsample: Per-block temporal upsample flags. Default `[]` (none).
+  ///   - outChannels: Output channels (before unpatchify). Default `12`.
+  public init(
+    dim: Int = 256,
+    zDim: Int = 48,
+    dimMult: [Int] = [1, 2, 4, 4],
+    numResBlocks: Int = 2,
+    temporalUpsample: [Bool] = [],
+    outChannels: Int = 12
+  ) {
+    // Decoder dims are reversed from encoder:
+    // dims = [dim*dimMult[-1], dim*dimMult[-1], dim*dimMult[-2], ..., dim*dimMult[0]]
+    let reversedMult = [dimMult.last!] + dimMult.reversed()
+    let dims = reversedMult.map { dim * $0 }
+
+    self._convIn.wrappedValue = FiboCausalConv3d(
+      inChannels: zDim, outChannels: dims[0],
+      kernelSize: 3, padding: 1
+    )
+
+    self._midBlock.wrappedValue = FiboVAEMidBlock(dim: dims[0], numLayers: 1)
+
+    // Build up blocks
+    var blocks: [FiboVAEResidualUpBlock] = []
+    for i in 0..<dimMult.count {
+      let inDim = dims[i]
+      let outDim = dims[i + 1]
+      let upFlag = i != dimMult.count - 1
+
+      let tempUp: Bool
+      if upFlag && i < temporalUpsample.count {
+        tempUp = temporalUpsample[i]
+      } else {
+        tempUp = false
+      }
+
+      blocks.append(FiboVAEResidualUpBlock(
+        inDim: inDim,
+        outDim: outDim,
+        numResBlocks: numResBlocks,
+        temporalUpsample: tempUp,
+        upFlag: upFlag
+      ))
+    }
+    self._upBlocks.wrappedValue = blocks
+
+    let lastDim = dims.last!
+    self._normOut.wrappedValue = FiboVAERMSNorm(dim: lastDim, images: false)
+    self._convOut.wrappedValue = FiboCausalConv3d(
+      inChannels: lastDim, outChannels: outChannels,
+      kernelSize: 3, padding: 1
+    )
+
+    super.init()
+  }
+
+  /// Decodes a latent tensor back to pixel space.
+  ///
+  /// - Parameter x: Latent tensor of shape `(B, z_dim, T_lat, H_lat, W_lat)`.
+  /// - Returns: Decoded tensor of shape `(B, out_channels, T, H, W)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var h = convIn(x)
+    h = midBlock(h)
+
+    for upBlock in upBlocks {
+      h = upBlock(h, firstChunk: true)
+    }
+
+    h = normOut(h)
+    h = silu(h)
+    h = convOut(h)
+
+    return h
+  }
+}

--- a/Sources/ZImage/Fibo/VAE/FiboVAEEncoder.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboVAEEncoder.swift
@@ -1,0 +1,203 @@
+// FiboVAEEncoder.swift — Wan 2.2 VAE encoder (downsampling path)
+// Ported from mflux:
+//   - wan_2_2_encoder_3d.py
+//   - wan_2_2_down_block.py
+//
+// The encoder maps patchified input (B, C_in*4, T, H/2, W/2) to the latent
+// space (B, z_dim*2, T_lat, H_lat, W_lat) through progressive downsampling.
+//
+// Architecture:
+//   conv_in → down_blocks[0..3] → mid_block → norm_out → SiLU → conv_out
+//
+// Each down block has:
+//   - Residual blocks (with optional attention, unused for FIBO)
+//   - A main-path downsampler (Resample) for all but the last block
+//   - A shortcut-path downsampler (AvgDown3D)
+//   - The block output is: main_path(x) + shortcut(x)
+
+import MLX
+import MLXNN
+
+// MARK: - Down Block
+
+/// Encoder down block for the Wan 2.2 VAE.
+///
+/// Each block applies residual blocks, optionally downsamples the main path,
+/// and adds an average-pool shortcut for the residual connection.
+///
+/// For FIBO (attn_scales=[]):
+///   - No attention blocks are inserted
+///   - Each block has `numResBlocks` residual blocks
+///   - All but the last block have a spatial downsampler
+public final class FiboVAEDownBlock: Module {
+
+  @ModuleInfo(key: "resnets") var resnets: [FiboVAEResidualBlock]
+  @ModuleInfo(key: "downsampler") var downsampler: FiboVAEResample?
+  @ModuleInfo(key: "avg_shortcut") var avgShortcut: FiboVAEAvgDown3D
+
+  /// Creates an encoder down block.
+  ///
+  /// - Parameters:
+  ///   - inDim: Input channel dimension.
+  ///   - outDim: Output channel dimension.
+  ///   - numResBlocks: Number of residual blocks.
+  ///   - temporalDownsample: Whether this block also downsamples temporally.
+  ///   - isLast: If true, no spatial downsampler is added.
+  public init(
+    inDim: Int,
+    outDim: Int,
+    numResBlocks: Int,
+    temporalDownsample: Bool = false,
+    isLast: Bool = false
+  ) {
+    // Build residual blocks
+    var resnetList: [FiboVAEResidualBlock] = []
+    var currentDim = inDim
+    for _ in 0..<numResBlocks {
+      resnetList.append(FiboVAEResidualBlock(inDim: currentDim, outDim: outDim))
+      currentDim = outDim
+    }
+    self._resnets.wrappedValue = resnetList
+
+    // Shortcut path with downsample
+    self._avgShortcut.wrappedValue = FiboVAEAvgDown3D(
+      inChannels: inDim,
+      outChannels: outDim,
+      factorT: temporalDownsample ? 2 : 1,
+      factorS: isLast ? 1 : 2
+    )
+
+    // Main path downsampler (all but last block)
+    if !isLast {
+      let mode: FiboVAEResample.Mode = temporalDownsample ? .downsample3d : .downsample2d
+      self._downsampler.wrappedValue = FiboVAEResample(dim: outDim, mode: mode)
+    } else {
+      self._downsampler.wrappedValue = nil
+    }
+
+    super.init()
+  }
+
+  /// Applies the down block.
+  ///
+  /// - Parameter x: Input tensor of shape `(B, C, T, H, W)`.
+  /// - Returns: Downsampled tensor.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let shortcut = avgShortcut(x)
+
+    var h = x
+    for resnet in resnets {
+      h = resnet(h)
+    }
+    if let ds = downsampler {
+      h = ds(h)
+    }
+
+    return h + shortcut
+  }
+}
+
+// MARK: - Encoder 3D
+
+/// Full encoder for the Wan 2.2 VAE.
+///
+/// Progressive downsampling from input to latent space:
+///
+/// ```
+/// Input (B, 48, T, H/2, W/2)    — after patchify
+///   ├─ conv_in:       CausalConv3d(48 → 160, k=3)
+///   ├─ down_blocks[0]: DownBlock(160 → 320, no temporal, spatial 2x)
+///   ├─ down_blocks[1]: DownBlock(320 → 640, temporal 2x, spatial 2x)
+///   ├─ down_blocks[2]: DownBlock(640 → 640, temporal 2x, spatial 2x)
+///   ├─ down_blocks[3]: DownBlock(640 → 640, no downsample, is_last)
+///   ├─ mid_block:      MidBlock(640)
+///   ├─ norm_out:       RMSNorm(640) → SiLU
+///   ├─ conv_out:       CausalConv3d(640 → 96, k=3)
+///   └─ Output (B, 96, T_lat, H_lat, W_lat)
+/// ```
+///
+/// The output has `z_dim * 2 = 96` channels (mean + logvar). Only the first
+/// 48 channels (mean) are used by the VAE.
+public final class FiboVAEEncoder: Module {
+
+  @ModuleInfo(key: "conv_in") var convIn: FiboCausalConv3d
+  @ModuleInfo(key: "down_blocks") var downBlocks: [FiboVAEDownBlock]
+  @ModuleInfo(key: "mid_block") var midBlock: FiboVAEMidBlock
+  @ModuleInfo(key: "norm_out") var normOut: FiboVAERMSNorm
+  @ModuleInfo(key: "conv_out") var convOut: FiboCausalConv3d
+
+  /// Creates a Wan 2.2 VAE encoder.
+  ///
+  /// - Parameters:
+  ///   - inChannels: Number of input channels (after patchify). Default `12`
+  ///     (3 RGB * patch_size^2 = 12, then patchified to 48).
+  ///   - dim: Base channel dimension. Default `160`.
+  ///   - zDim: Latent dimension (doubled for mean+logvar). Default `96`.
+  ///   - dimMult: Channel multipliers for each stage. Default `[1, 2, 4, 4]`.
+  ///   - numResBlocks: Residual blocks per stage. Default `2`.
+  ///   - temporalDownsample: Per-block temporal downsample flags.
+  ///     Default `[false, true, true]`.
+  public init(
+    inChannels: Int = 12,
+    dim: Int = 160,
+    zDim: Int = 96,
+    dimMult: [Int] = [1, 2, 4, 4],
+    numResBlocks: Int = 2,
+    temporalDownsample: [Bool] = [false, true, true]
+  ) {
+    // Channel dimensions: [dim, dim*1, dim*2, dim*4, dim*4]
+    let dims = [dim] + dimMult.map { dim * $0 }
+
+    self._convIn.wrappedValue = FiboCausalConv3d(
+      inChannels: inChannels, outChannels: dims[0],
+      kernelSize: 3, padding: 1
+    )
+
+    // Build down blocks
+    var blocks: [FiboVAEDownBlock] = []
+    for i in 0..<dimMult.count {
+      let inDim = dims[i]
+      let outDim = dims[i + 1]
+      let tempDown = i < temporalDownsample.count ? temporalDownsample[i] : false
+      let isLast = i == dimMult.count - 1
+
+      blocks.append(FiboVAEDownBlock(
+        inDim: inDim,
+        outDim: outDim,
+        numResBlocks: numResBlocks,
+        temporalDownsample: tempDown,
+        isLast: isLast
+      ))
+    }
+    self._downBlocks.wrappedValue = blocks
+
+    let lastDim = dims.last!
+    self._midBlock.wrappedValue = FiboVAEMidBlock(dim: lastDim, numLayers: 1)
+    self._normOut.wrappedValue = FiboVAERMSNorm(dim: lastDim, images: false)
+    self._convOut.wrappedValue = FiboCausalConv3d(
+      inChannels: lastDim, outChannels: zDim,
+      kernelSize: 3, padding: 1
+    )
+
+    super.init()
+  }
+
+  /// Encodes an input tensor into the latent space.
+  ///
+  /// - Parameter x: Patchified input of shape `(B, C_in, T, H, W)`.
+  /// - Returns: Latent tensor of shape `(B, z_dim*2, T_lat, H_lat, W_lat)`.
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var h = convIn(x)
+
+    for block in downBlocks {
+      h = block(h)
+    }
+
+    h = midBlock(h)
+    h = normOut(h)
+    h = silu(h)
+    h = convOut(h)
+
+    return h
+  }
+}

--- a/Sources/ZImage/Fibo/VAE/FiboVAEPatchify.swift
+++ b/Sources/ZImage/Fibo/VAE/FiboVAEPatchify.swift
@@ -1,0 +1,107 @@
+// FiboVAEPatchify.swift — Patchify and unpatchify operations for the Wan 2.2 VAE
+// Ported from mflux: wan_2_2_vae.py (_patchify / _unpatchify)
+//
+// The Wan 2.2 VAE uses spatial patchification to reduce the input resolution
+// before encoding, and unpatchification after decoding to restore it. With
+// patch_size=2:
+//
+//   Patchify:   (B, 3, T, H, W) → (B, 3*2*2, T, H/2, W/2) = (B, 12, T, H/2, W/2)
+//   Unpatchify: (B, 12, T, H/2, W/2) → (B, 3, T, H, W)
+//
+// This is a simple spatial pixel-shuffle/unshuffle — the patch pixels are
+// folded into the channel dimension.
+
+import MLX
+
+/// Patchify and unpatchify operations for the Wan 2.2 VAE.
+///
+/// These are static utility functions used by ``FiboVAE`` during encode and decode.
+/// The operations fold/unfold spatial patches into the channel dimension.
+public enum FiboVAEPatchify {
+
+  /// Folds spatial patches into the channel dimension.
+  ///
+  /// Equivalent to a pixel-unshuffle (space-to-depth) operation:
+  /// - Splits each spatial dimension by `patchSize`
+  /// - Moves the patch pixels into the channel dimension
+  ///
+  /// Example with patchSize=2:
+  ///   (B, 3, T, 256, 256) → (B, 12, T, 128, 128)
+  ///
+  /// - Parameters:
+  ///   - x: Input tensor of shape `(B, C, T, H, W)`.
+  ///   - patchSize: Spatial patch size. Default `2`.
+  /// - Returns: Patchified tensor of shape `(B, C*P*P, T, H/P, W/P)`.
+  public static func patchify(_ x: MLXArray, patchSize: Int = 2) -> MLXArray {
+    if patchSize == 1 { return x }
+
+    let (batchSize, channels, frames, height, width) = (
+      x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4)
+    )
+
+    // Reshape to separate patch pixels:
+    // (B, C, T, H, W) → (B, C, T, H/P, P, W/P, P)
+    var result = x.reshaped(
+      batchSize, channels, frames,
+      height / patchSize, patchSize,
+      width / patchSize, patchSize
+    )
+
+    // Reorder to move patch pixels to channel dim:
+    // (B, C, T, H/P, P_h, W/P, P_w) → (B, C, P_w, P_h, T, H/P, W/P)
+    result = result.transposed(0, 1, 6, 4, 2, 3, 5)
+
+    // Collapse channels and patch pixels:
+    // (B, C, P_w, P_h, T, H/P, W/P) → (B, C*P*P, T, H/P, W/P)
+    result = result.reshaped(
+      batchSize,
+      channels * patchSize * patchSize,
+      frames,
+      height / patchSize,
+      width / patchSize
+    )
+
+    return result
+  }
+
+  /// Unfolds the channel dimension back into spatial patches.
+  ///
+  /// Equivalent to a pixel-shuffle (depth-to-space) operation:
+  /// - Extracts patch pixels from the channel dimension
+  /// - Distributes them back to spatial dimensions
+  ///
+  /// Example with patchSize=2:
+  ///   (B, 12, T, 128, 128) → (B, 3, T, 256, 256)
+  ///
+  /// - Parameters:
+  ///   - x: Patchified tensor of shape `(B, C*P*P, T, H/P, W/P)`.
+  ///   - patchSize: Spatial patch size. Default `2`.
+  /// - Returns: Unpatchified tensor of shape `(B, C, T, H, W)`.
+  public static func unpatchify(_ x: MLXArray, patchSize: Int = 2) -> MLXArray {
+    if patchSize == 1 { return x }
+
+    let (batchSize, cPatches, frames, height, width) = (
+      x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4)
+    )
+    let channels = cPatches / (patchSize * patchSize)
+
+    // Reshape to separate patch pixels:
+    // (B, C*P*P, T, H, W) → (B, C, P_h, P_w, T, H, W)
+    var result = x.reshaped(
+      batchSize, channels, patchSize, patchSize, frames, height, width
+    )
+
+    // Reorder to distribute patches back to spatial dims:
+    // (B, C, P_h, P_w, T, H, W) → (B, C, T, H, P_w, W, P_h)
+    result = result.transposed(0, 1, 4, 5, 3, 6, 2)
+
+    // Collapse spatial + patch dims:
+    // (B, C, T, H, P_w, W, P_h) → (B, C, T, H*P, W*P)
+    result = result.reshaped(
+      batchSize, channels, frames,
+      height * patchSize, width * patchSize
+    )
+
+    return result
+  }
+}


### PR DESCRIPTION
Wan 2.2 VAE port: CausalConv3d, 4-stage encoder/decoder, RMSNorm, patchify/unpatchify, 48-channel latent space. 1448 lines.