### PR TITLE
feat(bridge): model registry + style presets for Krita

### DIFF
--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
@@ -3,7 +3,7 @@
 // Returns model classification data that the Krita AI Diffusion plugin uses
 // to determine which architectures (workloads) are available.
 //
-// Delegates to ComfyBridgeModelRegistry for the actual model definitions.
+// Delegates to ComfyBoxModelRegistry for the actual model definitions.
 
 import Foundation
 
@@ -11,8 +11,8 @@ import Foundation
 enum ComfyBridgeModelInfo {
 
   /// Return model metadata for the given folder name.
-  /// Delegates to `ComfyBridgeModelRegistry.bridgeModelInfo(for:)`.
+  /// Delegates to `ComfyBoxModelRegistry.bridgeModelInfo(for:)`.
   static func models(for folder: String) -> [String: Any] {
-    ComfyBridgeModelRegistry.bridgeModelInfo(for: folder)
+    ComfyBoxModelRegistry.bridgeModelInfo(for: folder)
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelInfo.swift
@@ -2,6 +2,8 @@
 //
 // Returns model classification data that the Krita AI Diffusion plugin uses
 // to determine which architectures (workloads) are available.
+//
+// Delegates to ComfyBridgeModelRegistry for the actual model definitions.
 
 import Foundation
 
@@ -9,41 +11,8 @@ import Foundation
 enum ComfyBridgeModelInfo {
 
   /// Return model metadata for the given folder name.
-  /// Folders: "checkpoints", "diffusion_models", "unet", "unet_gguf"
+  /// Delegates to `ComfyBridgeModelRegistry.bridgeModelInfo(for:)`.
   static func models(for folder: String) -> [String: Any] {
-    switch folder {
-    case "checkpoints":
-      // We don't use checkpoint format — Z-Image uses diffusion_models.
-      return [:]
-
-    case "diffusion_models", "unet":
-      return [
-        "z-image-turbo-bf16": [
-          "base_model": "zimage",
-          "type": "eps",
-          "is_inpaint": false,
-          "quant": "none",
-        ] as [String: Any],
-        "z-image-turbo-q8": [
-          "base_model": "zimage",
-          "type": "eps",
-          "is_inpaint": false,
-          "quant": "q8",
-        ] as [String: Any],
-        "z-image-turbo-q4": [
-          "base_model": "zimage",
-          "type": "eps",
-          "is_inpaint": false,
-          "quant": "q4",
-        ] as [String: Any],
-      ]
-
-    case "unet_gguf":
-      // No GGUF models — feature is disabled in our bridge.
-      return [:]
-
-    default:
-      return [:]
-    }
+    ComfyBridgeModelRegistry.bridgeModelInfo(for: folder)
   }
 }

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
@@ -131,15 +131,12 @@ public enum ComfyBoxModelRegistry {
 
   /// All registered models, keyed by ID.
   public static let models: [String: ComfyBoxModel] = {
-    var dict: [String: CombxModel] = [:]
+    var dict: [String: ComfyBoxModel] = [:]
     for model in allModels {
       dict[model.id] = model
     }
     return dict
   }()
-
-  // For the compiler — fix the typo in the computed property above
-  private typealias CombxModel = ComfyBoxModel
 
   /// All registered models as an array.
   public static let allModels: [ComfyBoxModel] = [

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
@@ -1,0 +1,379 @@
+// ComfyBridgeModelRegistry.swift — Unified model registry for ComfyBox
+//
+// Central registry of all supported model families, their capabilities,
+// recommended parameters, and HuggingFace identifiers. Used by:
+// - ComfyBridgeModelInfo (serves /api/etn/model_info to Krita)
+// - WarmServer (model loading and family detection)
+// - StylePresets (model-specific defaults)
+//
+// Models are grouped by family and variant (distilled vs base, quantization).
+
+import Foundation
+
+// MARK: - Model Family
+
+/// Top-level model family classification.
+public enum ComfyBoxModelFamily: String, Codable, CaseIterable, Sendable {
+  case zImage = "z-image"
+  case flux2Klein = "flux2-klein"
+  case fibo = "fibo"
+  case seedvr2 = "seedvr2"
+
+  /// Human-readable display name.
+  public var displayName: String {
+    switch self {
+    case .zImage: return "Z-Image"
+    case .flux2Klein: return "Flux 2 Klein"
+    case .fibo: return "FIBO"
+    case .seedvr2: return "SeedVR2"
+    }
+  }
+
+  /// Architecture description for UI tooltips.
+  public var architecture: String {
+    switch self {
+    case .zImage: return "6B DiT, Qwen3-Coder text encoder, Lumina2 architecture"
+    case .flux2Klein: return "4B/9B DiT, Qwen3 text encoder, Flux 2 architecture"
+    case .fibo: return "8B DiT, SmolLM3-3B text encoder, Wan 2.2 VAE, DimFusion"
+    case .seedvr2: return "3B upscaler, 2× resolution enhancement"
+    }
+  }
+}
+
+// MARK: - Model Variant
+
+/// Whether a model is distilled (few-step) or base (multi-step, supports CFG).
+public enum ComfyBoxModelVariant: String, Codable, Sendable {
+  case turbo       // Distilled, 4-9 steps, no CFG needed
+  case base        // Non-distilled, 20-50 steps, CFG guidance > 1.0
+  case upscaler    // Post-processing model
+}
+
+// MARK: - Quantization
+
+/// Quantization level for model weights.
+public enum ComfyBoxQuantization: String, Codable, CaseIterable, Sendable {
+  case none = "bf16"    // Full bfloat16
+  case q8 = "q8"        // 8-bit quantized
+  case q4 = "q4"        // 4-bit quantized
+
+  /// Approximate VRAM reduction factor vs bf16.
+  public var vramFactor: Float {
+    switch self {
+    case .none: return 1.0
+    case .q8: return 0.5
+    case .q4: return 0.25
+    }
+  }
+}
+
+// MARK: - Model Definition
+
+/// A single registered model with all metadata needed by the bridge and WarmServer.
+public struct ComfyBoxModel: Codable, Sendable {
+  /// Unique identifier used in API responses and config (e.g. "z-image-turbo-bf16").
+  public let id: String
+
+  /// Model family.
+  public let family: ComfyBoxModelFamily
+
+  /// Distilled or base variant.
+  public let variant: ComfyBoxModelVariant
+
+  /// Weight quantization level.
+  public let quantization: ComfyBoxQuantization
+
+  /// HuggingFace model identifier (e.g. "Tongyi-MAI/Z-Image").
+  public let huggingFaceId: String
+
+  /// Parameter count in billions (approximate).
+  public let parametersBillions: Float
+
+  /// Number of latent channels (48 for FIBO/Wan2.2, 128 for Flux-family).
+  public let latentChannels: Int
+
+  /// Default number of denoising steps.
+  public let defaultSteps: Int
+
+  /// Default CFG guidance scale (1.0 = no guidance).
+  public let defaultGuidance: Float
+
+  /// Whether the model supports CFG guidance > 1.0.
+  public let supportsGuidance: Bool
+
+  /// Whether the model supports LoRA adapters.
+  public let supportsLoRA: Bool
+
+  /// Whether the model supports ControlNet.
+  public let supportsControlNet: Bool
+
+  /// Whether the model supports img2img.
+  public let supportsImg2Img: Bool
+
+  /// Default resolution (width × height).
+  public let defaultWidth: Int
+  public let defaultHeight: Int
+
+  /// Estimated VRAM usage in GB at default resolution.
+  public let estimatedVRAM_GB: Float
+
+  /// Human-readable display name.
+  public let displayName: String
+
+  /// Short description for UI tooltips.
+  public let description: String
+}
+
+// MARK: - Model Registry
+
+/// Central registry of all ComfyBox models.
+public enum ComfyBoxModelRegistry {
+
+  /// All registered models, keyed by ID.
+  public static let models: [String: ComfyBoxModel] = {
+    var dict: [String: CombxModel] = [:]
+    for model in allModels {
+      dict[model.id] = model
+    }
+    return dict
+  }()
+
+  // For the compiler — fix the typo in the computed property above
+  private typealias CombxModel = ComfyBoxModel
+
+  /// All registered models as an array.
+  public static let allModels: [ComfyBoxModel] = [
+
+    // ─── Z-Image Family ──────────────────────────────────────────────
+    // 6B DiT with Qwen3-Coder text encoder. Lumina2 architecture.
+    // Turbo = distilled (4-9 steps), Base = non-distilled (20-50 steps).
+
+    ComfyBoxModel(
+      id: "z-image-turbo-bf16",
+      family: .zImage, variant: .turbo, quantization: .none,
+      huggingFaceId: "Tongyi-MAI/Z-Image",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 9, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 12.5,
+      displayName: "Z-Image Turbo",
+      description: "Daily driver — fast 9-step distilled model. Best quality-to-speed ratio."
+    ),
+
+    ComfyBoxModel(
+      id: "z-image-turbo-q8",
+      family: .zImage, variant: .turbo, quantization: .q8,
+      huggingFaceId: "Tongyi-MAI/Z-Image",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 9, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 7.0,
+      displayName: "Z-Image Turbo (Q8)",
+      description: "8-bit quantized Z-Image Turbo. Good quality, lower VRAM."
+    ),
+
+    ComfyBoxModel(
+      id: "z-image-turbo-q4",
+      family: .zImage, variant: .turbo, quantization: .q4,
+      huggingFaceId: "Tongyi-MAI/Z-Image",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 9, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 4.0,
+      displayName: "Z-Image Turbo (Q4)",
+      description: "4-bit quantized Z-Image Turbo. Fastest, lowest VRAM."
+    ),
+
+    ComfyBoxModel(
+      id: "z-image-base-bf16",
+      family: .zImage, variant: .base, quantization: .none,
+      huggingFaceId: "Tongyi-MAI/Z-Image",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 28, defaultGuidance: 3.5,
+      supportsGuidance: true, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 12.5,
+      displayName: "Z-Image Base",
+      description: "Non-distilled Z-Image. Higher quality with CFG, slower. Best for final renders."
+    ),
+
+    // ─── Flux 2 Klein Family ─────────────────────────────────────────
+    // Compact Flux 2 models with Qwen3 text encoder.
+    // Klein = distilled (4-8 steps), Klein Base = non-distilled (20-50 steps).
+
+    ComfyBoxModel(
+      id: "flux2-klein-4b-bf16",
+      family: .flux2Klein, variant: .turbo, quantization: .none,
+      huggingFaceId: "black-forest-labs/FLUX.2-Klein-4B",
+      parametersBillions: 4.0, latentChannels: 128,
+      defaultSteps: 6, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 8.5,
+      displayName: "Flux 2 Klein 4B",
+      description: "Compact distilled model. Fast 6-step generation, good for live painting."
+    ),
+
+    ComfyBoxModel(
+      id: "flux2-klein-9b-bf16",
+      family: .flux2Klein, variant: .turbo, quantization: .none,
+      huggingFaceId: "black-forest-labs/FLUX.2-Klein-9B",
+      parametersBillions: 9.0, latentChannels: 128,
+      defaultSteps: 6, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 18.0,
+      displayName: "Flux 2 Klein 9B",
+      description: "Larger distilled model. Better quality than 4B, still fast."
+    ),
+
+    ComfyBoxModel(
+      id: "flux2-klein-base-4b-bf16",
+      family: .flux2Klein, variant: .base, quantization: .none,
+      huggingFaceId: "black-forest-labs/FLUX.2-Klein-Base-4B",
+      parametersBillions: 4.0, latentChannels: 128,
+      defaultSteps: 28, defaultGuidance: 3.5,
+      supportsGuidance: true, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 8.5,
+      displayName: "Flux 2 Klein Base 4B",
+      description: "Non-distilled 4B model. Supports CFG guidance for fine control."
+    ),
+
+    ComfyBoxModel(
+      id: "flux2-klein-base-9b-bf16",
+      family: .flux2Klein, variant: .base, quantization: .none,
+      huggingFaceId: "black-forest-labs/FLUX.2-Klein-Base-9B",
+      parametersBillions: 9.0, latentChannels: 128,
+      defaultSteps: 28, defaultGuidance: 3.5,
+      supportsGuidance: true, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 18.0,
+      displayName: "Flux 2 Klein Base 9B",
+      description: "Largest non-distilled Klein. Highest quality Flux 2 output."
+    ),
+
+    // ─── FIBO Family ─────────────────────────────────────────────────
+    // 8B DiT with SmolLM3-3B text encoder, Wan 2.2 VAE, DimFusion conditioning.
+
+    ComfyBoxModel(
+      id: "fibo-8b-bf16",
+      family: .fibo, variant: .base, quantization: .none,
+      huggingFaceId: "briaai/FIBO",
+      parametersBillions: 8.0, latentChannels: 48,
+      defaultSteps: 30, defaultGuidance: 4.0,
+      supportsGuidance: true, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: false,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 22.0,
+      displayName: "FIBO 8B",
+      description: "Bria AI's 8B model. Unique DimFusion architecture, Wan 2.2 VAE. Commercial-licensed."
+    ),
+
+    // ─── SeedVR2 Family ──────────────────────────────────────────────
+    // 3B upscaler — 2× resolution enhancement.
+
+    ComfyBoxModel(
+      id: "seedvr2-bf16",
+      family: .seedvr2, variant: .upscaler, quantization: .none,
+      huggingFaceId: "ByteDance/SeedVR2-3B",
+      parametersBillions: 3.0, latentChannels: 128,
+      defaultSteps: 18, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: false,
+      supportsControlNet: false, supportsImg2Img: true,
+      defaultWidth: 2048, defaultHeight: 2048,
+      estimatedVRAM_GB: 14.0,
+      displayName: "SeedVR2 Upscaler",
+      description: "2× resolution upscaler. Feed a generated image, get 2× detail."
+    ),
+  ]
+
+  // MARK: - Lookups
+
+  /// Get all models for a given family.
+  public static func models(for family: ComfyBoxModelFamily) -> [ComfyBoxModel] {
+    allModels.filter { $0.family == family }
+  }
+
+  /// Get the default model for a family (prefers turbo/distilled bf16).
+  public static func defaultModel(for family: ComfyBoxModelFamily) -> ComfyBoxModel? {
+    let familyModels = models(for: family)
+    // Prefer turbo/distilled bf16
+    return familyModels.first { $0.variant == .turbo && $0.quantization == .none }
+      ?? familyModels.first { $0.quantization == .none }
+      ?? familyModels.first
+  }
+
+  /// Get the recommended model for live painting (fastest img2img).
+  public static var livePaintingModel: ComfyBoxModel? {
+    models["flux2-klein-4b-bf16"]
+  }
+
+  /// Get the recommended model for final renders (highest quality).
+  public static var highQualityModel: ComfyBoxModel? {
+    models["z-image-base-bf16"]
+  }
+
+  // MARK: - Bridge Format
+
+  /// Convert to the format expected by /api/etn/model_info/{folder}.
+  /// Returns [modelId: metadata] for the Krita AI Diffusion plugin.
+  public static func bridgeModelInfo(for folder: String) -> [String: Any] {
+    switch folder {
+    case "diffusion_models", "unet":
+      var result: [String: Any] = [:]
+      for model in allModels where model.variant != .upscaler {
+        result[model.id] = [
+          "base_model": model.family.rawValue,
+          "type": model.supportsGuidance ? "v_prediction" : "eps",
+          "is_inpaint": false,
+          "quant": model.quantization.rawValue,
+          "params_b": model.parametersBillions,
+          "default_steps": model.defaultSteps,
+          "default_guidance": model.defaultGuidance,
+          "supports_guidance": model.supportsGuidance,
+          "supports_lora": model.supportsLoRA,
+          "supports_img2img": model.supportsImg2Img,
+          "display_name": model.displayName,
+          "description": model.description,
+        ] as [String: Any]
+      }
+      return result
+
+    case "upscale_models":
+      var result: [String: Any] = [:]
+      for model in allModels where model.variant == .upscaler {
+        result[model.id] = [
+          "base_model": model.family.rawValue,
+          "type": "upscaler",
+          "scale_factor": 2,
+          "display_name": model.displayName,
+          "description": model.description,
+        ] as [String: Any]
+      }
+      return result
+
+    case "checkpoints":
+      // We don't use checkpoint format.
+      return [:]
+
+    case "unet_gguf":
+      // No GGUF models in ComfyBox.
+      return [:]
+
+    default:
+      return [:]
+    }
+  }
+}

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeStylePresets.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeStylePresets.swift
@@ -1,0 +1,362 @@
+// ComfyBridgeStylePresets.swift — Style presets for ComfyBox
+//
+// Style presets provide prompt engineering shortcuts + tuned generation
+// parameters for common artistic styles. Used by the Krita bridge and
+// can be exposed via WarmServer API endpoints.
+//
+// Each preset specifies:
+// - Prompt prefix/suffix for the style
+// - Recommended model family + variant
+// - Optimal steps, guidance, resolution
+// - Negative prompt tailored to the style
+
+import Foundation
+
+// MARK: - Style Category
+
+/// Broad category for organizing presets in UI.
+public enum ComfyBoxStyleCategory: String, Codable, CaseIterable, Sendable {
+  case photography = "Photography"
+  case illustration = "Illustration"
+  case painting = "Painting"
+  case concept = "Concept Art"
+  case utility = "Utility"
+}
+
+// MARK: - Style Preset
+
+/// A named style preset with prompt engineering and generation parameters.
+public struct ComfyBoxStylePreset: Codable, Sendable {
+  /// Unique identifier (e.g. "cinematic").
+  public let id: String
+
+  /// Display name (e.g. "Cinematic Film").
+  public let name: String
+
+  /// Category for UI grouping.
+  public let category: ComfyBoxStyleCategory
+
+  /// Short description.
+  public let description: String
+
+  /// Text prepended to the user's prompt.
+  public let promptPrefix: String
+
+  /// Text appended to the user's prompt.
+  public let promptSuffix: String
+
+  /// Style-specific negative prompt (appended to user's negative prompt).
+  public let negativePrompt: String
+
+  /// Recommended model ID (from ComfyBoxModelRegistry).
+  public let recommendedModel: String
+
+  /// Recommended denoising steps (overrides model default if set).
+  public let steps: Int?
+
+  /// Recommended CFG guidance (overrides model default if set).
+  public let guidance: Float?
+
+  /// Recommended resolution.
+  public let width: Int?
+  public let height: Int?
+
+  /// Denoise strength for img2img (0.0-1.0). Nil = use default.
+  public let img2imgStrength: Float?
+
+  /// Apply the preset to a prompt — returns (enhancedPrompt, enhancedNegative).
+  public func apply(prompt: String, negativePrompt: String? = nil) -> (String, String?) {
+    let enhanced = [promptPrefix, prompt, promptSuffix]
+      .filter { !$0.isEmpty }
+      .joined(separator: ", ")
+
+    let combinedNegative: String?
+    if !self.negativePrompt.isEmpty {
+      if let userNeg = negativePrompt, !userNeg.isEmpty {
+        combinedNegative = userNeg + ", " + self.negativePrompt
+      } else {
+        combinedNegative = self.negativePrompt
+      }
+    } else {
+      combinedNegative = negativePrompt
+    }
+
+    return (enhanced, combinedNegative)
+  }
+}
+
+// MARK: - Preset Registry
+
+/// All built-in style presets.
+public enum ComfyBoxStylePresets {
+
+  /// All presets, keyed by ID.
+  public static let presets: [String: ComfyBoxStylePreset] = {
+    var dict: [String: ComfyBoxStylePreset] = [:]
+    for preset in allPresets {
+      dict[preset.id] = preset
+    }
+    return dict
+  }()
+
+  /// All presets as an array.
+  public static let allPresets: [ComfyBoxStylePreset] = [
+
+    // ─── Photography ─────────────────────────────────────────────────
+
+    ComfyBoxStylePreset(
+      id: "photorealistic",
+      name: "Photorealistic",
+      category: .photography,
+      description: "Clean photorealistic output with natural lighting",
+      promptPrefix: "photorealistic, highly detailed photograph",
+      promptSuffix: "natural lighting, sharp focus, 8k resolution",
+      negativePrompt: "illustration, painting, cartoon, anime, drawing, sketch, cgi, 3d render, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "portrait",
+      name: "Portrait",
+      category: .photography,
+      description: "Professional portrait photography with shallow depth of field",
+      promptPrefix: "professional portrait photograph, shallow depth of field, bokeh background",
+      promptSuffix: "studio lighting, sharp eyes, skin detail, 85mm lens",
+      negativePrompt: "illustration, cartoon, blurry face, distorted features, extra fingers, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 832, height: 1216,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "cinematic",
+      name: "Cinematic Film",
+      category: .photography,
+      description: "Film-like images with dramatic lighting and color grading",
+      promptPrefix: "cinematic film still, dramatic lighting, anamorphic lens",
+      promptSuffix: "color grading, volumetric lighting, film grain, depth of field, 35mm film",
+      negativePrompt: "flat lighting, overexposed, anime, cartoon, illustration, text, watermark",
+      recommendedModel: "z-image-base-bf16",
+      steps: 28, guidance: 4.0,
+      width: 1216, height: 832,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "street",
+      name: "Street Photography",
+      category: .photography,
+      description: "Candid street photography with urban atmosphere",
+      promptPrefix: "street photography, candid moment, urban",
+      promptSuffix: "natural light, documentary style, Leica lens, subtle grain",
+      negativePrompt: "studio, posed, illustration, anime, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "product",
+      name: "Product Shot",
+      category: .photography,
+      description: "Clean product photography on seamless background",
+      promptPrefix: "product photography, studio lighting, seamless white background",
+      promptSuffix: "soft shadows, commercial quality, centered composition, high detail",
+      negativePrompt: "cluttered, messy background, low quality, illustration, text",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "vintage",
+      name: "Vintage Film",
+      category: .photography,
+      description: "Retro film aesthetic with warm tones and grain",
+      promptPrefix: "vintage photograph, retro film aesthetic",
+      promptSuffix: "warm color cast, film grain, faded highlights, vignette, Kodak Portra 400",
+      negativePrompt: "digital, clean, modern, illustration, anime, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    // ─── Illustration ────────────────────────────────────────────────
+
+    ComfyBoxStylePreset(
+      id: "anime",
+      name: "Anime / Manga",
+      category: .illustration,
+      description: "Japanese anime/manga illustration style",
+      promptPrefix: "anime style illustration, vibrant colors",
+      promptSuffix: "clean linework, cel shading, high quality anime art",
+      negativePrompt: "photorealistic, photograph, 3d render, blurry, low quality, text",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 832, height: 1216,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "digital-art",
+      name: "Digital Art",
+      category: .illustration,
+      description: "Polished digital illustration with rich detail",
+      promptPrefix: "digital art, detailed illustration",
+      promptSuffix: "professional digital painting, artstation quality, vivid colors, clean composition",
+      negativePrompt: "photograph, blurry, sketch, rough, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "sketch",
+      name: "Pencil Sketch",
+      category: .illustration,
+      description: "Hand-drawn pencil sketch or charcoal drawing",
+      promptPrefix: "pencil sketch, hand drawn, graphite on paper",
+      promptSuffix: "detailed linework, cross-hatching, textured paper, monochrome",
+      negativePrompt: "color, photograph, digital, 3d, painting, text, watermark",
+      recommendedModel: "flux2-klein-4b-bf16",
+      steps: 6, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    // ─── Painting ────────────────────────────────────────────────────
+
+    ComfyBoxStylePreset(
+      id: "oil-painting",
+      name: "Oil Painting",
+      category: .painting,
+      description: "Classical oil painting with visible brushstrokes",
+      promptPrefix: "oil painting, classical fine art",
+      promptSuffix: "visible brushstrokes, canvas texture, rich impasto, museum quality, chiaroscuro",
+      negativePrompt: "photograph, digital, 3d render, anime, cartoon, text, watermark",
+      recommendedModel: "z-image-base-bf16",
+      steps: 28, guidance: 4.0,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "watercolor",
+      name: "Watercolor",
+      category: .painting,
+      description: "Watercolor painting with soft washes and bleeding edges",
+      promptPrefix: "watercolor painting, soft washes",
+      promptSuffix: "wet on wet technique, paper texture, translucent layers, bleeding edges, gentle gradients",
+      negativePrompt: "photograph, digital, sharp edges, hard lines, text, watermark",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+
+    // ─── Concept Art ─────────────────────────────────────────────────
+
+    ComfyBoxStylePreset(
+      id: "fantasy",
+      name: "Fantasy Art",
+      category: .concept,
+      description: "Epic fantasy concept art with dramatic atmosphere",
+      promptPrefix: "epic fantasy art, concept illustration",
+      promptSuffix: "dramatic atmosphere, magical lighting, detailed environment, artstation trending",
+      negativePrompt: "photograph, mundane, modern, blurry, text, watermark",
+      recommendedModel: "z-image-base-bf16",
+      steps: 28, guidance: 3.5,
+      width: 1216, height: 832,
+      img2imgStrength: nil
+    ),
+
+    ComfyBoxStylePreset(
+      id: "architecture",
+      name: "Architectural Render",
+      category: .concept,
+      description: "Architectural visualization with clean lines",
+      promptPrefix: "architectural visualization, photorealistic render",
+      promptSuffix: "clean lines, natural materials, golden hour lighting, exterior photography, professional archviz",
+      negativePrompt: "cartoon, sketch, blurry, distorted, text, watermark",
+      recommendedModel: "z-image-base-bf16",
+      steps: 28, guidance: 4.0,
+      width: 1216, height: 832,
+      img2imgStrength: nil
+    ),
+
+    // ─── Utility ─────────────────────────────────────────────────────
+
+    ComfyBoxStylePreset(
+      id: "live-paint",
+      name: "Live Painting",
+      category: .utility,
+      description: "Fastest possible img2img — optimized for Krita live canvas painting",
+      promptPrefix: "",
+      promptSuffix: "",
+      negativePrompt: "blurry, low quality",
+      recommendedModel: "flux2-klein-4b-bf16",
+      steps: 4, guidance: 1.0,
+      width: 512, height: 512,
+      img2imgStrength: 0.5
+    ),
+
+    ComfyBoxStylePreset(
+      id: "minimal",
+      name: "Minimal (No Style)",
+      category: .utility,
+      description: "No prompt engineering — pass your prompt directly to the model",
+      promptPrefix: "",
+      promptSuffix: "",
+      negativePrompt: "",
+      recommendedModel: "z-image-turbo-bf16",
+      steps: nil, guidance: nil,
+      width: 1024, height: 1024,
+      img2imgStrength: nil
+    ),
+  ]
+
+  // MARK: - Lookups
+
+  /// Get all presets in a category.
+  public static func presets(for category: ComfyBoxStyleCategory) -> [ComfyBoxStylePreset] {
+    allPresets.filter { $0.category == category }
+  }
+
+  /// Get the preset recommended for live painting.
+  public static var livePainting: ComfyBoxStylePreset? {
+    presets["live-paint"]
+  }
+
+  // MARK: - JSON Export
+
+  /// Export all presets as a JSON-serializable dictionary.
+  /// Used by WarmServer's /v1/styles endpoint.
+  public static func toJSON() -> [[String: Any]] {
+    allPresets.map { preset in
+      var dict: [String: Any] = [
+        "id": preset.id,
+        "name": preset.name,
+        "category": preset.category.rawValue,
+        "description": preset.description,
+        "prompt_prefix": preset.promptPrefix,
+        "prompt_suffix": preset.promptSuffix,
+        "negative_prompt": preset.negativePrompt,
+        "recommended_model": preset.recommendedModel,
+      ]
+      if let steps = preset.steps { dict["steps"] = steps }
+      if let guidance = preset.guidance { dict["guidance"] = guidance }
+      if let w = preset.width { dict["width"] = w }
+      if let h = preset.height { dict["height"] = h }
+      if let strength = preset.img2imgStrength { dict["img2img_strength"] = strength }
+      return dict
+    }
+  }
+}

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -195,6 +195,43 @@ public final class WarmServer {
         return .error(response(for: error))
       }
 
+    case ("GET", "/v1/models"):
+      let models = ComfyBoxModelRegistry.allModels.map { model -> [String: Any] in
+        [
+          "id": model.id,
+          "family": model.family.rawValue,
+          "variant": model.variant.rawValue,
+          "quantization": model.quantization.rawValue,
+          "display_name": model.displayName,
+          "description": model.description,
+          "parameters_b": model.parametersBillions,
+          "default_steps": model.defaultSteps,
+          "default_guidance": model.defaultGuidance,
+          "supports_guidance": model.supportsGuidance,
+          "supports_lora": model.supportsLoRA,
+          "supports_controlnet": model.supportsControlNet,
+          "supports_img2img": model.supportsImg2Img,
+          "default_resolution": "\(model.defaultWidth)x\(model.defaultHeight)",
+          "estimated_vram_gb": model.estimatedVRAM_GB,
+          "huggingface_id": model.huggingFaceId,
+        ] as [String: Any]
+      }
+      if let data = try? JSONSerialization.data(
+        withJSONObject: ["models": models, "count": models.count]
+      ) {
+        return .json(.rawJSON(status: 200, data: data))
+      }
+      return .error(.error(status: 500, message: "Failed to serialize models"))
+
+    case ("GET", "/v1/styles"):
+      let styles = ComfyBoxStylePresets.toJSON()
+      if let data = try? JSONSerialization.data(
+        withJSONObject: ["styles": styles, "count": styles.count]
+      ) {
+        return .json(.rawJSON(status: 200, data: data))
+      }
+      return .error(.error(status: 500, message: "Failed to serialize styles"))
+
     default:
       if ["/v1/generate", "/v1/lora/swap", "/v1/shutdown", "/health"].contains(request.path) {
         return .error(.error(status: 405, message: "Method not allowed"))


### PR DESCRIPTION
## Summary
- **Model registry** — 10 models across 4 families (Z-Image, Flux 2 Klein, FIBO, SeedVR2) with full metadata: HF IDs, capability flags, VRAM estimates, defaults
- **Style presets** — 15 styles across 5 categories (Photography, Illustration, Painting, Concept, Utility) with prompt engineering, tuned params, recommended models
- **WarmServer endpoints** — `GET /v1/models` and `GET /v1/styles` serve registry data as JSON
- **ComfyBridgeModelInfo** now delegates to the registry instead of hardcoded values

## Models
| Family | Models | Notes |
|--------|--------|-------|
| Z-Image | turbo bf16/q8/q4, base bf16 | 6B DiT, Lumina2 arch |
| Flux 2 Klein | 4B, 9B, base 4B, base 9B | Compact distilled |
| FIBO | 8B bf16 | DimFusion, Wan 2.2 VAE |
| SeedVR2 | 3B upscaler | 2× resolution |

## Test plan
- [ ] Build on Mac (blocked until Mac comes back online)
- [ ] `curl localhost:7862/v1/models` returns all 10 models
- [ ] `curl localhost:7862/v1/styles` returns all 15 styles
- [ ] `curl localhost:7862/api/etn/model_info/diffusion_models` returns expanded model list
- [ ] Krita AI Diffusion plugin connects and sees models in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)