### PR TITLE
feat(scheduler): add RES 2s sampler and beta57 schedule

### DIFF
--- a/Sources/ZImage/Pipeline/Scheduler/RES2sScheduler.swift
+++ b/Sources/ZImage/Pipeline/Scheduler/RES2sScheduler.swift
@@ -1,0 +1,174 @@
+import Foundation
+import MLX
+
+/// RES 2s: Refined Exponential Solver, 2-stage.
+///
+/// A second-order exponential integrator using two model evaluations per
+/// denoising step. The first model output is evaluated at the current sample,
+/// then a substep at `c2 * h` is used for the second evaluation before the
+/// exponential-integrator final update.
+///
+/// Reference: "Improved Order Analysis and Design of Exponential Integrator
+/// for Diffusion Models Sampling" (arXiv:2308.02157).
+public struct RES2sScheduler: ZImageScheduler {
+  public let sigmas: MLXArray
+  public let timesteps: MLXArray
+  public let numInferenceSteps: Int
+  public let requiresIntermediateEvaluation: Bool = true
+  public let c2: Float
+
+  private var firstModelOutput: (timestepIndex: Int, output: MLXArray)?
+
+  /// Create a RES 2s scheduler with pre-computed sigma values.
+  ///
+  /// - Parameters:
+  ///   - numInferenceSteps: Number of denoising steps.
+  ///   - sigmaValues: Array of `numInferenceSteps + 1` sigma values,
+  ///     monotonically decreasing with a trailing zero.
+  ///   - numTrainTimesteps: Training timestep count for deriving timesteps.
+  ///   - c2: Second-stage substep location in log-sigma space. Defaults to 0.5.
+  public init(
+    numInferenceSteps: Int,
+    sigmaValues: [Float],
+    numTrainTimesteps: Int = 1000,
+    c2: Float = 0.5
+  ) {
+    precondition(numInferenceSteps > 0, "numInferenceSteps must be positive")
+    precondition(
+      sigmaValues.count == numInferenceSteps + 1,
+      "sigmaValues must have numInferenceSteps + 1 elements"
+    )
+    precondition(c2 > 0.0 && c2 <= 1.0, "c2 must be in (0, 1]")
+
+    let numTrainF = Float(numTrainTimesteps)
+    let timestepValues = sigmaValues.dropLast().map { $0 * numTrainF }
+
+    self.sigmas = MLXArray(sigmaValues, [sigmaValues.count])
+    self.timesteps = MLXArray(timestepValues, [timestepValues.count])
+    self.numInferenceSteps = numInferenceSteps
+    self.c2 = c2
+  }
+
+  /// Single-step fallback: first-order exponential Euler update.
+  public mutating func step(
+    modelOutput: MLXArray,
+    timestepIndex: Int,
+    sample: MLXArray
+  ) -> MLXArray {
+    precondition(
+      timestepIndex >= 0 && timestepIndex + 1 < sigmas.dim(0),
+      "invalid timestep index"
+    )
+
+    firstModelOutput = nil
+
+    let h = stepSize(timestepIndex: timestepIndex)
+    let decay = scalar(expf(-h), like: sample)
+    let coeff = scalar(h * Self.phi1(-h), like: sample)
+    return decay * sample + coeff * modelOutput
+  }
+
+  /// Compute the RES 2s intermediate sample at `c2 * h`.
+  public mutating func intermediateStep(
+    modelOutput: MLXArray,
+    timestepIndex: Int,
+    sample: MLXArray
+  ) -> MLXArray? {
+    precondition(
+      timestepIndex >= 0 && timestepIndex + 1 < sigmas.dim(0),
+      "invalid timestep index"
+    )
+
+    firstModelOutput = (timestepIndex, modelOutput)
+
+    let h = stepSize(timestepIndex: timestepIndex)
+    let a21 = c2 * Self.phi1(-h * c2)
+    let decay = scalar(expf(-c2 * h), like: sample)
+    let coeff = scalar(h * a21, like: sample)
+    return decay * sample + coeff * modelOutput
+  }
+
+  /// Sigma for the second model evaluation, located at `c2 * h`.
+  public func intermediateSigma(timestepIndex: Int) -> Float? {
+    precondition(
+      timestepIndex >= 0 && timestepIndex + 1 < sigmas.dim(0),
+      "invalid timestep index"
+    )
+
+    let sigma = sigmas[timestepIndex].item(Float.self)
+    let h = stepSize(timestepIndex: timestepIndex)
+    return sigma * expf(-c2 * h)
+  }
+
+  /// Final RES 2s update using the stored first output and second-stage output.
+  public mutating func finalizeStep(
+    originalOutput: MLXArray,
+    intermediateOutput: MLXArray,
+    timestepIndex: Int,
+    sample: MLXArray
+  ) -> MLXArray {
+    precondition(
+      timestepIndex >= 0 && timestepIndex + 1 < sigmas.dim(0),
+      "invalid timestep index"
+    )
+
+    let k1: MLXArray
+    if let firstModelOutput, firstModelOutput.timestepIndex == timestepIndex {
+      k1 = firstModelOutput.output
+    } else {
+      k1 = originalOutput
+    }
+    firstModelOutput = nil
+
+    let h = stepSize(timestepIndex: timestepIndex)
+    let phi1Value = Self.phi1(-h)
+    let phi2Value = Self.phi2(-h)
+    let b1 = phi1Value - phi2Value / c2
+    let b2 = phi2Value / c2
+
+    let decay = scalar(expf(-h), like: sample)
+    let coeff1 = scalar(h * b1, like: sample)
+    let coeff2 = scalar(h * b2, like: sample)
+    return decay * sample + coeff1 * k1 + coeff2 * intermediateOutput
+  }
+
+  public mutating func reset() {
+    firstModelOutput = nil
+  }
+
+  // MARK: - Phi Functions
+
+  static func phi1ForTesting(_ z: Float) -> Float {
+    phi1(z)
+  }
+
+  static func phi2ForTesting(_ z: Float) -> Float {
+    phi2(z)
+  }
+
+  private static func phi1(_ z: Float) -> Float {
+    if abs(z) < 1e-4 {
+      return 1.0 + z / 2.0 + z * z / 6.0
+    }
+    return (expf(z) - 1.0) / z
+  }
+
+  private static func phi2(_ z: Float) -> Float {
+    if abs(z) < 1e-4 {
+      return 0.5 + z / 6.0 + z * z / 24.0
+    }
+    return (expf(z) - 1.0 - z) / (z * z)
+  }
+
+  // MARK: - Helpers
+
+  private func stepSize(timestepIndex: Int) -> Float {
+    let sigma = max(sigmas[timestepIndex].item(Float.self), 1e-8)
+    let sigmaNext = max(sigmas[timestepIndex + 1].item(Float.self), 1e-8)
+    return -logf(sigmaNext / sigma)
+  }
+
+  private func scalar(_ value: Float, like sample: MLXArray) -> MLXArray {
+    MLXArray(value).asType(sample.dtype)
+  }
+}

--- a/Sources/ZImage/Pipeline/Scheduler/SchedulerFactory.swift
+++ b/Sources/ZImage/Pipeline/Scheduler/SchedulerFactory.swift
@@ -10,6 +10,7 @@ public enum SchedulerKind: String, CaseIterable, Sendable {
   case dpmplusplus2sa = "dpmpp-2s-a"
   case deis = "deis"
   case ddim = "ddim"
+  case res2s = "res_2s"
 }
 
 /// Creates scheduler instances by kind.
@@ -27,6 +28,7 @@ public enum SchedulerFactory {
   ///   - mu: Dynamic shifting parameter (pass non-nil when `config.useDynamicShifting`).
   ///   - seed: Random seed for stochastic samplers (DPM++ 2S-A, DDIM with eta > 0).
   ///   - eta: DDIM stochasticity parameter (0 = deterministic, 1 = full DDPM).
+  ///   - c2: RES 2s second-stage substep location in log-sigma space.
   /// - Returns: A type-erased ``ZImageScheduler``.
   public static func create(
     kind: SchedulerKind,
@@ -35,7 +37,8 @@ public enum SchedulerFactory {
     config: ZImageSchedulerConfig,
     mu: Float? = nil,
     seed: UInt64? = nil,
-    eta: Float? = nil
+    eta: Float? = nil,
+    c2: Float = 0.5
   ) -> any ZImageScheduler {
     let sigmaValues = resolveSigmas(
       schedule: sigmaSchedule,
@@ -100,6 +103,14 @@ public enum SchedulerFactory {
         sigmaValues: sigmaValues,
         numTrainTimesteps: config.numTrainTimesteps
       )
+
+    case .res2s:
+      return RES2sScheduler(
+        numInferenceSteps: numInferenceSteps,
+        sigmaValues: sigmaValues,
+        numTrainTimesteps: config.numTrainTimesteps,
+        c2: c2
+      )
     }
   }
 
@@ -123,6 +134,15 @@ public enum SchedulerFactory {
     case .beta:
       let (lo, hi) = flowMatchingSigmaBounds(config: config)
       return SigmaSchedule.beta(numSteps: numSteps, sigmaMin: lo, sigmaMax: hi)
+    case .beta57:
+      let (lo, hi) = flowMatchingSigmaBounds(config: config)
+      return SigmaSchedule.beta(
+        numSteps: numSteps,
+        sigmaMin: lo,
+        sigmaMax: hi,
+        alpha: 0.5,
+        betaParam: 0.7
+      )
     }
   }
 

--- a/Sources/ZImage/Pipeline/Scheduler/SigmaSchedule.swift
+++ b/Sources/ZImage/Pipeline/Scheduler/SigmaSchedule.swift
@@ -6,6 +6,7 @@ public enum SigmaScheduleKind: String, CaseIterable, Sendable {
   case karras = "karras"
   case exponential = "exponential"
   case beta = "beta"
+  case beta57 = "beta57"
 }
 
 /// Pure-function sigma schedule generators.

--- a/Sources/ZImage/Pipeline/Scheduler/ZImageScheduler.swift
+++ b/Sources/ZImage/Pipeline/Scheduler/ZImageScheduler.swift
@@ -51,6 +51,13 @@ public protocol ZImageScheduler {
     sample: MLXArray
   ) -> MLXArray?
 
+  /// Sigma value for the intermediate model evaluation.
+  ///
+  /// Multi-evaluation schedulers may evaluate the second stage at a
+  /// substep between the current and next sigma. The default matches
+  /// Heun's existing next-sigma intermediate point.
+  func intermediateSigma(timestepIndex: Int) -> Float?
+
   /// Finalize a multi-evaluation step using predictions at both
   /// the original and intermediate points.
   ///
@@ -79,6 +86,14 @@ public extension ZImageScheduler {
     sample: MLXArray
   ) -> MLXArray? {
     nil
+  }
+
+  func intermediateSigma(timestepIndex: Int) -> Float? {
+    precondition(
+      timestepIndex >= 0 && timestepIndex + 1 < sigmas.dim(0),
+      "invalid timestep index"
+    )
+    return sigmas[timestepIndex + 1].item(Float.self)
   }
 
   mutating func finalizeStep(

--- a/Sources/ZImage/Pipeline/ZImageControlPipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImageControlPipeline.swift
@@ -1116,8 +1116,9 @@ public class ZImageControlPipeline {
            let intermediateSample = scheduler.intermediateStep(
              modelOutput: -guidedNoise, timestepIndex: stepIndex, sample: latents
            ) {
-          let nextSigma = scheduler.sigmas[stepIndex + 1].item(Float.self)
-          let intermediateTimestepValue = nextSigma * numTrainTimestepsF
+          let intermediateSigma = scheduler.intermediateSigma(timestepIndex: stepIndex)
+            ?? scheduler.sigmas[stepIndex + 1].item(Float.self)
+          let intermediateTimestepValue = intermediateSigma * numTrainTimestepsF
           let intermediateNormalized = (1000.0 - intermediateTimestepValue) / 1000.0
           let intermediateTimestepArray = MLXArray([intermediateNormalized], [1])
           var intermediateModelLatents = intermediateSample
@@ -1406,8 +1407,9 @@ public class ZImageControlPipeline {
            let intermediateSample = scheduler.intermediateStep(
              modelOutput: -guidedNoise, timestepIndex: stepIndex, sample: latents
            ) {
-          let nextSigma = scheduler.sigmas[stepIndex + 1].item(Float.self)
-          let intermediateTimestepValue = nextSigma * numTrainTimestepsF
+          let intermediateSigma = scheduler.intermediateSigma(timestepIndex: stepIndex)
+            ?? scheduler.sigmas[stepIndex + 1].item(Float.self)
+          let intermediateTimestepValue = intermediateSigma * numTrainTimestepsF
           let intermediateNormalized = (1000.0 - intermediateTimestepValue) / 1000.0
           let intermediateTimestepArray = MLXArray([intermediateNormalized], [1])
           var intermediateModelLatents = intermediateSample

--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -1034,9 +1034,10 @@ public final class ZImagePipeline {
            let intermediateSample = scheduler.intermediateStep(
              modelOutput: -guidedNoise, timestepIndex: stepIndex, sample: latents
            ) {
-          // Derive timestep at the intermediate point (sigma[stepIndex+1])
-          let nextSigma = scheduler.sigmas[stepIndex + 1].item(Float.self)
-          let intermediateTimestepValue = nextSigma * numTrainTimestepsF
+          // Derive timestep at the scheduler's intermediate point.
+          let intermediateSigma = scheduler.intermediateSigma(timestepIndex: stepIndex)
+            ?? scheduler.sigmas[stepIndex + 1].item(Float.self)
+          let intermediateTimestepValue = intermediateSigma * numTrainTimestepsF
           let intermediateNormalized = (1000.0 - intermediateTimestepValue) / 1000.0
           let intermediateTimestepArray = MLXArray([intermediateNormalized], [1])
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1833,8 +1833,8 @@ extension GeneratePayload: Decodable {
       defaultFilename: "zimage-\(UUID().uuidString).png"
     )
 
-    let schedulerKind = scheduler.flatMap { SchedulerKind(rawValue: $0) } ?? .euler
-    let sigmaScheduleKind = sigmaSchedule.flatMap { SigmaScheduleKind(rawValue: $0) } ?? .flow
+    let schedulerKind = Self.parseSchedulerKind(scheduler)
+    let sigmaScheduleKind = Self.parseSigmaScheduleKind(sigmaSchedule)
 
     // Build DyPE config — auto-enable for high-res requests
     let resolvedWidth = width ?? ZImageModelMetadata.recommendedWidth
@@ -1907,8 +1907,8 @@ extension GeneratePayload: Decodable {
       specifiedAs = .strength
     }
 
-    let schedulerKind = scheduler.flatMap { SchedulerKind(rawValue: $0) } ?? .euler
-    let sigmaScheduleKind = sigmaSchedule.flatMap { SigmaScheduleKind(rawValue: $0) } ?? .flow
+    let schedulerKind = Self.parseSchedulerKind(scheduler)
+    let sigmaScheduleKind = Self.parseSigmaScheduleKind(sigmaSchedule)
 
     let resolvedWidth = width ?? ZImageModelMetadata.recommendedWidth
     let resolvedHeight = height ?? ZImageModelMetadata.recommendedHeight
@@ -1962,6 +1962,26 @@ extension GeneratePayload: Decodable {
       switch self {
       case .mutuallyExclusive(let msg): return msg
       }
+    }
+  }
+
+  private static func parseSchedulerKind(_ rawValue: String?) -> SchedulerKind {
+    guard let rawValue else { return .euler }
+    switch rawValue {
+    case "res_2s":
+      return .res2s
+    default:
+      return SchedulerKind(rawValue: rawValue) ?? .euler
+    }
+  }
+
+  private static func parseSigmaScheduleKind(_ rawValue: String?) -> SigmaScheduleKind {
+    guard let rawValue else { return .flow }
+    switch rawValue {
+    case "beta57":
+      return .beta57
+    default:
+      return SigmaScheduleKind(rawValue: rawValue) ?? .flow
     }
   }
 

--- a/Sources/ZImageCLI/main.swift
+++ b/Sources/ZImageCLI/main.swift
@@ -1223,8 +1223,8 @@ struct ZImageCLI {
       --lora-scale           LoRA scale factor override for the next unmatched --lora (repeatable)
       --lora-paths           Comma-separated LoRA paths or HuggingFace IDs (quoted commas unsupported)
       --lora-scales          Comma-separated LoRA scale overrides (default: 1.0)
-      --scheduler, --sampler  Sampler algorithm: euler, heun, dpmpp-2m, dpmpp-2s-a, deis, ddim (default: euler)
-      --sigma-schedule       Sigma schedule: flow, karras, exponential, beta (default: flow)
+      --scheduler, --sampler  Sampler algorithm: euler, heun, res_2s, dpmpp-2m, dpmpp-2s-a, deis, ddim (default: euler)
+      --sigma-schedule       Sigma schedule: flow, karras, exponential, beta, beta57 (default: flow)
       --eta                  Stochasticity for DDIM/DPM++ 2S-A (0=deterministic, 1=DDPM; default: 0)
       --dype <method>        DyPE high-res mode: ntk, yarn, none (auto-enables for >1024px)
       --no-dype              Disable DyPE even for high-res generation
@@ -1302,6 +1302,7 @@ struct ZImageCLI {
       ZImageCLI -p "cat" --enhance  # Enhanced prompt generation
       ZImageCLI -p "portrait" --scheduler dpmpp-2m --sigma-schedule beta  # Best photorealism combo
       ZImageCLI -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
+      ZImageCLI -p "refiner pass" --scheduler res_2s --sigma-schedule beta57  # RES 2s + beta57
       ZImageCLI -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
       ZImageCLI serve -m ./models/z-image-turbo --port 7862
       ZImageCLI -p "portrait" --auto-seeds 5 -o portraits.png  # Generate 5 random variations
@@ -1899,8 +1900,8 @@ struct ZImageCLI {
       --lora-scale              LoRA scale factor override for the next unmatched --lora (repeatable)
       --lora-paths              Comma-separated LoRA paths or HuggingFace IDs (quoted commas unsupported)
       --lora-scales             Comma-separated LoRA scale overrides (default: 1.0)
-      --scheduler, --sampler    Sampler algorithm: euler, heun, dpmpp-2m, dpmpp-2s-a, deis, ddim (default: euler)
-      --sigma-schedule          Sigma schedule: flow, karras, exponential, beta (default: flow)
+      --scheduler, --sampler    Sampler algorithm: euler, heun, res_2s, dpmpp-2m, dpmpp-2s-a, deis, ddim (default: euler)
+      --sigma-schedule          Sigma schedule: flow, karras, exponential, beta, beta57 (default: flow)
       --eta                     Stochasticity for DDIM/DPM++ 2S-A (0=deterministic, 1=DDPM; default: 0)
       --no-progress             Disable progress output
       --help, -h                Show help

--- a/Tests/ZImageTests/Scheduler/RES2sSchedulerTests.swift
+++ b/Tests/ZImageTests/Scheduler/RES2sSchedulerTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+import MLX
+@testable import ZImage
+
+final class RES2sSchedulerTests: XCTestCase {
+
+  // MARK: - Phi Functions
+
+  func testPhi1AtZeroUsesTaylorExpansion() {
+    XCTAssertEqual(RES2sScheduler.phi1ForTesting(0.0), 1.0, accuracy: 1e-6)
+  }
+
+  func testPhi1AtOne() {
+    XCTAssertEqual(
+      RES2sScheduler.phi1ForTesting(1.0),
+      expf(1.0) - 1.0,
+      accuracy: 1e-5
+    )
+  }
+
+  func testPhi2AtZeroUsesTaylorExpansion() {
+    XCTAssertEqual(RES2sScheduler.phi2ForTesting(0.0), 0.5, accuracy: 1e-6)
+  }
+
+  func testPhi2AtOne() {
+    XCTAssertEqual(
+      RES2sScheduler.phi2ForTesting(1.0),
+      expf(1.0) - 2.0,
+      accuracy: 1e-5
+    )
+  }
+
+  // MARK: - Initialization
+
+  func testInitializationWithDefaultC2() {
+    let scheduler = Self.makeScheduler(steps: 9)
+
+    XCTAssertEqual(scheduler.numInferenceSteps, 9)
+    XCTAssertEqual(scheduler.sigmas.dim(0), 10)
+    XCTAssertEqual(scheduler.timesteps.dim(0), 9)
+    XCTAssertEqual(scheduler.c2, 0.5, accuracy: 1e-6)
+  }
+
+  // MARK: - Multi-Evaluation Protocol
+
+  func testRequiresIntermediateEvaluation() {
+    let scheduler = Self.makeScheduler(steps: 9)
+    XCTAssertTrue(scheduler.requiresIntermediateEvaluation)
+  }
+
+  func testIntermediateStepReturnsNonNilWithShapePreserved() {
+    var scheduler = Self.makeScheduler(steps: 9)
+    let sample = Self.makeSample()
+    let modelOutput = Self.makeModelOutput()
+
+    let intermediate = scheduler.intermediateStep(
+      modelOutput: modelOutput,
+      timestepIndex: 0,
+      sample: sample
+    )
+
+    XCTAssertNotNil(intermediate)
+    XCTAssertEqual(intermediate?.shape, sample.shape)
+  }
+
+  func testIntermediateSigmaUsesGeometricMidpointByDefault() {
+    let scheduler = Self.makeScheduler(steps: 9)
+    let sigmas = scheduler.sigmas.asArray(Float.self)
+
+    let intermediateSigma = scheduler.intermediateSigma(timestepIndex: 0)
+
+    XCTAssertEqual(
+      intermediateSigma!,
+      sqrtf(sigmas[0] * sigmas[1]),
+      accuracy: 1e-6
+    )
+  }
+
+  // MARK: - Finalize Behavior
+
+  func testFinalizeStepProducesDifferentOutputThanInput() {
+    var scheduler = Self.makeScheduler(steps: 9)
+    let sample = Self.makeSample()
+    let modelOutput = Self.makeModelOutput()
+    let intermediateOutput = Self.makeModelOutput(values: [0.15, 0.25, 0.35, 0.45])
+
+    _ = scheduler.intermediateStep(
+      modelOutput: modelOutput,
+      timestepIndex: 0,
+      sample: sample
+    )
+    let result = scheduler.finalizeStep(
+      originalOutput: modelOutput,
+      intermediateOutput: intermediateOutput,
+      timestepIndex: 0,
+      sample: sample
+    )
+
+    XCTAssertEqual(result.shape, sample.shape)
+    XCTAssertFalse(Self.arraysEqual(result, sample), "RES 2s output should differ from input")
+  }
+
+  // MARK: - Full Loop
+
+  func testFullLoopWithIntermediateAndFinalize() {
+    var scheduler = Self.makeScheduler(steps: 9)
+    var sample = Self.makeSample()
+    let modelOutput = Self.makeModelOutput()
+    let intermediateOutput = Self.makeModelOutput(values: [0.12, 0.22, 0.32, 0.42])
+
+    for i in 0..<scheduler.numInferenceSteps {
+      let intermediate = scheduler.intermediateStep(
+        modelOutput: modelOutput,
+        timestepIndex: i,
+        sample: sample
+      )
+      XCTAssertNotNil(intermediate)
+
+      sample = scheduler.finalizeStep(
+        originalOutput: modelOutput,
+        intermediateOutput: intermediateOutput,
+        timestepIndex: i,
+        sample: sample
+      )
+      MLX.eval(sample.asType(.float32))
+    }
+
+    XCTAssertEqual(sample.shape, [1, 1, 2, 2])
+  }
+
+  func testShapePreservationThroughFullLoop() {
+    var scheduler = Self.makeScheduler(steps: 9)
+    var sample = Self.makeSample()
+    let originalShape = sample.shape
+    let modelOutput = Self.makeModelOutput()
+    let intermediateOutput = Self.makeModelOutput(values: [0.12, 0.22, 0.32, 0.42])
+
+    for i in 0..<scheduler.numInferenceSteps {
+      let intermediate = scheduler.intermediateStep(
+        modelOutput: modelOutput,
+        timestepIndex: i,
+        sample: sample
+      )!
+      XCTAssertEqual(intermediate.shape, originalShape)
+
+      sample = scheduler.finalizeStep(
+        originalOutput: modelOutput,
+        intermediateOutput: intermediateOutput,
+        timestepIndex: i,
+        sample: sample
+      )
+      XCTAssertEqual(sample.shape, originalShape)
+      MLX.eval(sample.asType(.float32))
+    }
+  }
+
+  // MARK: - Helpers
+
+  static func defaultSigmas(steps: Int) -> [Float] {
+    SigmaSchedule.flow(
+      numSteps: steps,
+      config: FlowMatchSchedulerTests.makeConfig()
+    )
+  }
+
+  static func makeScheduler(steps: Int) -> RES2sScheduler {
+    RES2sScheduler(
+      numInferenceSteps: steps,
+      sigmaValues: defaultSigmas(steps: steps),
+      numTrainTimesteps: 1000
+    )
+  }
+
+  static func makeSample(values: [Float] = [1.0, 2.0, 3.0, 4.0]) -> MLXArray {
+    MLXArray(values, [1, 1, 2, 2]).asType(.bfloat16)
+  }
+
+  static func makeModelOutput(values: [Float] = [0.1, 0.2, 0.3, 0.4]) -> MLXArray {
+    MLXArray(values, [1, 1, 2, 2]).asType(.bfloat16)
+  }
+
+  static func arraysEqual(_ lhs: MLXArray, _ rhs: MLXArray, accuracy: Float = 1e-5) -> Bool {
+    let lhsF32 = lhs.asType(.float32)
+    let rhsF32 = rhs.asType(.float32)
+    MLX.eval(lhsF32, rhsF32)
+
+    let lhsData = lhsF32.asArray(Float.self)
+    let rhsData = rhsF32.asArray(Float.self)
+    return zip(lhsData, rhsData).allSatisfy { pair in
+      abs(pair.0 - pair.1) <= accuracy
+    }
+  }
+}

--- a/Tests/ZImageTests/Scheduler/SchedulerFactoryTests.swift
+++ b/Tests/ZImageTests/Scheduler/SchedulerFactoryTests.swift
@@ -139,6 +139,7 @@ final class SchedulerFactoryTests: XCTestCase {
     XCTAssertEqual(SchedulerKind(rawValue: "dpmpp-2s-a"), .dpmplusplus2sa)
     XCTAssertEqual(SchedulerKind(rawValue: "deis"), .deis)
     XCTAssertEqual(SchedulerKind(rawValue: "ddim"), .ddim)
+    XCTAssertEqual(SchedulerKind(rawValue: "res_2s"), .res2s)
   }
 
   func testUnknownSigmaScheduleKindFromString() {
@@ -151,6 +152,7 @@ final class SchedulerFactoryTests: XCTestCase {
     XCTAssertEqual(SigmaScheduleKind(rawValue: "karras"), .karras)
     XCTAssertEqual(SigmaScheduleKind(rawValue: "exponential"), .exponential)
     XCTAssertEqual(SigmaScheduleKind(rawValue: "beta"), .beta)
+    XCTAssertEqual(SigmaScheduleKind(rawValue: "beta57"), .beta57)
   }
 
   // MARK: - All Kinds
@@ -266,10 +268,53 @@ final class SchedulerFactoryTests: XCTestCase {
     XCTAssertTrue(scheduler.requiresIntermediateEvaluation)
   }
 
+  func testRES2sCreation() {
+    let config = FlowMatchSchedulerTests.makeConfig()
+    let scheduler = SchedulerFactory.create(
+      kind: .res2s,
+      numInferenceSteps: 9,
+      config: config
+    )
+
+    XCTAssertEqual(scheduler.numInferenceSteps, 9)
+    XCTAssertEqual(scheduler.sigmas.dim(0), 10)
+    XCTAssertTrue(scheduler.requiresIntermediateEvaluation)
+  }
+
+  func testBeta57ScheduleCreation() {
+    let config = FlowMatchSchedulerTests.makeConfig()
+    let scheduler = SchedulerFactory.create(
+      kind: .euler,
+      sigmaSchedule: .beta57,
+      numInferenceSteps: 9,
+      config: config
+    )
+    let defaultBeta = SchedulerFactory.create(
+      kind: .euler,
+      sigmaSchedule: .beta,
+      numInferenceSteps: 9,
+      config: config
+    )
+
+    let beta57Sigmas = scheduler.sigmas.asArray(Float.self)
+    let defaultBetaSigmas = defaultBeta.sigmas.asArray(Float.self)
+    XCTAssertEqual(beta57Sigmas.count, 10)
+    XCTAssertEqual(beta57Sigmas.last!, 0.0, accuracy: 1e-10)
+
+    var differs = false
+    for i in 0..<beta57Sigmas.count {
+      if abs(beta57Sigmas[i] - defaultBetaSigmas[i]) > 1e-6 {
+        differs = true
+        break
+      }
+    }
+    XCTAssertTrue(differs, "Factory beta57 should differ from default beta")
+  }
+
   func testPhase2SamplersWithKarrasSchedule() {
     let config = FlowMatchSchedulerTests.makeConfig()
     let phase2Kinds: [SchedulerKind] = [
-      .dpmplusplus2m, .ddim, .deis, .dpmplusplus2sa, .heun
+      .dpmplusplus2m, .ddim, .deis, .dpmplusplus2sa, .heun, .res2s
     ]
 
     for kind in phase2Kinds {

--- a/Tests/ZImageTests/Scheduler/SigmaScheduleTests.swift
+++ b/Tests/ZImageTests/Scheduler/SigmaScheduleTests.swift
@@ -215,6 +215,54 @@ final class SigmaScheduleTests: XCTestCase {
     }
   }
 
+  func testBeta57DiffersFromDefaultBeta() {
+    let steps = 9
+    let beta = SigmaSchedule.beta(
+      numSteps: steps,
+      sigmaMin: 0.001,
+      sigmaMax: 1.0
+    )
+    let beta57 = SigmaSchedule.beta(
+      numSteps: steps,
+      sigmaMin: 0.001,
+      sigmaMax: 1.0,
+      alpha: 0.5,
+      betaParam: 0.7
+    )
+
+    XCTAssertEqual(beta57.count, steps + 1)
+    XCTAssertEqual(beta57.last!, 0.0, accuracy: 1e-10)
+
+    var differs = false
+    for i in 0..<beta57.count {
+      if abs(beta57[i] - beta[i]) > 1e-6 {
+        differs = true
+        break
+      }
+    }
+    XCTAssertTrue(differs, "beta57 should differ from default beta")
+  }
+
+  func testBeta57MonotonicallyDecreasing() {
+    let sigmas = SigmaSchedule.beta(
+      numSteps: 20,
+      sigmaMin: 0.001,
+      sigmaMax: 1.0,
+      alpha: 0.5,
+      betaParam: 0.7
+    )
+
+    XCTAssertEqual(sigmas.count, 21)
+    for i in 1..<sigmas.count {
+      XCTAssertLessThanOrEqual(
+        sigmas[i],
+        sigmas[i - 1],
+        "beta57 sigmas should decrease monotonically at index \(i)"
+      )
+    }
+    XCTAssertEqual(sigmas.last!, 0.0, accuracy: 1e-10)
+  }
+
   // MARK: - Linspace Helper
 
   func testLinspaceTwoElements() {


### PR DESCRIPTION
## Summary

Closes #66. Adds the RES 2s (Refined Exponential Solver, 2-stage) sampler and beta57 schedule variant used in Wan 2.2 refiner workflows.

- **RES2sScheduler**: Two-eval exponential integrator using phi functions instead of Heun's trapezoidal rule. Follows HeunScheduler pattern with `intermediateStep`/`finalizeStep`.
- **Beta57 schedule**: Exposes `SigmaSchedule.beta(alpha: 0.5, beta: 0.7)` — asymmetric schedule concentrating denoising budget in high-noise region.
- CLI: `--scheduler res_2s`, `--sigma-schedule beta57`
- WarmServer: `res_2s` sampler + `beta57` schedule in `/v1/generate`
- Tests: phi function accuracy, shape preservation, full loop, beta57 sigma properties

## Test plan
- [ ] Unit tests pass (`RES2sSchedulerTests`)
- [ ] phi1/phi2 functions verified against known values
- [ ] Full denoising loop completes without crash
- [ ] Beta57 sigmas are monotonically decreasing with correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)