### PR TITLE
feat: Image levels post-processing for contrast adjustment

### DIFF
--- a/Sources/ZImage/Fibo/FiboPipeline.swift
+++ b/Sources/ZImage/Fibo/FiboPipeline.swift
@@ -34,6 +34,8 @@ public struct FiboGenerationRequest: Sendable {
   public var guidanceScale: Float
   public var seed: UInt64?
   public var outputPath: URL
+  public var levelsMin: Float
+  public var levelsMax: Float
 
   public init(
     prompt: String,
@@ -43,7 +45,9 @@ public struct FiboGenerationRequest: Sendable {
     steps: Int = 30,
     guidanceScale: Float = 4.0,
     seed: UInt64? = nil,
-    outputPath: URL = URL(fileURLWithPath: "fibo-output.png")
+    outputPath: URL = URL(fileURLWithPath: "fibo-output.png"),
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0
   ) {
     self.prompt = prompt
     self.negativePrompt = negativePrompt
@@ -53,6 +57,8 @@ public struct FiboGenerationRequest: Sendable {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
   }
 }
 
@@ -325,6 +331,9 @@ public final class FiboPipeline {
     // VAE output is in ~[-1, 1] range, denormalize to [0, 1]
     image = QwenImageIO.denormalizeFromDecoder(image)
     image = MLX.clip(image, min: 0, max: 1)
+    if ImageLevels.shouldApply(min: request.levelsMin, max: request.levelsMax) {
+      image = ImageLevels.apply(image: image, min: request.levelsMin, max: request.levelsMax)
+    }
     MLX.eval(image)
 
     GPU.clearCache()

--- a/Sources/ZImage/Flux2/Flux2Pipeline.swift
+++ b/Sources/ZImage/Flux2/Flux2Pipeline.swift
@@ -23,6 +23,8 @@ public struct Flux2GenerationRequest: Sendable {
   public var guidanceScale: Float
   public var seed: UInt64?
   public var outputPath: URL
+  public var levelsMin: Float
+  public var levelsMax: Float
   public var maxSequenceLength: Int
 
   /// Path to a source image for img2img. When set with denoise < 1.0,
@@ -43,6 +45,8 @@ public struct Flux2GenerationRequest: Sendable {
     guidanceScale: Float = 1.0,
     seed: UInt64? = nil,
     outputPath: URL = URL(fileURLWithPath: "flux2-output.png"),
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0,
     maxSequenceLength: Int = 512,
     inputImagePath: URL? = nil,
     denoise: Float = 1.0
@@ -55,6 +59,8 @@ public struct Flux2GenerationRequest: Sendable {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
     self.maxSequenceLength = maxSequenceLength
     self.inputImagePath = inputImagePath
     self.denoise = denoise
@@ -556,7 +562,10 @@ public final class Flux2Pipeline {
 
     // Denormalize from [-1, 1] to [0, 1]
     let image = QwenImageIO.denormalizeFromDecoder(decoded)
-    let clipped = MLX.clip(image, min: 0, max: 1)
+    var clipped = MLX.clip(image, min: 0, max: 1)
+    if ImageLevels.shouldApply(min: request.levelsMin, max: request.levelsMax) {
+      clipped = ImageLevels.apply(image: clipped, min: request.levelsMin, max: request.levelsMax)
+    }
     MLX.eval(clipped)
 
     GPU.clearCache()

--- a/Sources/ZImage/Pipeline/ImageLevels.swift
+++ b/Sources/ZImage/Pipeline/ImageLevels.swift
@@ -1,0 +1,15 @@
+import MLX
+
+public enum ImageLevels {
+  public static func apply(image: MLXArray, min: Float, max: Float) -> MLXArray {
+    guard min != max else {
+      return MLXArray.zeros(like: image)
+    }
+
+    return MLX.clip((image - MLXArray(min)) / MLXArray(max - min), min: 0, max: 1)
+  }
+
+  public static func shouldApply(min: Float, max: Float) -> Bool {
+    min != 0.0 || max != 1.0
+  }
+}

--- a/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ImageToImagePipeline.swift
@@ -27,6 +27,8 @@ public struct Img2ImgRequest: Sendable {
   public var guidanceScale: Float
   public var seed: UInt64?
   public var outputPath: URL
+  public var levelsMin: Float
+  public var levelsMax: Float
   public var model: String?
   public var textEncoderPath: String?
   public var maxSequenceLength: Int
@@ -64,6 +66,8 @@ public struct Img2ImgRequest: Sendable {
     guidanceScale: Float = ZImageModelMetadata.recommendedGuidanceScale,
     seed: UInt64? = nil,
     outputPath: URL = URL(fileURLWithPath: "z-image-img2img.png"),
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0,
     model: String? = nil,
     textEncoderPath: String? = nil,
     maxSequenceLength: Int = 512,
@@ -87,6 +91,8 @@ public struct Img2ImgRequest: Sendable {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
     self.model = model
     self.textEncoderPath = textEncoderPath
     self.maxSequenceLength = maxSequenceLength
@@ -273,6 +279,8 @@ extension ZImagePipeline {
       guidanceScale: request.guidanceScale,
       seed: request.seed,
       outputPath: request.outputPath,
+      levelsMin: request.levelsMin,
+      levelsMax: request.levelsMax,
       model: request.model,
       textEncoderPath: request.textEncoderPath,
       maxSequenceLength: request.maxSequenceLength,

--- a/Sources/ZImage/Pipeline/ZImageControlPipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImageControlPipeline.swift
@@ -47,6 +47,8 @@ public struct ZImageControlGenerationRequest {
   public var guidanceScale: Float
   public var seed: UInt64?
   public var outputPath: URL?
+  public var levelsMin: Float
+  public var levelsMax: Float
   public var model: String?
   public var textEncoderPath: String?
   public var controlnetWeights: String?
@@ -79,6 +81,8 @@ public struct ZImageControlGenerationRequest {
     guidanceScale: Float = ZImageModelMetadata.recommendedGuidanceScale,
     seed: UInt64? = nil,
     outputPath: URL? = nil,
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0,
     model: String? = nil,
     textEncoderPath: String? = nil,
     controlnetWeights: String? = nil,
@@ -105,6 +109,8 @@ public struct ZImageControlGenerationRequest {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
     self.model = model
     self.textEncoderPath = textEncoderPath
     self.controlnetWeights = controlnetWeights
@@ -132,6 +138,8 @@ public struct ZImageControlGenerationRequest {
     guidanceScale: Float = ZImageModelMetadata.recommendedGuidanceScale,
     seed: UInt64? = nil,
     outputPath: URL? = nil,
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0,
     model: String? = nil,
     textEncoderPath: String? = nil,
     controlnetWeights: String? = nil,
@@ -161,6 +169,8 @@ public struct ZImageControlGenerationRequest {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
     self.model = model
     self.textEncoderPath = textEncoderPath
     self.controlnetWeights = controlnetWeights
@@ -1164,7 +1174,11 @@ public class ZImageControlPipeline {
     guard let outputPath = request.outputPath else {
       throw PipelineError.outputPathRequired
     }
-    let decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    var decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    if ImageLevels.shouldApply(min: request.levelsMin, max: request.levelsMax) {
+      decoded = ImageLevels.apply(image: decoded, min: request.levelsMin, max: request.levelsMax)
+      MLX.eval(decoded)
+    }
     try QwenImageIO.saveImage(array: decoded, to: outputPath)
     logger.info("Wrote image to \(outputPath.path)")
     return outputPath
@@ -1447,7 +1461,11 @@ public class ZImageControlPipeline {
       fractionCompleted: 1.0
     ))
     logger.info("Denoising complete, decoding latents...")
-    let decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    var decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    if ImageLevels.shouldApply(min: request.levelsMin, max: request.levelsMax) {
+      decoded = ImageLevels.apply(image: decoded, min: request.levelsMin, max: request.levelsMax)
+      MLX.eval(decoded)
+    }
     let imageData = try QwenImageIO.imageData(from: decoded)
     logger.info("Generated image data (\(imageData.count) bytes)")
     return imageData

--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -16,6 +16,8 @@ public struct ZImageGenerationRequest: Sendable {
   public var guidanceScale: Float
   public var seed: UInt64?
   public var outputPath: URL
+  public var levelsMin: Float
+  public var levelsMax: Float
   public var model: String?
   public var textEncoderPath: String?
   public var maxSequenceLength: Int
@@ -71,6 +73,8 @@ public struct ZImageGenerationRequest: Sendable {
     guidanceScale: Float = ZImageModelMetadata.recommendedGuidanceScale,
     seed: UInt64? = nil,
     outputPath: URL = URL(fileURLWithPath: "z-image.png"),
+    levelsMin: Float = 0.0,
+    levelsMax: Float = 1.0,
     model: String? = nil,
     textEncoderPath: String? = nil,
     maxSequenceLength: Int = 512,
@@ -99,6 +103,8 @@ public struct ZImageGenerationRequest: Sendable {
     self.guidanceScale = guidanceScale
     self.seed = seed
     self.outputPath = outputPath
+    self.levelsMin = levelsMin
+    self.levelsMax = levelsMax
     self.model = model
     self.textEncoderPath = textEncoderPath
     self.maxSequenceLength = maxSequenceLength
@@ -1094,7 +1100,11 @@ public final class ZImagePipeline {
     logger.info("Denoising complete, decoding with VAE...")
     progressHandler?(GenerationProgress(stage: .decoding, stepIndex: request.steps, totalSteps: request.steps))
 
-    let decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    var decoded = decodeLatents(latents, vae: vae, height: request.height, width: request.width)
+    if ImageLevels.shouldApply(min: request.levelsMin, max: request.levelsMax) {
+      decoded = ImageLevels.apply(image: decoded, min: request.levelsMin, max: request.levelsMax)
+      MLX.eval(decoded)
+    }
     MLX.eval(MLXArray([]))
     GPU.clearCache()
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -984,6 +984,8 @@ private actor WarmServerCoordinator {
         guidanceScale: payload.guidance ?? defaultGuidance,
         seed: payload.seed,
         outputPath: outputURL,
+        levelsMin: payload.levelsMin ?? 0.0,
+        levelsMax: payload.levelsMax ?? 1.0,
         maxSequenceLength: configuration.maxSequenceLength,
         inputImagePath: inputImageURL,
         denoise: resolvedDenoise
@@ -1040,7 +1042,9 @@ private actor WarmServerCoordinator {
         steps: payload.steps ?? 30,
         guidanceScale: payload.guidance ?? 4.0,
         seed: payload.seed,
-        outputPath: outputURL
+        outputPath: outputURL,
+        levelsMin: payload.levelsMin ?? 0.0,
+        levelsMax: payload.levelsMax ?? 1.0
       )
 
       let result = try await fp.generate(fiboRequest, progressHandler: nil)
@@ -1423,6 +1427,8 @@ private struct GeneratePayload: Sendable {
   let guidance: Float?
   let seed: UInt64?
   let outputPath: String?
+  let levelsMin: Float?
+  let levelsMax: Float?
   let scheduler: String?
   let sigmaSchedule: String?
   let eta: Float?
@@ -1446,6 +1452,7 @@ private struct GeneratePayload: Sendable {
     prompt: String, negativePrompt: String? = nil,
     width: Int? = nil, height: Int? = nil, steps: Int? = nil,
     guidance: Float? = nil, seed: UInt64? = nil, outputPath: String? = nil,
+    levelsMin: Float? = nil, levelsMax: Float? = nil,
     scheduler: String? = nil, sigmaSchedule: String? = nil, eta: Float? = nil,
     dype: String? = nil, inpaintImageData: Data? = nil, maskData: Data? = nil,
     denoise: Float? = nil, maskGrow: Int? = nil, maskFeather: Int? = nil,
@@ -1455,6 +1462,7 @@ private struct GeneratePayload: Sendable {
     self.prompt = prompt; self.negativePrompt = negativePrompt
     self.width = width; self.height = height; self.steps = steps
     self.guidance = guidance; self.seed = seed; self.outputPath = outputPath
+    self.levelsMin = levelsMin; self.levelsMax = levelsMax
     self.scheduler = scheduler; self.sigmaSchedule = sigmaSchedule
     self.eta = eta; self.dype = dype
     self.inpaintImageData = inpaintImageData; self.maskData = maskData
@@ -1467,7 +1475,7 @@ private struct GeneratePayload: Sendable {
 extension GeneratePayload: Decodable {
   private enum CodingKeys: String, CodingKey {
     case prompt, negativePrompt, width, height, steps, guidance, seed
-    case outputPath, scheduler, sigmaSchedule, eta, dype
+    case outputPath, levelsMin, levelsMax, scheduler, sigmaSchedule, eta, dype
     case imagePath, imageStrength, creativity
   }
 
@@ -1481,6 +1489,8 @@ extension GeneratePayload: Decodable {
     guidance = try c.decodeIfPresent(Float.self, forKey: .guidance)
     seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
     outputPath = try c.decodeIfPresent(String.self, forKey: .outputPath)
+    levelsMin = try c.decodeIfPresent(Float.self, forKey: .levelsMin)
+    levelsMax = try c.decodeIfPresent(Float.self, forKey: .levelsMax)
     scheduler = try c.decodeIfPresent(String.self, forKey: .scheduler)
     sigmaSchedule = try c.decodeIfPresent(String.self, forKey: .sigmaSchedule)
     eta = try c.decodeIfPresent(Float.self, forKey: .eta)
@@ -1538,6 +1548,8 @@ extension GeneratePayload: Decodable {
       guidanceScale: guidance ?? ZImageModelMetadata.recommendedGuidanceScale,
       seed: seed,
       outputPath: outputURL,
+      levelsMin: levelsMin ?? 0.0,
+      levelsMax: levelsMax ?? 1.0,
       model: configuration.modelSpec,
       textEncoderPath: configuration.textEncoderPath,
       maxSequenceLength: configuration.maxSequenceLength,
@@ -1616,6 +1628,8 @@ extension GeneratePayload: Decodable {
       guidanceScale: guidance ?? ZImageModelMetadata.recommendedGuidanceScale,
       seed: seed,
       outputPath: outputURL,
+      levelsMin: levelsMin ?? 0.0,
+      levelsMax: levelsMax ?? 1.0,
       model: configuration.modelSpec,
       textEncoderPath: configuration.textEncoderPath,
       maxSequenceLength: configuration.maxSequenceLength,

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -51,6 +51,8 @@ struct ZImageCLI {
     var guidance = ZImageModelMetadata.recommendedGuidanceScale
     var seeds: [UInt64] = []
     var outputPath = "z-image.png"
+    var levelsMin: Float = 0.0
+    var levelsMax: Float = 1.0
     var model: String?
     var textEncoderPath: String?
     var cacheLimit: Int?
@@ -108,6 +110,10 @@ struct ZImageCLI {
         }
       case "--output", "-o":
         outputPath = nextValue(for: arg, iterator: &iterator)
+      case "--levels-min":
+        levelsMin = floatValue(for: arg, iterator: &iterator, fallback: 0.0)
+      case "--levels-max":
+        levelsMax = floatValue(for: arg, iterator: &iterator, fallback: 1.0)
       case "--model", "-m":
         model = nextValue(for: arg, iterator: &iterator)
       case "--text-encoder-path":
@@ -395,6 +401,8 @@ struct ZImageCLI {
               guidanceScale: guidance,
               seed: batchSeed,
               outputPath: URL(fileURLWithPath: batchOutputPath),
+              levelsMin: levelsMin,
+              levelsMax: levelsMax,
               model: capturedModel,
               textEncoderPath: capturedTextEncoderPath,
               maxSequenceLength: maxSequenceLength,
@@ -493,6 +501,8 @@ struct ZImageCLI {
         guidanceScale: guidance,
         seed: seed,
         outputPath: URL(fileURLWithPath: outputPath),
+        levelsMin: levelsMin,
+        levelsMax: levelsMax,
         model: model,
         textEncoderPath: textEncoderPath,
         maxSequenceLength: maxSequenceLength,
@@ -661,7 +671,9 @@ struct ZImageCLI {
             steps: fiboSteps,
             guidanceScale: fiboGuidance,
             seed: seed,
-            outputPath: URL(fileURLWithPath: outputPath)
+            outputPath: URL(fileURLWithPath: outputPath),
+            levelsMin: levelsMin,
+            levelsMax: levelsMax
           )
 
           _ = try await fiboPipeline.generate(fiboRequest, progressHandler: { progress in
@@ -764,6 +776,8 @@ struct ZImageCLI {
             guidanceScale: flux2Pipeline.isDistilled ? 1.0 : guidance,
             seed: seed,
             outputPath: URL(fileURLWithPath: outputPath),
+            levelsMin: levelsMin,
+            levelsMax: levelsMax,
             maxSequenceLength: maxSequenceLength,
             inputImagePath: flux2InputImage,
             denoise: flux2DenoiseValue
@@ -803,6 +817,8 @@ struct ZImageCLI {
       guidanceScale: guidance,
       seed: seed,
       outputPath: URL(fileURLWithPath: outputPath),
+      levelsMin: levelsMin,
+      levelsMax: levelsMax,
       model: model,
       textEncoderPath: textEncoderPath,
       maxSequenceLength: maxSequenceLength,
@@ -970,6 +986,8 @@ struct ZImageCLI {
       --guidance, -g         Guidance scale (default \(ZImageModelMetadata.recommendedGuidanceScale))
       --seed                 Random seed
       --output, -o           Output path (default z-image.png)
+      --levels-min           Levels lower bound for post-decode contrast adjustment (default: 0.0)
+      --levels-max           Levels upper bound for post-decode contrast adjustment (default: 1.0)
       --model, -m            Model path or HuggingFace ID (default: \(ZImageRepository.id))
                              Aliases: z-image-base (Base, CFG-guided), z-image-turbo (Turbo, distilled)
       --model-family         Model family: flux1, flux2, or fibo (default: auto-detect from model config)
@@ -1406,6 +1424,8 @@ struct ZImageCLI {
     var guidance = ZImageModelMetadata.recommendedGuidanceScale
     var seed: UInt64?
     var outputPath = "z-image-control.png"
+    var levelsMin: Float = 0.0
+    var levelsMax: Float = 1.0
     var model: String?
     var textEncoderPath: String?
     var cacheLimit: Int?
@@ -1448,6 +1468,10 @@ struct ZImageCLI {
         seed = UInt64(nextValue(for: arg, iterator: &iterator))
       case "--output", "-o":
         outputPath = nextValue(for: arg, iterator: &iterator)
+      case "--levels-min":
+        levelsMin = floatValue(for: arg, iterator: &iterator, fallback: 0.0)
+      case "--levels-max":
+        levelsMax = floatValue(for: arg, iterator: &iterator, fallback: 1.0)
       case "--model", "-m":
         model = nextValue(for: arg, iterator: &iterator)
       case "--text-encoder-path":
@@ -1576,6 +1600,8 @@ struct ZImageCLI {
       guidanceScale: guidance,
       seed: seed,
       outputPath: URL(fileURLWithPath: outputPath),
+      levelsMin: levelsMin,
+      levelsMax: levelsMax,
       model: model,
       textEncoderPath: textEncoderPath,
       controlnetWeights: controlnetWeights,
@@ -1624,6 +1650,8 @@ struct ZImageCLI {
       --guidance, -g            Guidance scale (default \(ZImageModelMetadata.recommendedGuidanceScale))
       --seed                    Random seed
       --output, -o              Output path (default z-image-control.png)
+      --levels-min              Levels lower bound for post-decode contrast adjustment (default: 0.0)
+      --levels-max              Levels upper bound for post-decode contrast adjustment (default: 1.0)
       --model, -m               Model path or HuggingFace ID (default: \(ZImageRepository.id))
       --text-encoder-path       Override text encoder directory (CLI > ZIMAGE_ENCODER_PATH > auto-detect > default)
       --cache-limit             GPU memory cache limit in MB (default: unlimited)

--- a/Tests/ZImageTests/Pipeline/ImageLevelsTests.swift
+++ b/Tests/ZImageTests/Pipeline/ImageLevelsTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import MLX
+@testable import ZImage
+
+final class ImageLevelsTests: XCTestCase {
+  func testIdentityPassDoesNotChangeInput() {
+    let values: [Float] = [0.0, 0.25, 0.5, 0.75, 1.0]
+    let image = MLXArray(values, [1, 1, 1, values.count])
+
+    let adjusted = ImageLevels.apply(image: image, min: 0.0, max: 1.0)
+    MLX.eval(adjusted)
+
+    XCTAssertEqual(adjusted.asArray(Float.self), values)
+  }
+
+  func testContrastStretch() {
+    let image = MLXArray([Float(0.1), 0.5, 0.9], [1, 1, 1, 3])
+
+    let adjusted = ImageLevels.apply(image: image, min: 0.1, max: 0.9)
+    MLX.eval(adjusted)
+
+    let result = adjusted.asArray(Float.self)
+    XCTAssertEqual(result[0], 0.0, accuracy: 1e-5)
+    XCTAssertEqual(result[1], 0.5, accuracy: 1e-5)
+    XCTAssertEqual(result[2], 1.0, accuracy: 1e-5)
+  }
+
+  func testClampingBehavior() {
+    let image = MLXArray([Float(0.0), 0.1, 0.5, 0.9, 1.0], [1, 1, 1, 5])
+
+    let adjusted = ImageLevels.apply(image: image, min: 0.25, max: 0.75)
+    MLX.eval(adjusted)
+
+    let result = adjusted.asArray(Float.self)
+    XCTAssertEqual(result[0], 0.0, accuracy: 1e-5)
+    XCTAssertEqual(result[1], 0.0, accuracy: 1e-5)
+    XCTAssertEqual(result[2], 0.5, accuracy: 1e-5)
+    XCTAssertEqual(result[3], 1.0, accuracy: 1e-5)
+    XCTAssertEqual(result[4], 1.0, accuracy: 1e-5)
+  }
+
+  func testMinEqualMaxReturnsZeros() {
+    let image = MLXArray([Float(0.2), 0.4, 0.6], [1, 1, 1, 3])
+
+    let adjusted = ImageLevels.apply(image: image, min: 0.5, max: 0.5)
+    MLX.eval(adjusted)
+
+    XCTAssertEqual(adjusted.asArray(Float.self), [0.0, 0.0, 0.0])
+  }
+}


### PR DESCRIPTION
## Summary
- Added `ImageLevels.apply(image:min:max:)` — equivalent to ComfyUI's JWImageLevels node
- Wired through all generation pipelines: Z-Image, img2img, ControlNet, FIBO, Flux 2
- CLI flags: `--levels-min` and `--levels-max`
- WarmServer: optional `levelsMin` / `levelsMax` in `/v1/generate` request
- 4 unit tests: identity, contrast stretch, clamping, min==max edge case

Closes #65

## Context
Used in Wan 2.2 refiner workflows for contrast correction after VAE decode. Common values: min=0.03, max=1.0 (lifts blacks slightly).

🤖 Codex — dispatched by Bree