### PR TITLE
feat(upscale): port ESRGAN/RRDBNet upscaler to MLX Swift

### DIFF
--- a/Sources/ZImage/Upscale/ESRGAN/ESRGANConfig.swift
+++ b/Sources/ZImage/Upscale/ESRGAN/ESRGANConfig.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Configuration for ESRGAN/Real-ESRGAN RRDBNet upscalers.
+public struct ESRGANConfig: Equatable, Sendable {
+  public let numInCh: Int
+  public let numOutCh: Int
+  public let scale: Int
+  public let numFeat: Int
+  public let numBlock: Int
+  public let numGrowCh: Int
+
+  public init(
+    numInCh: Int = 3,
+    numOutCh: Int = 3,
+    scale: Int = 4,
+    numFeat: Int = 64,
+    numBlock: Int = 23,
+    numGrowCh: Int = 32
+  ) {
+    self.numInCh = numInCh
+    self.numOutCh = numOutCh
+    self.scale = scale
+    self.numFeat = numFeat
+    self.numBlock = numBlock
+    self.numGrowCh = numGrowCh
+  }
+
+  public static let ultraSharp4x = ESRGANConfig(
+    numInCh: 3,
+    numOutCh: 3,
+    scale: 4,
+    numFeat: 64,
+    numBlock: 23,
+    numGrowCh: 32
+  )
+
+  public static let realESRGAN_x4plus = ESRGANConfig(
+    numInCh: 3,
+    numOutCh: 3,
+    scale: 4,
+    numFeat: 64,
+    numBlock: 23,
+    numGrowCh: 32
+  )
+
+  /// Detects the RRDB block count from safetensors keys in a weights directory.
+  ///
+  /// Other architecture dimensions default to the common 4x RRDBNet preset.
+  public static func detect(from directory: URL) -> ESRGANConfig {
+    let blockCount = detectBlockCount(from: directory)
+    guard let blockCount, blockCount > 0 else {
+      return .ultraSharp4x
+    }
+
+    return ESRGANConfig(
+      numInCh: ultraSharp4x.numInCh,
+      numOutCh: ultraSharp4x.numOutCh,
+      scale: ultraSharp4x.scale,
+      numFeat: ultraSharp4x.numFeat,
+      numBlock: blockCount,
+      numGrowCh: ultraSharp4x.numGrowCh
+    )
+  }
+
+  private static func detectBlockCount(from directory: URL) -> Int? {
+    let files = ESRGANConfig.safetensorsFiles(in: directory)
+    guard !files.isEmpty else { return nil }
+
+    var blockIndices = Set<Int>()
+    for file in files {
+      guard let reader = try? SafeTensorsReader(fileURL: file) else { continue }
+      for name in reader.tensorNames {
+        if let index = bodyBlockIndex(from: name) {
+          blockIndices.insert(index)
+        }
+      }
+    }
+
+    guard let maxIndex = blockIndices.max() else { return nil }
+    return maxIndex + 1
+  }
+
+  private static func safetensorsFiles(in url: URL) -> [URL] {
+    let fm = FileManager.default
+    var isDirectory: ObjCBool = false
+    guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+      return []
+    }
+
+    if !isDirectory.boolValue {
+      return url.pathExtension == "safetensors" ? [url] : []
+    }
+
+    let contents = (try? fm.contentsOfDirectory(
+      at: url,
+      includingPropertiesForKeys: [.isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    )) ?? []
+
+    return contents
+      .filter { $0.pathExtension == "safetensors" }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+  }
+
+  private static func bodyBlockIndex(from key: String) -> Int? {
+    let parts = key.split(separator: ".").map(String.init)
+    guard !parts.isEmpty else { return nil }
+
+    let offset: Int
+    switch parts.first {
+    case "params", "params_ema", "model":
+      offset = 1
+    default:
+      offset = 0
+    }
+
+    guard parts.count > offset + 1, parts[offset] == "body" else {
+      return nil
+    }
+
+    return Int(parts[offset + 1])
+  }
+}

--- a/Sources/ZImage/Upscale/ESRGAN/ESRGANModel.swift
+++ b/Sources/ZImage/Upscale/ESRGAN/ESRGANModel.swift
@@ -1,0 +1,184 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// ESRGAN residual dense block with five densely-connected 3x3 convolutions.
+public final class ResidualDenseBlock: Module {
+  @ModuleInfo(key: "conv1") public var conv1: Conv2d
+  @ModuleInfo(key: "conv2") public var conv2: Conv2d
+  @ModuleInfo(key: "conv3") public var conv3: Conv2d
+  @ModuleInfo(key: "conv4") public var conv4: Conv2d
+  @ModuleInfo(key: "conv5") public var conv5: Conv2d
+
+  public let numFeat: Int
+  public let numGrowCh: Int
+  public let residualScale: Float
+
+  public init(numFeat: Int = 64, numGrowCh: Int = 32, residualScale: Float = 0.2) {
+    self.numFeat = numFeat
+    self.numGrowCh = numGrowCh
+    self.residualScale = residualScale
+
+    self._conv1.wrappedValue = Conv2d(
+      inputChannels: numFeat,
+      outputChannels: numGrowCh,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._conv2.wrappedValue = Conv2d(
+      inputChannels: numFeat + numGrowCh,
+      outputChannels: numGrowCh,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._conv3.wrappedValue = Conv2d(
+      inputChannels: numFeat + 2 * numGrowCh,
+      outputChannels: numGrowCh,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._conv4.wrappedValue = Conv2d(
+      inputChannels: numFeat + 3 * numGrowCh,
+      outputChannels: numGrowCh,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._conv5.wrappedValue = Conv2d(
+      inputChannels: numFeat + 4 * numGrowCh,
+      outputChannels: numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+
+    super.init()
+  }
+
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let x1 = MLXNN.leakyRelu(conv1(x), negativeSlope: 0.2)
+    let x2Input = MLX.concatenated([x, x1], axis: -1)
+    let x2 = MLXNN.leakyRelu(conv2(x2Input), negativeSlope: 0.2)
+    let x3Input = MLX.concatenated([x, x1, x2], axis: -1)
+    let x3 = MLXNN.leakyRelu(conv3(x3Input), negativeSlope: 0.2)
+    let x4Input = MLX.concatenated([x, x1, x2, x3], axis: -1)
+    let x4 = MLXNN.leakyRelu(conv4(x4Input), negativeSlope: 0.2)
+    let x5Input = MLX.concatenated([x, x1, x2, x3, x4], axis: -1)
+    let x5 = conv5(x5Input)
+    return x5 * residualScale + x
+  }
+}
+
+/// Residual-in-residual dense block: three RDBs with an outer residual scale.
+public final class RRDB: Module {
+  @ModuleInfo(key: "rdb1") public var rdb1: ResidualDenseBlock
+  @ModuleInfo(key: "rdb2") public var rdb2: ResidualDenseBlock
+  @ModuleInfo(key: "rdb3") public var rdb3: ResidualDenseBlock
+
+  public let residualScale: Float
+
+  public init(numFeat: Int = 64, numGrowCh: Int = 32, residualScale: Float = 0.2) {
+    self.residualScale = residualScale
+    self._rdb1.wrappedValue = ResidualDenseBlock(numFeat: numFeat, numGrowCh: numGrowCh)
+    self._rdb2.wrappedValue = ResidualDenseBlock(numFeat: numFeat, numGrowCh: numGrowCh)
+    self._rdb3.wrappedValue = ResidualDenseBlock(numFeat: numFeat, numGrowCh: numGrowCh)
+    super.init()
+  }
+
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    let out = rdb3(rdb2(rdb1(x)))
+    return out * residualScale + x
+  }
+}
+
+/// BasicSR-style ESRGAN RRDBNet in MLX native NHWC layout.
+public final class RRDBNet: Module {
+  @ModuleInfo(key: "conv_first") public var convFirst: Conv2d
+  @ModuleInfo(key: "body") public var body: [RRDB]
+  @ModuleInfo(key: "conv_body") public var convBody: Conv2d
+  @ModuleInfo(key: "conv_up1") public var convUp1: Conv2d
+  @ModuleInfo(key: "conv_up2") public var convUp2: Conv2d
+  @ModuleInfo(key: "conv_hr") public var convHR: Conv2d
+  @ModuleInfo(key: "conv_last") public var convLast: Conv2d
+
+  public let config: ESRGANConfig
+
+  public init(config: ESRGANConfig = .ultraSharp4x) {
+    precondition(config.scale == 4, "RRDBNet currently implements the 4x ESRGAN upsampling head")
+    self.config = config
+
+    self._convFirst.wrappedValue = Conv2d(
+      inputChannels: config.numInCh,
+      outputChannels: config.numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+
+    self._body.wrappedValue = (0..<config.numBlock).map { _ in
+      RRDB(numFeat: config.numFeat, numGrowCh: config.numGrowCh)
+    }
+
+    self._convBody.wrappedValue = Conv2d(
+      inputChannels: config.numFeat,
+      outputChannels: config.numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._convUp1.wrappedValue = Conv2d(
+      inputChannels: config.numFeat,
+      outputChannels: config.numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._convUp2.wrappedValue = Conv2d(
+      inputChannels: config.numFeat,
+      outputChannels: config.numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._convHR.wrappedValue = Conv2d(
+      inputChannels: config.numFeat,
+      outputChannels: config.numFeat,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+    self._convLast.wrappedValue = Conv2d(
+      inputChannels: config.numFeat,
+      outputChannels: config.numOutCh,
+      kernelSize: 3,
+      stride: 1,
+      padding: 1
+    )
+
+    super.init()
+  }
+
+  public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    var feat = convFirst(x)
+    var bodyFeat = feat
+    for block in body {
+      bodyFeat = block(bodyFeat)
+    }
+    bodyFeat = convBody(bodyFeat)
+    feat = feat + bodyFeat
+    feat = MLXNN.leakyRelu(convUp1(Self.nearestUpsample2x(feat)), negativeSlope: 0.2)
+    feat = MLXNN.leakyRelu(convUp2(Self.nearestUpsample2x(feat)), negativeSlope: 0.2)
+    let hr = MLXNN.leakyRelu(convHR(feat), negativeSlope: 0.2)
+    return convLast(hr)
+  }
+
+  public static func nearestUpsample2x(_ x: MLXArray) -> MLXArray {
+    precondition(x.ndim == 4, "Expected NHWC tensor")
+    var out = MLX.repeated(x, count: 2, axis: 1)
+    out = MLX.repeated(out, count: 2, axis: 2)
+    return out
+  }
+}

--- a/Sources/ZImage/Upscale/ESRGAN/ESRGANPipeline.swift
+++ b/Sources/ZImage/Upscale/ESRGAN/ESRGANPipeline.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+/// End-to-end ESRGAN/Real-ESRGAN image upscaling pipeline.
+public final class ESRGANPipeline {
+  public let model: RRDBNet
+  public let config: ESRGANConfig
+  public let weightsDirectory: URL
+  public let logger: Logger
+
+  public enum PipelineError: Error, CustomStringConvertible {
+    case weightsDirectoryNotFound(String)
+    case imageLoadFailed(String)
+    case imagePreprocessFailed(Error)
+    case imagePostprocessFailed(Error)
+    case saveFailed(String)
+
+    public var description: String {
+      switch self {
+      case .weightsDirectoryNotFound(let path):
+        return "ESRGAN weights directory not found: \(path)"
+      case .imageLoadFailed(let path):
+        return "Failed to load input image: \(path)"
+      case .imagePreprocessFailed(let error):
+        return "ESRGAN image preprocessing failed: \(error)"
+      case .imagePostprocessFailed(let error):
+        return "ESRGAN image postprocessing failed: \(error)"
+      case .saveFailed(let path):
+        return "Failed to save ESRGAN output image to: \(path)"
+      }
+    }
+  }
+
+  public init(
+    weightsDirectory: URL,
+    config: ESRGANConfig? = nil,
+    logger: Logger? = nil
+  ) throws {
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: weightsDirectory.path, isDirectory: &isDirectory) else {
+      throw PipelineError.weightsDirectoryNotFound(weightsDirectory.path)
+    }
+
+    self.weightsDirectory = weightsDirectory
+    self.logger = logger ?? Logger(label: "esrgan.pipeline")
+    self.config = config ?? ESRGANConfig.detect(from: weightsDirectory)
+
+    self.logger.info("Initializing ESRGAN RRDBNet: blocks=\(self.config.numBlock), scale=\(self.config.scale), features=\(self.config.numFeat), growth=\(self.config.numGrowCh)")
+    self.model = RRDBNet(config: self.config)
+
+    self.logger.info("Loading ESRGAN weights...")
+    try ESRGANWeightLoader.loadWeights(
+      into: model,
+      from: weightsDirectory,
+      dtype: .float32,
+      logger: self.logger
+    )
+    self.logger.info("ESRGAN pipeline ready")
+  }
+
+  public func upscale(
+    imagePath: String,
+    tileSize: Int = 512,
+    tilePad: Int = 32
+  ) throws -> CGImage {
+    logger.info("ESRGAN upscaling \(imagePath) with tileSize=\(tileSize), tilePad=\(tilePad)")
+
+    let inputImage: CGImage
+    do {
+      inputImage = try SeedVR2Util.loadImage(from: imagePath)
+    } catch {
+      throw PipelineError.imageLoadFailed(imagePath)
+    }
+
+    let input: MLXArray
+    do {
+      input = try Self.preprocess(inputImage)
+    } catch {
+      throw PipelineError.imagePreprocessFailed(error)
+    }
+
+    logger.info("Input tensor shape: \(input.shape)")
+    let output: MLXArray
+    if shouldTile(input, tileSize: tileSize) {
+      output = upscaleTiled(input, tileSize: tileSize, tilePad: tilePad)
+    } else {
+      output = MLX.clip(model(input), min: 0, max: 1)
+      MLX.eval(output)
+    }
+
+    do {
+      let image = try Self.postprocess(output)
+      logger.info("ESRGAN upscale complete: \(image.width)x\(image.height)")
+      return image
+    } catch {
+      throw PipelineError.imagePostprocessFailed(error)
+    }
+  }
+
+  @discardableResult
+  public func upscaleAndSave(
+    imagePath: String,
+    outputPath: String? = nil,
+    tileSize: Int = 512,
+    tilePad: Int = 32
+  ) throws -> String {
+    let result = try upscale(
+      imagePath: imagePath,
+      tileSize: tileSize,
+      tilePad: tilePad
+    )
+
+    let outPath: String
+    if let outputPath {
+      outPath = outputPath
+    } else {
+      let inputURL = URL(fileURLWithPath: imagePath)
+      let baseName = inputURL.deletingPathExtension().lastPathComponent
+      outPath = inputURL.deletingLastPathComponent()
+        .appendingPathComponent("\(baseName)-upscaled.png").path
+    }
+
+    let outURL = URL(fileURLWithPath: outPath)
+    guard let destination = CGImageDestinationCreateWithURL(
+      outURL as CFURL,
+      UTType.png.identifier as CFString,
+      1,
+      nil
+    ) else {
+      throw PipelineError.saveFailed(outPath)
+    }
+
+    CGImageDestinationAddImage(destination, result, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      throw PipelineError.saveFailed(outPath)
+    }
+
+    logger.info("Saved ESRGAN upscaled image to \(outPath)")
+    return outPath
+  }
+
+  private static func preprocess(_ image: CGImage) throws -> MLXArray {
+    let chw = try QwenImageIO.array(from: image, addBatchDimension: true, dtype: .float32)
+    let nhwc = chw.transposed(0, 2, 3, 1)
+    return MLX.clip(nhwc, min: 0, max: 1)
+  }
+
+  private static func postprocess(_ tensor: MLXArray) throws -> CGImage {
+    var clipped = MLX.clip(tensor, min: 0, max: 1).asType(.float32)
+    MLX.eval(clipped)
+    if clipped.ndim == 3 {
+      clipped = clipped.reshaped(1, clipped.dim(0), clipped.dim(1), clipped.dim(2))
+    }
+    precondition(clipped.ndim == 4 && clipped.dim(0) == 1 && clipped.dim(3) == 3)
+    let bchw = clipped.transposed(0, 3, 1, 2)
+    return try QwenImageIO.image(from: bchw)
+  }
+
+  private func shouldTile(_ input: MLXArray, tileSize: Int) -> Bool {
+    guard tileSize > 0 else { return false }
+    return input.dim(1) > tileSize || input.dim(2) > tileSize
+  }
+
+  private func upscaleTiled(_ input: MLXArray, tileSize: Int, tilePad: Int) -> MLXArray {
+    let height = input.dim(1)
+    let width = input.dim(2)
+    let channels = config.numOutCh
+    let scale = config.scale
+    let outHeight = height * scale
+    let outWidth = width * scale
+    let clampedTileSize = max(1, tileSize)
+    let overlap = max(0, min(tilePad, clampedTileSize - 1))
+    let stride = max(1, clampedTileSize - overlap)
+    let yStarts = Self.tileStarts(length: height, tileSize: clampedTileSize, stride: stride)
+    let xStarts = Self.tileStarts(length: width, tileSize: clampedTileSize, stride: stride)
+
+    logger.info("Processing ESRGAN tiles: \(xStarts.count * yStarts.count) tiles for \(width)x\(height)")
+
+    var output = [Float](repeating: 0, count: outHeight * outWidth * channels)
+    var weights = [Float](repeating: 0, count: outHeight * outWidth)
+
+    for y0 in yStarts {
+      let y1 = min(y0 + clampedTileSize, height)
+      for x0 in xStarts {
+        let x1 = min(x0 + clampedTileSize, width)
+        let tile = input[0..., y0..<y1, x0..<x1, 0...]
+        let tileOut = MLX.clip(model(tile), min: 0, max: 1).asType(.float32)
+        MLX.eval(tileOut)
+        accumulate(
+          tileOut,
+          into: &output,
+          weights: &weights,
+          tileX: x0,
+          tileY: y0,
+          outWidth: outWidth,
+          channels: channels,
+          scale: scale
+        )
+      }
+    }
+
+    for pixel in 0..<weights.count where weights[pixel] > 0 {
+      let invWeight = 1.0 / weights[pixel]
+      let base = pixel * channels
+      for channel in 0..<channels {
+        output[base + channel] *= invWeight
+      }
+    }
+
+    return MLXArray(output, [1, outHeight, outWidth, channels]).asType(.float32)
+  }
+
+  private func accumulate(
+    _ tileOut: MLXArray,
+    into output: inout [Float],
+    weights: inout [Float],
+    tileX: Int,
+    tileY: Int,
+    outWidth: Int,
+    channels: Int,
+    scale: Int
+  ) {
+    let tileOutHeight = tileOut.dim(1)
+    let tileOutWidth = tileOut.dim(2)
+    let values = tileOut.asArray(Float.self)
+    let outX0 = tileX * scale
+    let outY0 = tileY * scale
+
+    for y in 0..<tileOutHeight {
+      let outY = outY0 + y
+      for x in 0..<tileOutWidth {
+        let outX = outX0 + x
+        let outputPixel = outY * outWidth + outX
+        let tilePixel = y * tileOutWidth + x
+        weights[outputPixel] += 1.0
+
+        let outputBase = outputPixel * channels
+        let tileBase = tilePixel * channels
+        for channel in 0..<channels {
+          output[outputBase + channel] += values[tileBase + channel]
+        }
+      }
+    }
+  }
+
+  private static func tileStarts(length: Int, tileSize: Int, stride: Int) -> [Int] {
+    guard length > tileSize else { return [0] }
+    var starts: [Int] = []
+    var position = 0
+    while position + tileSize < length {
+      starts.append(position)
+      position += stride
+    }
+
+    let finalStart = max(0, length - tileSize)
+    if starts.last != finalStart {
+      starts.append(finalStart)
+    }
+    return starts
+  }
+}
+#endif

--- a/Sources/ZImage/Upscale/ESRGAN/ESRGANWeightLoader.swift
+++ b/Sources/ZImage/Upscale/ESRGAN/ESRGANWeightLoader.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Logging
+import MLX
+import MLXNN
+
+/// Loads BasicSR/Real-ESRGAN RRDBNet weights from safetensors files.
+public enum ESRGANWeightLoader {
+  public enum LoadError: Error, CustomStringConvertible {
+    case pathNotFound(String)
+    case noSafeTensorsFound(String)
+    case noCompatibleWeightsFound(String)
+    case safetensorsReadFailed(String, Error)
+    case weightApplicationFailed(Error)
+
+    public var description: String {
+      switch self {
+      case .pathNotFound(let path):
+        return "ESRGAN weights path not found: \(path)"
+      case .noSafeTensorsFound(let path):
+        return "No ESRGAN safetensors files found in: \(path)"
+      case .noCompatibleWeightsFound(let path):
+        return "No compatible ESRGAN weights found in: \(path)"
+      case .safetensorsReadFailed(let path, let error):
+        return "Failed to read safetensors file \(path): \(error)"
+      case .weightApplicationFailed(let error):
+        return "Failed to apply ESRGAN weights: \(error)"
+      }
+    }
+  }
+
+  public static func loadWeights(
+    into model: RRDBNet,
+    from directory: URL,
+    dtype: DType = .float32,
+    logger: Logger? = nil
+  ) throws {
+    let files = try safetensorsFiles(in: directory)
+    guard !files.isEmpty else {
+      throw LoadError.noSafeTensorsFound(directory.path)
+    }
+
+    var rawTensors: [String: MLXArray] = [:]
+    for file in files {
+      do {
+        let reader = try SafeTensorsReader(fileURL: file)
+        let tensors = try reader.loadAllTensors(as: dtype)
+        for (key, value) in tensors {
+          rawTensors[key] = value
+        }
+        logger?.info("Read \(tensors.count) ESRGAN tensors from \(file.lastPathComponent)")
+      } catch {
+        throw LoadError.safetensorsReadFailed(file.path, error)
+      }
+    }
+
+    let remapped = remapAndTranspose(rawTensors, for: model)
+    guard !remapped.isEmpty else {
+      throw LoadError.noCompatibleWeightsFound(directory.path)
+    }
+
+    do {
+      let params = ModuleParameters.unflattened(remapped)
+      try model.update(parameters: params, verify: [.shapeMismatch])
+    } catch {
+      throw LoadError.weightApplicationFailed(error)
+    }
+
+    logger?.info("Applied \(remapped.count) ESRGAN tensors")
+  }
+
+  public static func detectConfig(from directory: URL) -> ESRGANConfig {
+    ESRGANConfig.detect(from: directory)
+  }
+
+  static func remapAndTranspose(
+    _ tensors: [String: MLXArray],
+    for model: RRDBNet
+  ) -> [(String, MLXArray)] {
+    let expectedShapes = Dictionary(
+      uniqueKeysWithValues: model.parameters().flattened().map { ($0.0, $0.1.shape) }
+    )
+
+    var result: [(String, MLXArray)] = []
+    result.reserveCapacity(tensors.count)
+
+    for (rawKey, value) in tensors {
+      let key = canonicalKey(rawKey)
+      guard let expectedShape = expectedShapes[key] else {
+        continue
+      }
+
+      let prepared: MLXArray
+      if value.shape == expectedShape {
+        prepared = value
+      } else if value.ndim == 4 && key.hasSuffix(".weight") {
+        let transposed = value.transposed(0, 2, 3, 1)
+        prepared = transposed.shape == expectedShape ? transposed : value
+      } else {
+        prepared = value
+      }
+
+      result.append((key, prepared))
+    }
+
+    return result.sorted { $0.0 < $1.0 }
+  }
+
+  private static func canonicalKey(_ key: String) -> String {
+    for prefix in ["params_ema.", "params.", "model."] where key.hasPrefix(prefix) {
+      return String(key.dropFirst(prefix.count))
+    }
+    return key
+  }
+
+  private static func safetensorsFiles(in url: URL) throws -> [URL] {
+    let fm = FileManager.default
+    var isDirectory: ObjCBool = false
+    guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+      throw LoadError.pathNotFound(url.path)
+    }
+
+    if !isDirectory.boolValue {
+      return url.pathExtension == "safetensors" ? [url] : []
+    }
+
+    let contents = try fm.contentsOfDirectory(
+      at: url,
+      includingPropertiesForKeys: [.isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    )
+
+    return contents
+      .filter { $0.pathExtension == "safetensors" }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+  }
+}

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -1057,13 +1057,15 @@ struct ZImageCLI {
         --lora, -l           Initial LoRA(s)
         Use 'ZImageCLI serve --help' for full options
 
-      upscale                Upscale image via SeedVR2
+      upscale                Upscale image via SeedVR2 or ESRGAN
         --input, -i          Input image path (required)
         --output, -o         Output image path (default: input-upscaled.png)
         --resolution, -r     Target resolution (default: 2048)
         --steps              Inference steps (default: 1)
         --seed               Random seed
         --weights, -w        Path to SeedVR2 model weights directory
+        --esrgan-weights     Path to ESRGAN safetensors directory
+        --tile-size          ESRGAN tile size (default: 512)
         --softness           Preprocessing softness 0.0-1.0 (default: 0.0)
 
       models                 List known model families with installation status
@@ -1843,6 +1845,8 @@ struct ZImageCLI {
     var steps = 1
     var seed: Int?
     var weightsPath: String?
+    var esrganWeightsPath: String?
+    var tileSize = 512
     var softness: Float = 0.0
 
     var iterator = args.makeIterator()
@@ -1862,26 +1866,33 @@ struct ZImageCLI {
         }
       case "--weights", "-w":
         weightsPath = nextValue(for: arg, iterator: &iterator)
+      case "--esrgan-weights":
+        esrganWeightsPath = nextValue(for: arg, iterator: &iterator)
+      case "--tile-size":
+        tileSize = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: tileSize)
       case "--softness":
         softness = floatValue(for: arg, iterator: &iterator, fallback: softness)
       case "--help", "-h":
         print("""
-        SeedVR2 Image Upscaler
+        SeedVR2 / ESRGAN Image Upscaler
 
-        Usage: ZImageCLI upscale --input <path> --weights <path> [options]
+        Usage: ZImageCLI upscale --input <path> (--weights <path> | --esrgan-weights <path>) [options]
 
           --input, -i          Input image path (required)
           --output, -o         Output image path (default: input-upscaled.png)
           --resolution, -r     Target resolution for shortest side (default: 2048)
           --steps              Inference steps (default: 1)
           --seed               Random seed for reproducibility
-          --weights, -w        Path to SeedVR2 model weights directory (required)
+          --weights, -w        Path to SeedVR2 model weights directory
+          --esrgan-weights     Path to ESRGAN safetensors directory
+          --tile-size          ESRGAN tile size for large images (default: 512)
           --softness           Preprocessing softness 0.0-1.0 (default: 0.0)
           --help, -h           Show this help
 
         Examples:
           ZImageCLI upscale -i photo.jpg -w ./models/seedvr2
           ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 4096 --seed 42
+          ZImageCLI upscale -i photo.jpg --esrgan-weights ./models/4x-ultrasharp --tile-size 512
           ZImageCLI upscale -i low-res.png -w ./models/seedvr2 --softness 0.3 -o high-res.png
         """)
         return
@@ -1895,8 +1906,8 @@ struct ZImageCLI {
       exit(1)
     }
 
-    guard let weights = weightsPath else {
-      fputs("Error: --weights is required for upscale\n", stderr)
+    guard weightsPath != nil || esrganWeightsPath != nil else {
+      fputs("Error: --weights or --esrgan-weights is required for upscale\n", stderr)
       exit(1)
     }
 
@@ -1906,6 +1917,29 @@ struct ZImageCLI {
     }
 
     let startTime = CFAbsoluteTimeGetCurrent()
+
+    if let esrganWeights = esrganWeightsPath {
+      let pipeline = try ESRGANPipeline(
+        weightsDirectory: URL(fileURLWithPath: esrganWeights),
+        config: nil,
+        logger: logger
+      )
+
+      let savedPath = try pipeline.upscaleAndSave(
+        imagePath: input,
+        outputPath: outputPath,
+        tileSize: tileSize
+      )
+
+      let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+      logger.info("ESRGAN upscale complete in \(String(format: "%.1f", elapsed))s -> \(savedPath)")
+      return
+    }
+
+    guard let weights = weightsPath else {
+      fputs("Error: --weights is required for SeedVR2 upscale\n", stderr)
+      exit(1)
+    }
 
     let pipeline = try SeedVR2Pipeline(
       weightsPath: weights,
@@ -1926,7 +1960,7 @@ struct ZImageCLI {
   }
   #else
   private static func runUpscale(args: [String]) throws {
-    fputs("Error: SeedVR2 upscale requires CoreGraphics (macOS)\n", stderr)
+    fputs("Error: upscale requires CoreGraphics (macOS)\n", stderr)
     exit(1)
   }
   #endif

--- a/Tests/ZImageTests/Upscale/ESRGANModelTests.swift
+++ b/Tests/ZImageTests/Upscale/ESRGANModelTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import MLX
+@testable import ZImage
+
+final class ESRGANModelTests: XCTestCase {
+  func testResidualDenseBlockForwardPassShape() {
+    let block = ResidualDenseBlock(numFeat: 64, numGrowCh: 32)
+    let input = MLX.ones([1, 64, 64, 64], dtype: .float32)
+
+    let output = block(input)
+    MLX.eval(output)
+
+    XCTAssertEqual(output.shape, [1, 64, 64, 64])
+  }
+
+  func testRRDBForwardPassShape() {
+    let block = RRDB(numFeat: 64, numGrowCh: 32)
+    let input = MLX.ones([1, 64, 64, 64], dtype: .float32)
+
+    let output = block(input)
+    MLX.eval(output)
+
+    XCTAssertEqual(output.shape, [1, 64, 64, 64])
+  }
+
+  func testRRDBNetForwardPassShape() {
+    let config = ESRGANConfig(
+      numInCh: 3,
+      numOutCh: 3,
+      scale: 4,
+      numFeat: 8,
+      numBlock: 1,
+      numGrowCh: 4
+    )
+    let model = RRDBNet(config: config)
+    let input = MLX.ones([1, 64, 64, 3], dtype: .float32)
+
+    let output = model(input)
+    MLX.eval(output)
+
+    XCTAssertEqual(output.shape, [1, 256, 256, 3])
+  }
+
+  func testNearestUpsample2xShapeAndValues() {
+    let values = (0..<48).map(Float.init)
+    let input = MLXArray(values, [1, 4, 4, 3])
+
+    let output = RRDBNet.nearestUpsample2x(input)
+    MLX.eval(output)
+
+    XCTAssertEqual(output.shape, [1, 8, 8, 3])
+    let result = output.asArray(Float.self)
+    XCTAssertEqual(result[Self.nhwcIndex(y: 0, x: 0, c: 0, width: 8)], 0)
+    XCTAssertEqual(result[Self.nhwcIndex(y: 1, x: 1, c: 2, width: 8)], 2)
+    XCTAssertEqual(result[Self.nhwcIndex(y: 2, x: 4, c: 0, width: 8)], 18)
+    XCTAssertEqual(result[Self.nhwcIndex(y: 3, x: 5, c: 2, width: 8)], 20)
+  }
+
+  func testResidualScalingIsNotIdentity() {
+    let block = ResidualDenseBlock(numFeat: 4, numGrowCh: 2)
+    let input = MLX.ones([1, 8, 8, 4], dtype: .float32)
+
+    let output = block(input)
+    let diff = MLX.sum(MLX.abs((output - input).asType(.float32)))
+    MLX.eval(diff)
+
+    XCTAssertGreaterThan(diff.item(Float.self), 0)
+  }
+
+  func testDetectConfigCountsBodyBlocksFromSafeTensors() throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let file = directory.appendingPathComponent("tiny.safetensors")
+    let arrays: [String: MLXArray] = [
+      "body.0.rdb1.conv1.weight": MLXArray.zeros([2, 4, 3, 3]),
+      "body.1.rdb1.conv1.weight": MLXArray.zeros([2, 4, 3, 3])
+    ]
+    try MLX.save(arrays: arrays, metadata: [:], url: file)
+
+    let config = ESRGANConfig.detect(from: directory)
+
+    XCTAssertEqual(config.numBlock, 2)
+    XCTAssertEqual(config.scale, 4)
+  }
+
+  func testWeightLoadingFromMockSafeTensors() throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let config = ESRGANConfig(
+      numInCh: 3,
+      numOutCh: 3,
+      scale: 4,
+      numFeat: 4,
+      numBlock: 1,
+      numGrowCh: 2
+    )
+    let model = RRDBNet(config: config)
+    let arrays = makePyTorchLayoutWeights(for: model)
+    try MLX.save(arrays: arrays, metadata: [:], url: directory.appendingPathComponent("mock.safetensors"))
+
+    try ESRGANWeightLoader.loadWeights(into: model, from: directory, dtype: .float32)
+
+    let shapes = Dictionary(uniqueKeysWithValues: model.parameters().flattened().map { ($0.0, $0.1.shape) })
+    XCTAssertEqual(shapes["conv_first.weight"], [4, 3, 3, 3])
+    XCTAssertEqual(shapes["body.0.rdb1.conv1.weight"], [2, 3, 3, 4])
+    XCTAssertEqual(shapes["body.0.rdb1.conv5.weight"], [4, 3, 3, 12])
+    XCTAssertEqual(ESRGANConfig.detect(from: directory).numBlock, 1)
+  }
+
+  private static func nhwcIndex(y: Int, x: Int, c: Int, width: Int, channels: Int = 3) -> Int {
+    (y * width + x) * channels + c
+  }
+
+  private func makeTempDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "esrgan-tests-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  private func makePyTorchLayoutWeights(for model: RRDBNet) -> [String: MLXArray] {
+    var arrays: [String: MLXArray] = [:]
+    for (key, value) in model.parameters().flattened() {
+      if key.hasSuffix(".weight"), value.ndim == 4 {
+        let shape = value.shape
+        let pytorchShape = [shape[0], shape[3], shape[1], shape[2]]
+        arrays[key] = MLXArray.zeros(pytorchShape).asType(.float32)
+      } else {
+        arrays[key] = MLXArray.zeros(value.shape).asType(.float32)
+      }
+    }
+    return arrays
+  }
+}


### PR DESCRIPTION
## Summary

Closes #67. Ports the ESRGAN (RRDBNet) upscaler architecture to MLX Swift for native Apple Silicon execution.

- **ESRGANModel**: ResidualDenseBlock (5 conv, dense connections, 0.2 residual) → RRDB (3 RDB) → RRDBNet (23 blocks for 4x-UltraSharp)
- **ESRGANConfig**: Presets for UltraSharp, RealESRGAN, auto-detection from safetensors
- **ESRGANWeightLoader**: OIHW→OHWI transposition, PyTorch key mapping
- **ESRGANPipeline**: Load → normalize → forward → clip → save, with tiling for large images
- **CLI**: `--esrgan-weights` flag, `--tile-size` option
- **Tests**: Shape validation, upsample, residual scaling

Reference: hanxiao/real-esrgan-mlx (MLX Python, numerically verified against PyTorch)

## Test plan
- [ ] Unit tests pass (`ESRGANModelTests`)
- [ ] Forward pass shapes verified (4x upscale)
- [ ] Download 4x-UltraSharp.safetensors and test real inference
- [ ] Compare output quality against Python reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)