### PR TITLE
P0: Fix DDIM scheduler test — use later timestep to avoid alpha-threshold fallback

### DIFF
--- a/Tests/ZImageTests/Scheduler/DDIMSchedulerTests.swift
+++ b/Tests/ZImageTests/Scheduler/DDIMSchedulerTests.swift
@@ -83,10 +83,10 @@ final class DDIMSchedulerTests: XCTestCase {
     var ddimStoch = Self.makeScheduler(steps: 9, eta: 1.0, seed: seed)
 
     let resultDet = ddimDet.step(
-      modelOutput: modelOutput, timestepIndex: 0, sample: sample
+      modelOutput: modelOutput, timestepIndex: 4, sample: sample
     )
     let resultStoch = ddimStoch.step(
-      modelOutput: modelOutput, timestepIndex: 0, sample: sample
+      modelOutput: modelOutput, timestepIndex: 4, sample: sample
     )
 
     let detF32 = resultDet.asType(.float32)
@@ -115,10 +115,10 @@ final class DDIMSchedulerTests: XCTestCase {
     var ddim2 = Self.makeScheduler(steps: 9, eta: 1.0, seed: seed)
 
     let result1 = ddim1.step(
-      modelOutput: modelOutput, timestepIndex: 0, sample: sample
+      modelOutput: modelOutput, timestepIndex: 4, sample: sample
     )
     let result2 = ddim2.step(
-      modelOutput: modelOutput, timestepIndex: 0, sample: sample
+      modelOutput: modelOutput, timestepIndex: 4, sample: sample
     )
 
     let r1 = result1.asType(.float32)


### PR DESCRIPTION
## Summary
- Fix `DDIMSchedulerTests.testEtaOneDiffersFromEtaZero` — was testing at timestepIndex 0 where alpha-threshold Euler fallback bypasses eta logic
- Changed to timestepIndex 4 where eta actually affects output
- Also updated `testReproducibleWithSeed` for consistency

Closes #58

## Verification
275 tests, 2 skipped, 0 failures.

🤖 Codex — dispatched by Bree