### PR TITLE
feat(lora): Klein 9B LoRA support for Flux2 pipeline

### DIFF
--- a/Sources/ZImage/Flux2/Flux2Pipeline.swift
+++ b/Sources/ZImage/Flux2/Flux2Pipeline.swift
@@ -125,6 +125,12 @@ public final class Flux2Pipeline {
   private var modelSnapshot: URL?
   private var isLoaded: Bool = false
 
+  /// Currently applied LoRA configurations (for hot-swap tracking).
+  private var appliedLoRAs: [LoRAConfiguration] = []
+
+  /// Public accessor for currently loaded LoRA configurations.
+  public var loadedLoRAConfigs: [LoRAConfiguration] { appliedLoRAs }
+
   // Model configs for current loaded model
   private var transformerConfig: Flux2TransformerConfig?
   private var textEncoderConfig: Qwen3TextEncoderConfiguration?
@@ -159,6 +165,7 @@ public final class Flux2Pipeline {
     textEncoderConfig = nil
     _isBaseModel = false
     isLoaded = false
+    appliedLoRAs = []
     GPU.clearCache()
     logger.info("Flux 2 model unloaded")
   }
@@ -206,6 +213,50 @@ public final class Flux2Pipeline {
     progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 1, totalSteps: 1))
     let modelKind = isBase ? "base (non-distilled)" : "distilled"
     logger.info("Flux 2 Klein model loaded from \(snapshot.path) [\(modelKind)]")
+  }
+
+  // MARK: - LoRA Support
+
+  /// Load and apply LoRAs to the Flux 2 transformer.
+  ///
+  /// Clears any previously applied LoRAs before applying the new set.
+  /// Uses ``LoRAWeightLoader/loadForFlux2(from:)`` which handles the
+  /// Flux 2 key mapping (including fused QKV splitting).
+  ///
+  /// - Parameter configs: LoRA configurations to apply. Pass an empty array to clear all LoRAs.
+  public func loadLoRAs(_ configs: [LoRAConfiguration]) async throws {
+    guard let components = components else {
+      throw Flux2PipelineError.modelNotLoaded
+    }
+
+    // Clear existing dynamic LoRAs
+    if !appliedLoRAs.isEmpty {
+      LoRAApplicator.clearDynamicLoRA(from: components.transformer, logger: logger)
+      appliedLoRAs = []
+      logger.info("Cleared existing LoRAs from Flux 2 transformer")
+    }
+
+    guard !configs.isEmpty else {
+      return
+    }
+
+    // Load and apply each LoRA
+    for config in configs {
+      let url = try await LoRAWeightLoader.resolveSource(config.source)
+      let weights = try LoRAWeightLoader.loadForFlux2(from: url)
+
+      logger.info("Applying Flux 2 LoRA: \(config.source.displayName) (rank=\(weights.rank), layers=\(weights.layerCount), scale=\(config.scale))")
+
+      LoRAApplicator.applyDynamically(
+        to: components.transformer,
+        loraWeights: weights,
+        scale: config.scale,
+        logger: logger
+      )
+    }
+
+    appliedLoRAs = configs
+    logger.info("Flux 2 LoRA loading complete: \(configs.count) LoRA(s) applied")
   }
 
   /// Generate an image and save it to disk.

--- a/Sources/ZImage/Flux2/Weights/Flux2LoRAMapping.swift
+++ b/Sources/ZImage/Flux2/Weights/Flux2LoRAMapping.swift
@@ -1,23 +1,269 @@
 // Flux2LoRAMapping.swift — LoRA weight mapping for Flux 2 Klein
 //
-// Deferred to post-integration PR. The full Flux 2 LoRA mapping
-// (from mflux flux2_lora_mapping.py, ~915 lines) covers:
-//   - Global targets (x_embedder, context_embedder)
-//   - Double-stream block targets (attn Q/K/V/out, FF in/out, context FF)
-//   - Single-stream block targets (fused QKV+MLP proj, out)
-//   - BFL/ComfyUI-style naming conventions (qkv split patterns)
-//
-// This will be implemented when LoRA support is integrated into
-// the Flux 2 pipeline.
+// Maps CivitAI / BFL / Kohya LoRA adapter keys to Flux2Transformer module paths.
+// Handles fused QKV keys (split into separate Q/K/V targets) and
+// Kohya-style underscore naming conventions.
 
 import Foundation
 
-/// Placeholder for Flux 2 Klein LoRA weight mapping.
+/// Maps LoRA adapter base keys to Flux2Transformer Swift module paths.
 ///
-/// The full implementation maps LoRA adapter weights (lora_A/lora_B pairs)
-/// from various naming conventions (diffusers, BFL, ComfyUI, kohya) to
-/// the Flux2Transformer module paths.
+/// LoRA adapters for Klein 9B use various naming conventions for their keys.
+/// After stripping the `diffusion_model.`/`base_model.model.`/`lora_unet_` prefix
+/// and the `lora_A`/`lora_B` suffix, the remaining "base key" is mapped here.
+///
+/// ## Fused QKV Keys
+///
+/// Some LoRAs store Q/K/V as a single fused tensor (e.g., `double_blocks.0.img_attn.qkv`).
+/// These are mapped to a ``QKVSplitTarget`` with three separate module paths.
+/// The caller must split `lora_B` along dim 0 into three equal parts.
+///
+/// ## Key Conventions Handled
+///
+/// - **BFL/diffusers dot notation**: `double_blocks.0.img_attn.qkv`
+/// - **Kohya underscore notation**: `lora_unet_double_blocks_0_img_attn_qkv`
+///   (converted to dot notation before mapping)
 public enum Flux2LoRAMapping {
-  // Deferred to post-integration PR.
-  // See mflux flux2_lora_mapping.py for the full mapping specification.
+
+  /// A fused QKV target that requires splitting lora_B into 3 parts.
+  public struct QKVSplitTarget {
+    public let qPath: String
+    public let kPath: String
+    public let vPath: String
+  }
+
+  /// Result of mapping a LoRA base key.
+  public enum MappingResult {
+    /// Direct 1:1 mapping — use the LoRA pair as-is.
+    case direct(String)
+    /// Fused QKV — caller must split lora_B into 3 parts along dim 0.
+    case qkvSplit(QKVSplitTarget)
+    /// Key not recognized.
+    case unmapped
+  }
+
+  /// Prefixes stripped before mapping (order matters — longest/most specific first).
+  private static let prefixesToStrip = [
+    "base_model.model.diffusion_model.",
+    "base_model.model.",
+    "diffusion_model.",
+    "lora_unet_",
+    "transformer.",
+  ]
+
+  /// Convert a Kohya-style underscore key to dot notation.
+  ///
+  /// Kohya keys look like `double_blocks_0_img_attn_qkv`. The tricky part is
+  /// distinguishing word boundaries from numeric indices. Strategy:
+  /// - Known compound tokens are preserved (img_attn, img_mlp, txt_attn, txt_mlp)
+  /// - Numeric components become `.N`
+  /// - Remaining underscores become dots
+  private static func kohyaToDot(_ key: String) -> String {
+    // Replace known compound tokens first to protect them
+    var result = key
+    let compounds = [
+      ("img_attn", "img_attn"),
+      ("txt_attn", "txt_attn"),
+      ("img_mlp", "img_mlp"),
+      ("txt_mlp", "txt_mlp"),
+      ("single_blocks", "single_blocks"),
+      ("double_blocks", "double_blocks"),
+      ("to_qkv_mlp_proj", "to_qkv_mlp_proj"),
+      ("add_q_proj", "add_q_proj"),
+      ("add_k_proj", "add_k_proj"),
+      ("add_v_proj", "add_v_proj"),
+      ("to_add_out", "to_add_out"),
+      ("linear_in", "linear_in"),
+      ("linear_out", "linear_out"),
+      ("to_out", "to_out"),
+      ("to_q", "to_q"),
+      ("to_k", "to_k"),
+      ("to_v", "to_v"),
+    ]
+
+    // Simple approach: split on underscore, recombine intelligently
+    // For Kohya keys: lora_unet_double_blocks_0_img_attn_qkv
+    // After prefix strip: double_blocks_0_img_attn_qkv
+    // Target: double_blocks.0.img_attn.qkv
+
+    // Replace block type + index pattern
+    let blockPattern = try! NSRegularExpression(pattern: "(double_blocks|single_blocks)_(\\d+)_(.+)")
+    let range = NSRange(result.startIndex..., in: result)
+    if let match = blockPattern.firstMatch(in: result, range: range) {
+      let blockType = String(result[Range(match.range(at: 1), in: result)!])
+      let index = String(result[Range(match.range(at: 2), in: result)!])
+      let remainder = String(result[Range(match.range(at: 3), in: result)!])
+
+      // Map remainder underscore components
+      let mappedRemainder = mapKohyaRemainder(remainder)
+      result = "\(blockType).\(index).\(mappedRemainder)"
+    }
+
+    return result
+  }
+
+  /// Map the remainder portion of a Kohya key (after block type and index).
+  private static func mapKohyaRemainder(_ remainder: String) -> String {
+    // Known remainder patterns (underscore -> dot-separated)
+    let patterns: [(String, String)] = [
+      ("img_attn_qkv", "img_attn.qkv"),
+      ("img_attn_proj", "img_attn.proj"),
+      ("txt_attn_qkv", "txt_attn.qkv"),
+      ("txt_attn_proj", "txt_attn.proj"),
+      ("img_mlp_0", "img_mlp.0"),
+      ("img_mlp_2", "img_mlp.2"),
+      ("txt_mlp_0", "txt_mlp.0"),
+      ("txt_mlp_2", "txt_mlp.2"),
+      ("linear1", "linear1"),
+      ("linear2", "linear2"),
+    ]
+
+    for (pattern, replacement) in patterns {
+      if remainder == pattern {
+        return replacement
+      }
+    }
+
+    // Fallback: replace underscores with dots
+    return remainder.replacingOccurrences(of: "_", with: ".")
+  }
+
+  /// Strip known prefixes from a raw LoRA key.
+  public static func stripPrefix(_ rawKey: String) -> String {
+    var key = rawKey
+    for prefix in prefixesToStrip {
+      if key.hasPrefix(prefix) {
+        key = String(key.dropFirst(prefix.count))
+        break
+      }
+    }
+    return key
+  }
+
+  /// Map a LoRA base key (after prefix/suffix stripping) to Flux2Transformer module path(s).
+  ///
+  /// - Parameter baseKey: The base key with prefixes stripped and lora_A/lora_B suffix removed.
+  /// - Returns: The mapping result indicating direct, QKV split, or unmapped.
+  public static func map(_ baseKey: String) -> MappingResult {
+    var key = baseKey
+
+    // Handle Kohya underscore notation: if key has underscores but no dots,
+    // convert to dot notation first.
+    if key.contains("_") && !key.contains(".") {
+      key = kohyaToDot(key)
+    }
+
+    // Also strip any remaining known prefixes (in case they weren't caught earlier)
+    key = stripPrefix(key)
+
+    // --- Double blocks ---
+    // Pattern: double_blocks.{i}.{component}
+    if key.hasPrefix("double_blocks.") {
+      return mapDoubleBlock(key)
+    }
+
+    // --- Single blocks ---
+    // Pattern: single_blocks.{i}.{component}
+    if key.hasPrefix("single_blocks.") {
+      return mapSingleBlock(key)
+    }
+
+    return .unmapped
+  }
+
+  // MARK: - Double Block Mapping
+
+  private static func mapDoubleBlock(_ key: String) -> MappingResult {
+    // Extract: double_blocks.{i}.{rest}
+    let parts = key.split(separator: ".", maxSplits: 3)
+    guard parts.count >= 3,
+          let blockIndex = Int(parts[1]) else {
+      return .unmapped
+    }
+    let rest = parts.count > 2 ? parts[2...].joined(separator: ".") : ""
+    let prefix = "transformer_blocks.\(blockIndex)"
+
+    switch rest {
+    // --- Image attention (fused QKV) ---
+    case "img_attn.qkv":
+      return .qkvSplit(QKVSplitTarget(
+        qPath: "\(prefix).attn.to_q",
+        kPath: "\(prefix).attn.to_k",
+        vPath: "\(prefix).attn.to_v"
+      ))
+
+    // --- Image attention (already split) ---
+    case "img_attn.to_q", "attn.to_q":
+      return .direct("\(prefix).attn.to_q")
+    case "img_attn.to_k", "attn.to_k":
+      return .direct("\(prefix).attn.to_k")
+    case "img_attn.to_v", "attn.to_v":
+      return .direct("\(prefix).attn.to_v")
+
+    // --- Image attention output ---
+    case "img_attn.proj", "attn.to_out":
+      return .direct("\(prefix).attn.to_out")
+
+    // --- Text attention (fused QKV) ---
+    case "txt_attn.qkv":
+      return .qkvSplit(QKVSplitTarget(
+        qPath: "\(prefix).attn.add_q_proj",
+        kPath: "\(prefix).attn.add_k_proj",
+        vPath: "\(prefix).attn.add_v_proj"
+      ))
+
+    // --- Text attention (already split) ---
+    case "txt_attn.to_q", "attn.add_q_proj":
+      return .direct("\(prefix).attn.add_q_proj")
+    case "txt_attn.to_k", "attn.add_k_proj":
+      return .direct("\(prefix).attn.add_k_proj")
+    case "txt_attn.to_v", "attn.add_v_proj":
+      return .direct("\(prefix).attn.add_v_proj")
+
+    // --- Text attention output ---
+    case "txt_attn.proj", "attn.to_add_out":
+      return .direct("\(prefix).attn.to_add_out")
+
+    // --- Image feed-forward ---
+    case "img_mlp.0", "ff.linear_in":
+      return .direct("\(prefix).ff.linear_in")
+    case "img_mlp.2", "ff.linear_out":
+      return .direct("\(prefix).ff.linear_out")
+
+    // --- Text feed-forward ---
+    case "txt_mlp.0", "ff_context.linear_in":
+      return .direct("\(prefix).ff_context.linear_in")
+    case "txt_mlp.2", "ff_context.linear_out":
+      return .direct("\(prefix).ff_context.linear_out")
+
+    default:
+      return .unmapped
+    }
+  }
+
+  // MARK: - Single Block Mapping
+
+  private static func mapSingleBlock(_ key: String) -> MappingResult {
+    // Extract: single_blocks.{i}.{rest}
+    let parts = key.split(separator: ".", maxSplits: 3)
+    guard parts.count >= 3,
+          let blockIndex = Int(parts[1]) else {
+      return .unmapped
+    }
+    let rest = parts.count > 2 ? parts[2...].joined(separator: ".") : ""
+    let prefix = "single_transformer_blocks.\(blockIndex)"
+
+    switch rest {
+    // --- Fused QKV+MLP projection (direct, no split needed) ---
+    case "linear1", "attn.to_qkv_mlp_proj":
+      return .direct("\(prefix).attn.to_qkv_mlp_proj")
+
+    // --- Output projection ---
+    case "linear2", "attn.to_out":
+      return .direct("\(prefix).attn.to_out")
+
+    default:
+      return .unmapped
+    }
+  }
 }

--- a/Sources/ZImage/LoRA/LoRAWeightLoader.swift
+++ b/Sources/ZImage/LoRA/LoRAWeightLoader.swift
@@ -291,6 +291,83 @@ public final class LoRAWeightLoader {
         return results.sorted(by: { $0.path < $1.path })
     }
 
+    // MARK: - Flux 2 LoRA Loading
+
+    /// Load a safetensors LoRA file and map keys for the Flux2Transformer.
+    ///
+    /// Uses ``Flux2LoRAMapping`` instead of ``LoRAKeyMapper`` to map adapter keys
+    /// to Flux2Transformer module paths. For fused QKV keys, lora_B is split into
+    /// 3 equal parts along dim 0, creating separate Q/K/V entries.
+    ///
+    /// - Parameter url: Path to a `.safetensors` file.
+    /// - Returns: LoRAWeights with keys matching Flux2Transformer module paths.
+    public static func loadForFlux2(from url: URL) throws -> LoRAWeights {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw LoRAError.fileNotFound(url.path)
+        }
+
+        let reader = try SafeTensorsReader(fileURL: url)
+        let keys = reader.tensorNames
+
+        var processedKeys = Set<String>()
+        var loraPairs: [String: (down: MLXArray, up: MLXArray)] = [:]
+
+        for key in keys {
+            if processedKeys.contains(key) { continue }
+
+            // Find lora_A/lora_B or lora_down/lora_up pair
+            guard let (downKey, upKey, baseKey) = resolveKeyPair(key) else { continue }
+            guard reader.contains(downKey), reader.contains(upKey) else { continue }
+
+            let downWeight = try reader.tensor(named: downKey)  // lora_A
+            let upWeight = try reader.tensor(named: upKey)      // lora_B
+
+            processedKeys.insert(downKey)
+            processedKeys.insert(upKey)
+
+            // Map using Flux2LoRAMapping instead of LoRAKeyMapper
+            let mapping = Flux2LoRAMapping.map(baseKey)
+
+            switch mapping {
+            case .direct(let targetPath):
+                loraPairs[targetPath] = (down: downWeight, up: upWeight)
+
+            case .qkvSplit(let target):
+                // Split lora_B (up) into 3 parts along dim 0
+                guard upWeight.ndim == 2 else { continue }
+                let totalOut = upWeight.dim(0)
+                guard totalOut % 3 == 0 else { continue }
+                let splitSize = totalOut / 3
+
+                let qUp = upWeight[0..<splitSize, 0...]
+                let kUp = upWeight[splitSize..<(2 * splitSize), 0...]
+                let vUp = upWeight[(2 * splitSize)..<(3 * splitSize), 0...]
+
+                // lora_A (down): use the full tensor for all 3 projections.
+                // The rank dimension is shared across Q/K/V.
+                loraPairs[target.qPath] = (down: downWeight, up: qUp)
+                loraPairs[target.kPath] = (down: downWeight, up: kUp)
+                loraPairs[target.vPath] = (down: downWeight, up: vUp)
+
+            case .unmapped:
+                // Skip keys we don't recognize
+                continue
+            }
+        }
+
+        guard !loraPairs.isEmpty else {
+            throw LoRAError.invalidFormat(
+                "No valid Flux 2 LoRA weight pairs found in \(url.lastPathComponent). " +
+                "Expected keys matching double_blocks/single_blocks patterns."
+            )
+        }
+
+        let rank = inferRank(from: loraPairs)
+        let alpha = loadAlpha(from: url.deletingLastPathComponent())
+
+        return LoRAWeights(weights: loraPairs, rank: rank, alpha: alpha)
+    }
+
     private static func mapLoKrModuleKey(_ key: String) -> (moduleKey: String, suffix: LoKrSuffix)? {
         let suffix: LoKrSuffix
         if key.hasSuffix(LoKrSuffix.w1.rawValue) {

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -266,25 +266,20 @@ public final class WarmServer {
     // --- Phase 4: Dynamic LoRA swap ---
     // If the workflow contains LoraLoader nodes, swap LoRAs before generating.
     // The coordinator serializes operations, so swap completes before generate starts.
-    // LoRA swap is not supported for Flux 2 models.
     if !request.loras.isEmpty {
-      if await coordinator.modelFamily == .flux2 {
-        logger.warning("WarmServer: ignoring LoRA swap for Flux 2 model (not supported)")
-      } else {
-        let loraEntries = request.loras.map { lora -> LoRAEntry in
-          // Resolve bare filenames to full paths in the LoRA directory.
-          let resolvedPath: String
-          if lora.name.contains("/") || lora.name.hasPrefix("~") {
-            resolvedPath = lora.name
-          } else {
-            resolvedPath = Self.loraDirectoryPath + "/" + lora.name
-          }
-          return LoRAEntry(path: resolvedPath, scale: lora.scale)
+      let loraEntries = request.loras.map { lora -> LoRAEntry in
+        // Resolve bare filenames to full paths in the LoRA directory.
+        let resolvedPath: String
+        if lora.name.contains("/") || lora.name.hasPrefix("~") {
+          resolvedPath = lora.name
+        } else {
+          resolvedPath = Self.loraDirectoryPath + "/" + lora.name
         }
-        let swapPayload = LoRASwapPayload(loras: loraEntries)
-        let swapResult = try await coordinator.enqueueSwap(swapPayload)
-        logger.info("WarmServer: bridge LoRA swap complete — \(swapResult.loraCount) LoRA(s) active")
+        return LoRAEntry(path: resolvedPath, scale: lora.scale)
       }
+      let swapPayload = LoRASwapPayload(loras: loraEntries)
+      let swapResult = try await coordinator.enqueueSwap(swapPayload)
+      logger.info("WarmServer: bridge LoRA swap complete — \(swapResult.loraCount) LoRA(s) active")
     }
 
     // Derive dimensions from inpaint image if parser returned 0x0
@@ -1105,15 +1100,28 @@ private actor WarmServerCoordinator {
   }
 
   private func runSwap(_ payload: LoRASwapPayload, continuation: ContinuationBox<LoRASwapResponse>) async {
-    if currentModelFamily == .flux2 || currentModelFamily == .fibo {
+    if currentModelFamily == .fibo {
       continuation.resume(throwing: WarmServerError.loraSwapNotSupported)
       return
     }
 
     do {
       let newLoRAs = try payload.makeConfigurations()
-      try await pipeline.swapLoRAs(newLoRAs)
-      activeLoRAs = newLoRAs
+
+      if currentModelFamily == .flux2 {
+        // Flux 2 LoRA swap via Flux2Pipeline.loadLoRAs()
+        guard let f2 = flux2Pipeline else {
+          continuation.resume(throwing: WarmServerError.flux2NotLoaded)
+          return
+        }
+        try await f2.loadLoRAs(newLoRAs)
+        activeLoRAs = newLoRAs
+      } else {
+        // Flux 1 LoRA swap via ZImagePipeline.swapLoRAs()
+        try await pipeline.swapLoRAs(newLoRAs)
+        activeLoRAs = newLoRAs
+      }
+
       lastError = nil
       continuation.resume(
         returning: LoRASwapResponse(
@@ -1123,7 +1131,11 @@ private actor WarmServerCoordinator {
         )
       )
     } catch {
-      activeLoRAs = pipeline.loadedLoRAConfigs
+      if currentModelFamily == .flux2 {
+        activeLoRAs = flux2Pipeline?.loadedLoRAConfigs ?? []
+      } else {
+        activeLoRAs = pipeline.loadedLoRAConfigs
+      }
       lastError = error.localizedDescription
       continuation.resume(throwing: error)
     }

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -736,6 +736,12 @@ struct ZImageCLI {
             isBase: detected.isBaseModel
           )
 
+          // Load LoRAs for Flux 2
+          if !loraConfigs.isEmpty {
+            logger.info("Loading \(loraConfigs.count) LoRA(s) for Flux 2...")
+            try await flux2Pipeline.loadLoRAs(loraConfigs)
+          }
+
           // Validate guidance for distilled models
           if flux2Pipeline.isDistilled && guidance != 1.0 && guidance != ZImageModelMetadata.recommendedGuidanceScale {
             logger.warning("Guidance scale \(guidance) has no effect on distilled Klein models (forcing 1.0)")


### PR DESCRIPTION
## Summary

- Full Flux2LoRAMapping key mapper replacing the stub — handles BFL, diffusers, and Kohya naming conventions with fused QKV split (lora_B split into separate Q/K/V deltas)
- New `LoRAWeightLoader.loadForFlux2()` using Flux2-specific mapping instead of Z-Image LoRAKeyMapper
- `Flux2Pipeline.loadLoRAs()` for dynamic LoRA application with hot-swap (clear + reapply)
- WarmServer Flux2 LoRA swap enabled — removed the "not supported" guard
- CLI `--lora` flag wired into Flux2 generation path

## Tested

| LoRA | Rank | Layers | Status |
|------|------|--------|--------|
| nsfw-no-face-change-v2 | 32 | 144/144 | ✅ |
| sexgod-nudity-helper | 128 | 144/144 | ✅ |
| chest slider | 8 | 144/144 | ✅ |
| Multi-LoRA stack (SexGod + chest) | mixed | 144 each | ✅ |

## Not included (P1)

- LoKr decomposition for Flux2 (needed for SNOFS v1.3)
- Per-LoRA scale annotation metadata

## Test plan

- [x] Single LoRA render (nsfw-no-face-change-v2)
- [x] Multi-LoRA stacking (sexgod + sliders)
- [x] CLI path with --lora flag
- [ ] WarmServer hot-swap via image service (manual test)
- [ ] Anatomy comparison renders (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
