### PR TITLE
fix(bridge): add missing ObjectInfo nodes + sampler mapping

### DIFF
--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -283,7 +283,7 @@ enum ComfyBridgeObjectInfo {
     )
     info["KSamplerSelect"] = nodeDefinition(
       required: [
-        "sampler_name": optionInput(["euler", "heun", "dpmpp_2m", "dpmpp_2s_ancestral", "deis", "ddim", "uni_pc"]),
+        "sampler_name": optionInput(["euler", "heun", "dpmpp_2m", "dpmpp_2s_ancestral", "deis", "ddim", "uni_pc", "res_2s"]),
       ],
       outputs: ["SAMPLER"]
     )
@@ -377,6 +377,32 @@ enum ComfyBridgeObjectInfo {
         "unet_name": optionInput([]),
       ],
       outputs: ["MODEL"]
+    )
+
+
+    // --- Nodes referenced by ComfyBridge parser ---
+    info["ImageCrop"] = nodeDefinition(
+      required: [
+        "image": imageInput(),
+        "width": intInput(default: 512),
+        "height": intInput(default: 512),
+        "x": intInput(default: 0),
+        "y": intInput(default: 0),
+      ],
+      outputs: ["IMAGE"]
+    )
+    info["SplitSigmas"] = nodeDefinition(
+      required: [
+        "sigmas": sigmasInput(),
+        "step": intInput(default: 0),
+      ],
+      outputs: ["SIGMAS", "SIGMAS"]
+    )
+    info["PreviewImage"] = nodeDefinition(
+      required: [
+        "images": imageInput(),
+      ],
+      outputs: []
     )
 
     return info

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -22,6 +22,8 @@ struct ComfyBridgeGenerateRequest: Sendable {
   let batchSize: Int
   /// The node ID of the output node (ETN_SaveImageCache or PreviewImage).
   let outputNodeId: String
+  /// Sampler name extracted from KSamplerSelect node (e.g. "euler", "res_2s").
+  let sampler: String?
 
   // --- Phase 3: Inpainting fields ---
 
@@ -234,6 +236,10 @@ enum ComfyBridgeWorkflowParser {
     let noiseNode = nodes.values.first { $0.classType == "RandomNoise" }
     let seed = uint64Value(noiseNode?.inputs["noise_seed"])
 
+    // --- Sampler name ---
+    let samplerSelectNode = nodes.values.first { $0.classType == "KSamplerSelect" }
+    let samplerName = samplerSelectNode?.inputs["sampler_name"] as? String
+
     // --- Output node ---
     let outputNodeId: String
     if let saveNode = nodes.values.first(where: { $0.classType == "ETN_SaveImageCache" }) {
@@ -337,6 +343,7 @@ enum ComfyBridgeWorkflowParser {
       seed: seed,
       batchSize: max(batchSize, 1),
       outputNodeId: outputNodeId,
+      sampler: samplerName,
       inpaintImageId: inpaintImageId,
       maskImageId: maskImageId,
       denoise: denoise,

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -569,6 +569,7 @@ public final class WarmServer {
       guidance: resolvedGuidance,
       seed: request.seed,
       outputPath: nil,
+      scheduler: request.sampler,
       inpaintImageData: request.inpaintImageData,
       maskData: request.maskImageData,
       denoise: request.denoise,


### PR DESCRIPTION
## Summary
- Add ImageCrop, SplitSigmas, PreviewImage node declarations to ObjectInfo
- Add `res_2s` to KSamplerSelect sampler options
- Extract and map sampler_name from KSamplerSelect through bridge generate path
- Bridge generations now respect sampler selection instead of always defaulting to euler

All 5 P0 Krita bridge gaps resolved.

## Test plan
- [x] swift build -c release succeeds (45.9s)
- [ ] Test with Krita AI Diffusion: verify no missing node warnings, verify sampler selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)