### PR TITLE
P2: README defaults, CLI parser, SafeTensors hardening, PNG validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ ZImageCLI -h
 | `-W, --width` | Output width | 1024 |
 | `-H, --height` | Output height | 1024 |
 | `-s, --steps` | Inference steps | 9 |
-| `-g, --guidance` | Guidance scale | 3.0 |
+| `-g, --guidance` | Guidance scale | 0.0 |
 | `--seed` | Random seed | random |
 | `-o, --output` | Output path | z-image.png |
 | `-m, --model` | Model path (dir or .safetensors) or HuggingFace ID | Tongyi-MAI/Z-Image-Turbo |
@@ -103,6 +103,8 @@ ZImageCLI -h
 | `--no-progress` | Disable progress output | false |
 | `--svg` | Generate SVG vector output (requires vtracer) | false |
 | `--svg-preset` | SVG conversion preset | default |
+
+Z-Image-Turbo defaults to guidance `0.0`. Other model families use different recommended guidance defaults.
 
 ### SVG Presets
 
@@ -275,7 +277,7 @@ ZImageCLI control \
 | `-W, --width` | Output width | 1024 |
 | `-H, --height` | Output height | 1024 |
 | `-s, --steps` | Inference steps | 9 |
-| `-g, --guidance` | Guidance scale | 3.0 |
+| `-g, --guidance` | Guidance scale | 0.0 |
 | `--seed` | Random seed | random |
 | `-o, --output` | Output path | z-image-control.png |
 | `-m, --model` | Model path or HuggingFace ID | Tongyi-MAI/Z-Image-Turbo |

--- a/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
@@ -122,6 +122,8 @@ public struct Img2ImgRequest: Sendable {
 // MARK: - White Mask Generation
 
 private enum Img2ImgUtilities {
+  private static let pngSignature: [UInt8] = [137, 80, 78, 71, 13, 10, 26, 10]
+
   enum Img2ImgError: Error, CustomStringConvertible {
     case sourceImageNotFound(String)
     case sourceImageLoadFailed(String)
@@ -177,7 +179,7 @@ private enum Img2ImgUtilities {
 
   /// Read the dimensions of a PNG file from its IHDR chunk.
   static func pngDimensions(from data: Data) -> (width: Int, height: Int)? {
-    guard data.count >= 24 else { return nil }
+    guard data.count >= 24, data.prefix(pngSignature.count).elementsEqual(pngSignature) else { return nil }
     let w = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
     let h = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
     guard w > 0 && h > 0 && w < 65536 && h < 65536 else { return nil }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -41,6 +41,8 @@ enum WarmModelFamily: String, Sendable {
 }
 
 public final class WarmServer {
+  private static let pngSignature: [UInt8] = [137, 80, 78, 71, 13, 10, 26, 10]
+
   private let configuration: WarmServerConfiguration
   private let logger: Logger
   private let coordinator: WarmServerCoordinator
@@ -245,7 +247,7 @@ public final class WarmServer {
   /// Called by ComfyBridgeExecutor via the closure set in init.
   /// Read PNG dimensions from IHDR chunk (bytes 16-23 of a valid PNG).
   private func pngDimensions(from data: Data) -> (width: Int, height: Int)? {
-    guard data.count >= 24 else { return nil }
+    guard data.count >= 24, data.prefix(Self.pngSignature.count).elementsEqual(Self.pngSignature) else { return nil }
     let w = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
     let h = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
     return (w, h)

--- a/Sources/ZImage/Weights/SafeTensorsReader.swift
+++ b/Sources/ZImage/Weights/SafeTensorsReader.swift
@@ -25,6 +25,8 @@ public enum SafeTensorsReaderError: Error {
 }
 
 public final class SafeTensorsReader {
+  private static let maxHeaderLength = 100_000_000
+
   public let fileURL: URL
   private let mappedData: Data
   private let tensors: [String: SafeTensorMetadata]
@@ -38,16 +40,21 @@ public final class SafeTensorsReader {
       throw SafeTensorsReaderError.fileTooSmall(fileURL)
     }
 
-    let headerLength = mappedData.prefix(8).withUnsafeBytes { rawBuffer -> Int in
+    let rawHeaderLength = mappedData.prefix(8).withUnsafeBytes { rawBuffer -> UInt64 in
       let value = rawBuffer.load(as: UInt64.self)
-      return Int(UInt64(littleEndian: value))
+      return UInt64(littleEndian: value)
     }
 
-    let headerStart = 8
-    let headerEnd = headerStart + headerLength
-    guard headerEnd <= mappedData.count else {
+    guard rawHeaderLength < UInt64(Self.maxHeaderLength) else {
       throw SafeTensorsReaderError.invalidHeaderLength(fileURL)
     }
+
+    let headerLength = Int(rawHeaderLength)
+    let headerStart = 8
+    guard headerLength <= mappedData.count - headerStart else {
+      throw SafeTensorsReaderError.invalidHeaderLength(fileURL)
+    }
+    let headerEnd = headerStart + headerLength
 
     let headerData = mappedData.subdata(in: headerStart..<headerEnd)
     let headerJSON = try JSONSerialization.jsonObject(with: headerData, options: [])
@@ -60,6 +67,7 @@ public final class SafeTensorsReader {
     var metadataValues: [String: String] = [:]
 
     let dataStartOffset = headerEnd
+    let dataSectionByteCount = mappedData.count - dataStartOffset
 
     for (key, value) in headerDict {
       if key == "__metadata__" {
@@ -90,13 +98,7 @@ public final class SafeTensorsReader {
       }
 
       let shape: [Int] = try shapeAny.map { element in
-        if let number = element as? NSNumber {
-          return number.intValue
-        } else if let string = element as? String, let intValue = Int(string) {
-          return intValue
-        } else {
-          throw SafeTensorsReaderError.invalidShape(name: key)
-        }
+        try SafeTensorsReader.parseDimension(element, tensorName: key)
       }
 
       guard let offsetsAny = tensorInfo["data_offsets"] as? [Any], offsetsAny.count == 2 else {
@@ -106,18 +108,25 @@ public final class SafeTensorsReader {
       let startOffset = try SafeTensorsReader.parseOffset(offsetsAny[0], tensorName: key)
       let endOffset = try SafeTensorsReader.parseOffset(offsetsAny[1], tensorName: key)
 
-      guard endOffset >= startOffset else {
+      guard startOffset <= dataSectionByteCount,
+            endOffset >= startOffset,
+            endOffset <= dataSectionByteCount else {
         throw SafeTensorsReaderError.invalidOffsets(name: key)
       }
 
       let byteCount = endOffset - startOffset
-      let expectedBytes = SafeTensorsReader.expectedByteCount(shape: shape, dtype: dtype)
+      let expectedBytes = try SafeTensorsReader.expectedByteCount(shape: shape, dtype: dtype, tensorName: key)
       guard byteCount == expectedBytes else {
         throw SafeTensorsReaderError.invalidShape(name: key)
       }
 
-      let absoluteOffset = dataStartOffset + startOffset
-      guard absoluteOffset + byteCount <= mappedData.count else {
+      let absoluteOffsetResult = dataStartOffset.addingReportingOverflow(startOffset)
+      guard !absoluteOffsetResult.overflow else {
+        throw SafeTensorsReaderError.invalidOffsets(name: key)
+      }
+      let absoluteOffset = absoluteOffsetResult.partialValue
+      let absoluteEndResult = absoluteOffset.addingReportingOverflow(byteCount)
+      guard !absoluteEndResult.overflow, absoluteEndResult.partialValue <= mappedData.count else {
         throw SafeTensorsReaderError.invalidOffsets(name: key)
       }
 
@@ -195,18 +204,57 @@ public final class SafeTensorsReader {
   }
 
   private static func parseOffset(_ value: Any, tensorName: String) throws -> Int {
-    if let number = value as? NSNumber {
-      return number.intValue
+    guard let parsed = parseNonNegativeInteger(value) else {
+      throw SafeTensorsReaderError.invalidOffsets(name: tensorName)
     }
-    if let string = value as? String, let intValue = Int(string) {
-      return intValue
-    }
-    throw SafeTensorsReaderError.invalidOffsets(name: tensorName)
+    return parsed
   }
 
-  private static func expectedByteCount(shape: [Int], dtype: DType) -> Int {
-    let elements = shape.reduce(1, *)
-    return elements * dtype.size
+  private static func parseDimension(_ value: Any, tensorName: String) throws -> Int {
+    guard let parsed = parseNonNegativeInteger(value) else {
+      throw SafeTensorsReaderError.invalidShape(name: tensorName)
+    }
+    return parsed
+  }
+
+  private static func parseNonNegativeInteger(_ value: Any) -> Int? {
+    if let number = value as? NSNumber {
+      if CFGetTypeID(number) == CFBooleanGetTypeID() {
+        return nil
+      }
+      if let intValue = Int(number.stringValue), intValue >= 0 {
+        return intValue
+      }
+      let doubleValue = number.doubleValue
+      guard doubleValue.isFinite,
+            doubleValue >= 0,
+            doubleValue.rounded(.towardZero) == doubleValue,
+            doubleValue < Double(Int.max) else {
+        return nil
+      }
+      return Int(doubleValue)
+    }
+    if let string = value as? String, let intValue = Int(string), intValue >= 0 {
+      return intValue
+    }
+    return nil
+  }
+
+  private static func expectedByteCount(shape: [Int], dtype: DType, tensorName: String) throws -> Int {
+    var elements = 1
+    for dimension in shape {
+      let result = elements.multipliedReportingOverflow(by: dimension)
+      guard !result.overflow else {
+        throw SafeTensorsReaderError.invalidShape(name: tensorName)
+      }
+      elements = result.partialValue
+    }
+
+    let byteCount = elements.multipliedReportingOverflow(by: dtype.size)
+    guard !byteCount.overflow else {
+      throw SafeTensorsReaderError.invalidShape(name: tensorName)
+    }
+    return byteCount.partialValue
   }
 
   private static func mapDType(_ value: String) throws -> DType {

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -103,7 +103,7 @@ struct ZImageCLI {
       case "--guidance", "-g":
         guidance = floatValue(for: arg, iterator: &iterator, fallback: guidance)
       case "--seed":
-        if let s = UInt64(nextValue(for: arg, iterator: &iterator)) {
+        if let s = uint64Value(for: arg, iterator: &iterator) {
           seeds.append(s)
         }
       case "--output", "-o":
@@ -125,7 +125,7 @@ struct ZImageCLI {
       case "--lora-paths":
         loraEntries.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)))
       case "--lora-scales":
-        loraScaleOverrides.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)).compactMap(Float.init))
+        loraScaleOverrides.append(contentsOf: floatListValue(for: arg, iterator: &iterator, fallback: 1.0))
       case "--enhance", "-e":
         enhancePrompt = true
       case "--enhance-max-tokens":
@@ -138,14 +138,14 @@ struct ZImageCLI {
         let raw = nextValue(for: arg, iterator: &iterator)
         guard let kind = SchedulerKind(rawValue: raw) else {
           let valid = SchedulerKind.allCases.map(\.rawValue).joined(separator: ", ")
-          fatalError("Unknown scheduler '\(raw)'. Valid: \(valid)")
+          failArgumentParsing("Unknown scheduler '\(raw)'. Valid: \(valid)")
         }
         schedulerKind = kind
       case "--sigma-schedule":
         let raw = nextValue(for: arg, iterator: &iterator)
         guard let kind = SigmaScheduleKind(rawValue: raw) else {
           let valid = SigmaScheduleKind.allCases.map(\.rawValue).joined(separator: ", ")
-          fatalError("Unknown sigma schedule '\(raw)'. Valid: \(valid)")
+          failArgumentParsing("Unknown sigma schedule '\(raw)'. Valid: \(valid)")
         }
         sigmaSchedule = kind
       case "--eta":
@@ -157,7 +157,7 @@ struct ZImageCLI {
         case "yarn": dyPEMethod = .yarn
         case "none", "off": dyPEMethod = .none
         default:
-          fatalError("Unknown DyPE method '\(raw)'. Valid: ntk, yarn, none")
+          failArgumentParsing("Unknown DyPE method '\(raw)'. Valid: ntk, yarn, none")
         }
       case "--no-dype":
         dyPEDisabled = true
@@ -1329,7 +1329,7 @@ struct ZImageCLI {
       case "--lora-paths":
         loraEntries.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)))
       case "--lora-scales":
-        loraScaleOverrides.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)).compactMap(Float.init))
+        loraScaleOverrides.append(contentsOf: floatListValue(for: arg, iterator: &iterator, fallback: 1.0))
       case "--help", "-h":
         printServeUsage()
         return
@@ -1445,7 +1445,7 @@ struct ZImageCLI {
       case "--guidance", "-g":
         guidance = floatValue(for: arg, iterator: &iterator, fallback: guidance)
       case "--seed":
-        seed = UInt64(nextValue(for: arg, iterator: &iterator))
+        seed = uint64Value(for: arg, iterator: &iterator)
       case "--output", "-o":
         outputPath = nextValue(for: arg, iterator: &iterator)
       case "--model", "-m":
@@ -1463,21 +1463,21 @@ struct ZImageCLI {
       case "--lora-paths":
         loraEntries.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)))
       case "--lora-scales":
-        loraScaleOverrides.append(contentsOf: splitCommaSeparated(nextValue(for: arg, iterator: &iterator)).compactMap(Float.init))
+        loraScaleOverrides.append(contentsOf: floatListValue(for: arg, iterator: &iterator, fallback: 1.0))
       case "--no-progress":
         noProgress = true
       case "--scheduler", "--sampler":
         let raw = nextValue(for: arg, iterator: &iterator)
         guard let kind = SchedulerKind(rawValue: raw) else {
           let valid = SchedulerKind.allCases.map(\.rawValue).joined(separator: ", ")
-          fatalError("Unknown scheduler '\(raw)'. Valid: \(valid)")
+          failArgumentParsing("Unknown scheduler '\(raw)'. Valid: \(valid)")
         }
         schedulerKind = kind
       case "--sigma-schedule":
         let raw = nextValue(for: arg, iterator: &iterator)
         guard let kind = SigmaScheduleKind(rawValue: raw) else {
           let valid = SigmaScheduleKind.allCases.map(\.rawValue).joined(separator: ", ")
-          fatalError("Unknown sigma schedule '\(raw)'. Valid: \(valid)")
+          failArgumentParsing("Unknown sigma schedule '\(raw)'. Valid: \(valid)")
         }
         sigmaSchedule = kind
       case "--eta":
@@ -1677,9 +1677,18 @@ struct ZImageCLI {
 
   private static func nextValue(for arg: String, iterator: inout IndexingIterator<[String]>) -> String {
     guard let value = iterator.next() else {
-      fatalError("Expected value after \(arg)")
+      failArgumentParsing("Expected value after \(arg)")
     }
     return value
+  }
+
+  private static func failArgumentParsing(_ message: String) -> Never {
+    fputs("Error: \(message)\n", stderr)
+    exit(1)
+  }
+
+  private static func warnArgumentParsing(_ message: String) {
+    fputs("Warning: \(message)\n", stderr)
   }
 
   private static func splitCommaSeparated(_ value: String) -> [String] {
@@ -1742,12 +1751,53 @@ struct ZImageCLI {
   }
 
   private static func intValue(for arg: String, iterator: inout IndexingIterator<[String]>, minimum: Int, fallback: Int) -> Int {
-    guard let value = Int(nextValue(for: arg, iterator: &iterator)) else { return fallback }
-    return max(minimum, value)
+    let raw = nextValue(for: arg, iterator: &iterator)
+    guard let value = Int(raw) else {
+      warnArgumentParsing("Invalid value '\(raw)' for \(arg); using \(fallback).")
+      return fallback
+    }
+    if value < minimum {
+      warnArgumentParsing("Invalid value '\(raw)' for \(arg); using minimum \(minimum).")
+      return minimum
+    }
+    return value
   }
 
   private static func floatValue(for arg: String, iterator: inout IndexingIterator<[String]>, fallback: Float) -> Float {
-    Float(nextValue(for: arg, iterator: &iterator)) ?? fallback
+    let raw = nextValue(for: arg, iterator: &iterator)
+    guard let value = Float(raw), value.isFinite else {
+      warnArgumentParsing("Invalid value '\(raw)' for \(arg); using \(fallback).")
+      return fallback
+    }
+    return value
+  }
+
+  private static func floatListValue(for arg: String, iterator: inout IndexingIterator<[String]>, fallback: Float) -> [Float] {
+    splitCommaSeparated(nextValue(for: arg, iterator: &iterator)).map { raw in
+      guard let value = Float(raw), value.isFinite else {
+        warnArgumentParsing("Invalid value '\(raw)' for \(arg); using \(fallback).")
+        return fallback
+      }
+      return value
+    }
+  }
+
+  private static func uint64Value(for arg: String, iterator: inout IndexingIterator<[String]>) -> UInt64? {
+    let raw = nextValue(for: arg, iterator: &iterator)
+    guard let value = UInt64(raw) else {
+      warnArgumentParsing("Invalid value '\(raw)' for \(arg); ignoring it.")
+      return nil
+    }
+    return value
+  }
+
+  private static func optionalIntValue(for arg: String, iterator: inout IndexingIterator<[String]>) -> Int? {
+    let raw = nextValue(for: arg, iterator: &iterator)
+    guard let value = Int(raw) else {
+      warnArgumentParsing("Invalid value '\(raw)' for \(arg); ignoring it.")
+      return nil
+    }
+    return value
   }
 
   // MARK: - Upscale Subcommand
@@ -1774,7 +1824,7 @@ struct ZImageCLI {
       case "--steps":
         steps = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: steps)
       case "--seed":
-        if let s = Int(nextValue(for: arg, iterator: &iterator)) {
+        if let s = optionalIntValue(for: arg, iterator: &iterator) {
           seed = s
         }
       case "--weights", "-w":

--- a/Tests/ZImageTests/Weights/SafeTensorsReaderTests.swift
+++ b/Tests/ZImageTests/Weights/SafeTensorsReaderTests.swift
@@ -207,6 +207,110 @@ final class SafeTensorsReaderTests: XCTestCase {
     }
   }
 
+  func testHeaderLengthAtCapThrowsInvalidHeaderLength() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("large_header_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    var data = Data()
+    var headerLength = UInt64(100_000_000).littleEndian
+    withUnsafeBytes(of: &headerLength) { data.append(contentsOf: $0) }
+    try data.write(to: fileURL)
+
+    XCTAssertThrowsError(try SafeTensorsReader(fileURL: fileURL)) { error in
+      if case SafeTensorsReaderError.invalidHeaderLength = error {
+        // Expected
+      } else {
+        XCTFail("Expected invalidHeaderLength error, got \(error)")
+      }
+    }
+  }
+
+  func testTensorOffsetsCannotExceedFileSize() throws {
+    let fileURL = try writeSyntheticSafeTensors(
+      header: [
+        "weight": [
+          "dtype": "U8",
+          "shape": [4],
+          "data_offsets": [0, 4]
+        ]
+      ],
+      payload: Data([1, 2])
+    )
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    XCTAssertThrowsError(try SafeTensorsReader(fileURL: fileURL)) { error in
+      if case SafeTensorsReaderError.invalidOffsets(let name) = error {
+        XCTAssertEqual(name, "weight")
+      } else {
+        XCTFail("Expected invalidOffsets error, got \(error)")
+      }
+    }
+  }
+
+  func testNegativeTensorOffsetThrowsInvalidOffsets() throws {
+    let fileURL = try writeSyntheticSafeTensors(
+      header: [
+        "weight": [
+          "dtype": "U8",
+          "shape": [0],
+          "data_offsets": [-1, 0]
+        ]
+      ]
+    )
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    XCTAssertThrowsError(try SafeTensorsReader(fileURL: fileURL)) { error in
+      if case SafeTensorsReaderError.invalidOffsets(let name) = error {
+        XCTAssertEqual(name, "weight")
+      } else {
+        XCTFail("Expected invalidOffsets error, got \(error)")
+      }
+    }
+  }
+
+  func testShapeProductOverflowThrowsInvalidShape() throws {
+    let fileURL = try writeSyntheticSafeTensors(
+      header: [
+        "weight": [
+          "dtype": "U8",
+          "shape": [Int.max, 2],
+          "data_offsets": [0, 0]
+        ]
+      ]
+    )
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    XCTAssertThrowsError(try SafeTensorsReader(fileURL: fileURL)) { error in
+      if case SafeTensorsReaderError.invalidShape(let name) = error {
+        XCTAssertEqual(name, "weight")
+      } else {
+        XCTFail("Expected invalidShape error, got \(error)")
+      }
+    }
+  }
+
+  func testNegativeShapeDimensionThrowsInvalidShape() throws {
+    let fileURL = try writeSyntheticSafeTensors(
+      header: [
+        "weight": [
+          "dtype": "U8",
+          "shape": [-1],
+          "data_offsets": [0, 0]
+        ]
+      ]
+    )
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    XCTAssertThrowsError(try SafeTensorsReader(fileURL: fileURL)) { error in
+      if case SafeTensorsReaderError.invalidShape(let name) = error {
+        XCTAssertEqual(name, "weight")
+      } else {
+        XCTFail("Expected invalidShape error, got \(error)")
+      }
+    }
+  }
+
   // MARK: - Integration Test with Real SafeTensors File
 
   func testCreateAndReadSafeTensors() throws {
@@ -374,5 +478,19 @@ final class SafeTensorsReaderTests: XCTestCase {
 
     // 4 floats * 4 bytes = 16 bytes
     XCTAssertEqual(data.count, 16)
+  }
+
+  private func writeSyntheticSafeTensors(header: [String: Any], payload: Data = Data()) throws -> URL {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("synthetic_\(UUID().uuidString).safetensors")
+    let headerData = try JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+
+    var data = Data()
+    var headerLength = UInt64(headerData.count).littleEndian
+    withUnsafeBytes(of: &headerLength) { data.append(contentsOf: $0) }
+    data.append(headerData)
+    data.append(payload)
+    try data.write(to: fileURL)
+    return fileURL
   }
 }


### PR DESCRIPTION
## Summary
- README guidance default corrected to 0.0 for Z-Image-Turbo (was 3.0)
- CLI parser: replaced fatalError with stderr + exit(1), numeric parse warnings
- SafeTensors reader: header size cap (100MB), offset/bounds validation, shape overflow/negative checks
- PNG dimension helpers: validate PNG signature before fixed-offset reads
- New SafeTensors tests: huge header, bad offsets, overflow shapes, negative dimensions

Closes #60

## Verification
SafeTensors tests pass. Full test suite has expected DDIM failure (fixed in separate PR).

🤖 Codex — dispatched by Bree