### PR TITLE
chore: rename package to ComfyBox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
 
       - name: Type check
         run: |
-          xcodebuild build -scheme ZImageCLI -configuration Debug -destination 'platform=macOS' -derivedDataPath ./dist -skipPackagePluginValidation ENABLE_PLUGIN_PREPAREMLSHADERS=YES CLANG_COVERAGE_MAPPING=NO 2>&1
+          xcodebuild build -scheme ComfyBox -configuration Debug -destination 'platform=macOS' -derivedDataPath ./dist -skipPackagePluginValidation ENABLE_PLUGIN_PREPAREMLSHADERS=YES CLANG_COVERAGE_MAPPING=NO 2>&1
 
       - name: Run unit tests
-        run: xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests
+        run: xcodebuild test -scheme comfybox-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests
 
   release-build:
     if: github.ref == 'refs/heads/main'
@@ -53,14 +53,14 @@ jobs:
 
       - name: Release build
         run: |
-          xcodebuild build -scheme ZImageCLI -configuration Release -destination 'platform=macOS' -derivedDataPath ./dist -skipPackagePluginValidation ENABLE_PLUGIN_PREPAREMLSHADERS=YES CLANG_COVERAGE_MAPPING=NO
+          xcodebuild build -scheme ComfyBox -configuration Release -destination 'platform=macOS' -derivedDataPath ./dist -skipPackagePluginValidation ENABLE_PLUGIN_PREPAREMLSHADERS=YES CLANG_COVERAGE_MAPPING=NO
 
       - name: Prepare Artifacts
         run: |
           cd ./dist/Build/Products/Release
-          chmod +x ZImageCLI
+          chmod +x ComfyBox
           cp mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib .
-          zip -r zimage.macos.arm64.zip ZImageCLI default.metallib
+          zip -r comfybox.macos.arm64.zip ComfyBox default.metallib
 
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
@@ -75,5 +75,5 @@ jobs:
           draft: false
           prerelease: true
           allowUpdates: true
-          artifacts: ./dist/Build/Products/Release/zimage.macos.arm64.zip
+          artifacts: ./dist/Build/Products/Release/comfybox.macos.arm64.zip
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,36 +1,38 @@
 # CLAUDE.md
 
+> Repo renamed from zimage.swift to comfybox on 2026-05-08. Package and executable are now "ComfyBox"; the ZImage Swift module name is unchanged.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 
-Z-Image.swift is a Swift port of [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) using mlx-swift for Apple Silicon. It provides a CLI tool and library for text-to-image generation with support for LoRA and ControlNet.
+ComfyBox (formerly Z-Image.swift) is a Swift port of [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) using mlx-swift for Apple Silicon. It provides a CLI tool and library for text-to-image generation with support for LoRA and ControlNet.
 
 ## Build Commands
 
 ```bash
 # Build release CLI binary
-xcodebuild -scheme ZImageCLI -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
+xcodebuild -scheme ComfyBox -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
 
 # Run all tests (use -enableCodeCoverage NO to avoid creating default.profraw)
-xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enableCodeCoverage NO
+xcodebuild test -scheme comfybox-Package -destination 'platform=macOS' -enableCodeCoverage NO
 
 # Run specific test target
-xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests
+xcodebuild test -scheme comfybox-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests
 
 # Run a single test class
-xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests/FlowMatchSchedulerTests
+xcodebuild test -scheme comfybox-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests/FlowMatchSchedulerTests
 
 # Run a single test method
-xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests/FlowMatchSchedulerTests/testTimestepsDecreasing
+xcodebuild test -scheme comfybox-Package -destination 'platform=macOS' -enableCodeCoverage NO -only-testing:ZImageTests/FlowMatchSchedulerTests/testTimestepsDecreasing
 ```
 
 ## Architecture
 
 ### Core Components
 
-**Application Layer** (`Sources/ZImageCLI`):
-- `ZImageCLI`: Entry point for generation, controlnet, and quantization commands. Handles argument parsing and global GPU settings.
+**Application Layer** (`Sources/ComfyBox`):
+- `ComfyBox`: Entry point for generation, controlnet, and quantization commands. Handles argument parsing and global GPU settings.
 
 **Pipeline Layer** (`Sources/ZImage/Pipeline`):
 - `ZImagePipeline`: Orchestrates Text-to-Image generation. Manages dynamic model loading/unloading (phase-scoped lifetimes), LoRA application, and the denoising loop.
@@ -51,13 +53,13 @@ xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -enab
 
 ### Key Data Flow
 
-1. **Enhancement (Optional)**: Text prompt → QwenTextEncoder (LLM Mode) → Enhanced Prompt.
-2. **Encoding**: Enhanced Prompt → QwenTokenizer → QwenTextEncoder → Text Embeddings.
+1. **Enhancement (Optional)**: Text prompt -> QwenTextEncoder (LLM Mode) -> Enhanced Prompt.
+2. **Encoding**: Enhanced Prompt -> QwenTokenizer -> QwenTextEncoder -> Text Embeddings.
 3. **Initialization**: Random Gaussian Latents generated.
 4. **Denoising Loop**:
-   - Latents + Timestep + Text Embeddings → `ZImageTransformer2D` (Refiners → Joint Blocks) → Noise Prediction.
+   - Latents + Timestep + Text Embeddings -> `ZImageTransformer2D` (Refiners -> Joint Blocks) -> Noise Prediction.
    - `FlowMatchEulerScheduler` updates latents based on prediction.
-5. **Decoding**: Refined Latents → `AutoencoderKL` (Decoder) → RGB Image.
+5. **Decoding**: Refined Latents -> `AutoencoderKL` (Decoder) -> RGB Image.
 
 ### Test Structure
 

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-  name: "zimage.swift",
+  name: "comfybox",
   platforms: [.macOS(.v14), .iOS(.v16)],
   products: [
     .library(name: "ZImage", targets: ["ZImage"]),
-    .executable(name: "ZImageCLI", targets: ["ZImageCLI"])
+    .executable(name: "ComfyBox", targets: ["ComfyBox"])
   ],
   dependencies: [
     .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.29.1")),
@@ -31,9 +31,9 @@ let package = Package(
       path: "Sources/ZImage"
     ),
     .executableTarget(
-      name: "ZImageCLI",
+      name: "ComfyBox",
       dependencies: ["ZImage"],
-      path: "Sources/ZImageCLI"
+      path: "Sources/ComfyBox"
     ),
     .testTarget(
       name: "ZImageTests",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Z-Image.swift (twalderman fork)
+# ComfyBox
 
 Swift port of [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) using [mlx-swift](https://github.com/ml-explore/mlx-swift) for Apple Silicon.
 
@@ -31,23 +31,23 @@ Reviewer handoff for the Barkada fork work lives at [`docs/review-handoff-barkad
 Download and install the latest Barkada release:
 
 ```bash
-curl -LO https://github.com/BarkadaBrew/zimage.swift/releases/download/0.2.3/ZImageCLI-0.2.3-macos-arm64.tar.gz
-tar -xzf ZImageCLI-0.2.3-macos-arm64.tar.gz
-cd ZImageCLI-0.2.3
+curl -LO https://github.com/BarkadaBrew/comfybox/releases/download/0.2.3/ComfyBox-0.2.3-macos-arm64.tar.gz
+tar -xzf ComfyBox-0.2.3-macos-arm64.tar.gz
+cd ComfyBox-0.2.3
 sudo ./install.sh
 ```
 
 This installs:
-- Binary to `/usr/local/lib/zimage/ZImageCLI`
-- Metal library to `/usr/local/lib/zimage/mlx.metallib`
-- Wrapper script to `/usr/local/bin/ZImageCLI`
+- Binary to `/usr/local/lib/comfybox/ComfyBox`
+- Metal library to `/usr/local/lib/comfybox/mlx.metallib`
+- Wrapper script to `/usr/local/bin/ComfyBox`
 
 ### Building from Source
 
 ```bash
-git clone https://github.com/twalderman/zimage.swift.git
-cd zimage.swift
-xcodebuild -scheme ZImageCLI -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
+git clone https://github.com/BarkadaBrew/comfybox.git
+cd comfybox
+xcodebuild -scheme ComfyBox -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
 ```
 
 The CLI binary and required Metal libraries will be in `.build/xcode/Build/Products/Release/`.
@@ -70,13 +70,13 @@ cargo install vtracer
 ## Usage
 
 ```bash
-ZImageCLI -p "A beautiful mountain landscape at sunset" -o output.png
+ComfyBox -p "A beautiful mountain landscape at sunset" -o output.png
 ```
 
 For all available options:
 
 ```bash
-ZImageCLI -h
+ComfyBox -h
 ```
 
 ### Options
@@ -121,7 +121,7 @@ Z-Image-Turbo defaults to guidance `0.0`. Other model families use different rec
 You can load a single `.safetensors` file containing the Transformer, Text Encoder, and VAE (AIO) directly:
 
 ```bash
-ZImageCLI -p "a cozy cabin" -m path/to/z_image_turbo_aio.safetensors
+ComfyBox -p "a cozy cabin" -m path/to/z_image_turbo_aio.safetensors
 ```
 
 If the file is detected as an AIO checkpoint, it will skip loading base model weights and use the components from the file. To force it to be treated as a transformer-only override (overlaying base weights), use `--force-transformer-override-only`.
@@ -130,35 +130,35 @@ If the file is detected as an AIO checkpoint, it will skip loading base model we
 
 ```bash
 # Basic generation
-ZImageCLI -p "a cute cat sitting on a windowsill" -o cat.png
+ComfyBox -p "a cute cat sitting on a windowsill" -o cat.png
 
 # Portrait image with custom size
-ZImageCLI -p "portrait of a woman in renaissance style" -W 768 -H 1152 -o portrait.png
+ComfyBox -p "portrait of a woman in renaissance style" -W 768 -H 1152 -o portrait.png
 
 # Using quantized model for lower memory usage
-ZImageCLI -p "a futuristic city at night" -m mzbac/Z-Image-Turbo-8bit -o city.png
+ComfyBox -p "a futuristic city at night" -m mzbac/Z-Image-Turbo-8bit -o city.png
 
 # With memory limit
-ZImageCLI -p "abstract art" --cache-limit 2048 -o art.png
+ComfyBox -p "abstract art" --cache-limit 2048 -o art.png
 
 # With single LoRA
-ZImageCLI -p "a lion" --lora ostris/z_image_turbo_childrens_drawings -o lion.png
+ComfyBox -p "a lion" --lora ostris/z_image_turbo_childrens_drawings -o lion.png
 
 # With multiple LoRAs (new in this fork)
-ZImageCLI -p "a beautiful portrait" \
+ComfyBox -p "a beautiful portrait" \
   --lora style1.safetensors=0.8 \
   --lora style2.safetensors=0.5 \
   -o portrait.png
 
 # Generate with SVG output (new in this fork)
-ZImageCLI -p "minimalist mountain logo" --svg --svg-preset logo -o logo.png
+ComfyBox -p "minimalist mountain logo" --svg --svg-preset logo -o logo.png
 # Creates: logo.png and logo.svg
 
 # SVG with detailed preset for complex images
-ZImageCLI -p "intricate mandala pattern" --svg --svg-preset detailed -o mandala.png
+ComfyBox -p "intricate mandala pattern" --svg --svg-preset detailed -o mandala.png
 
 # Scripting without progress bars
-ZImageCLI -p "batch image" --no-progress -o batch.png
+ComfyBox -p "batch image" --no-progress -o batch.png
 ```
 
 ## LoRA
@@ -168,7 +168,7 @@ Apply LoRA weights for style customization.
 ### Single LoRA
 
 ```bash
-ZImageCLI -p "a lion" --lora ostris/z_image_turbo_childrens_drawings --lora-scale 1.0 -o lion.png
+ComfyBox -p "a lion" --lora ostris/z_image_turbo_childrens_drawings --lora-scale 1.0 -o lion.png
 ```
 
 ### Multiple LoRAs (New in This Fork)
@@ -176,7 +176,7 @@ ZImageCLI -p "a lion" --lora ostris/z_image_turbo_childrens_drawings --lora-scal
 Combine multiple LoRA styles:
 
 ```bash
-ZImageCLI -p "a fantasy portrait" \
+ComfyBox -p "a fantasy portrait" \
   --lora ~/loras/style.safetensors=0.8 \
   --lora ~/loras/detail.safetensors=0.6 \
   -o combined.png
@@ -220,15 +220,15 @@ cargo install vtracer
 
 ```bash
 # Basic SVG generation
-ZImageCLI -p "geometric pattern" --svg -o pattern.png
+ComfyBox -p "geometric pattern" --svg -o pattern.png
 # Creates: pattern.png and pattern.svg
 
 # Logo preset (best for icons, logos, flat graphics)
-ZImageCLI -p "minimalist coffee cup logo, flat design, white background" \
+ComfyBox -p "minimalist coffee cup logo, flat design, white background" \
   --svg --svg-preset logo -o coffee_logo.png
 
 # Detailed preset (preserves complex details)
-ZImageCLI -p "intricate celtic knot pattern" \
+ComfyBox -p "intricate celtic knot pattern" \
   --svg --svg-preset detailed -o celtic.png
 ```
 
@@ -254,7 +254,7 @@ ZImageCLI -p "intricate celtic knot pattern" \
 Generate images with ControlNet conditioning using Canny, HED, Depth, Pose, or MLSD control images:
 
 ```bash
-ZImageCLI control \
+ComfyBox control \
   --prompt "A hyper-realistic close-up portrait of a leopard" \
   --control-image canny_edges.jpg \
   --controlnet-weights alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \
@@ -303,7 +303,7 @@ ZImageCLI control \
 Quantize the model to reduce memory usage:
 
 ```bash
-ZImageCLI quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --bits 8 --group-size 32 --verbose
+ComfyBox quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --bits 8 --group-size 32 --verbose
 ```
 
 ### Performance

--- a/Sources/ComfyBox/main.swift
+++ b/Sources/ComfyBox/main.swift
@@ -1201,7 +1201,7 @@ struct ZImageCLI {
     print("""
     Z-Image-Turbo Swift port
 
-    Usage: ZImageCLI --prompt "text" [options]
+    Usage: ComfyBox --prompt "text" [options]
       --prompt, -p           Text prompt (required)
       --negative-prompt      Negative prompt
       --width, -W            Output width (default \(ZImageModelMetadata.recommendedWidth))
@@ -1272,14 +1272,14 @@ struct ZImageCLI {
         --control-image, -c  Control image path (required)
         --controlnet-weights Path to controlnet weights dir or HF ID (required)
         --control-scale      Control scale (default: 0.75)
-        Use 'ZImageCLI control --help' for full options
+        Use 'ComfyBox control --help' for full options
 
       serve                  Start warm HTTP server
         --model, -m          Model path or HuggingFace ID
         --text-encoder-path  Override text encoder directory
         --port               HTTP port (default 7862)
         --lora, -l           Initial LoRA(s)
-        Use 'ZImageCLI serve --help' for full options
+        Use 'ComfyBox serve --help' for full options
 
       upscale                Upscale image via SeedVR2 or ESRGAN
         --input, -i          Input image path (required)
@@ -1296,21 +1296,21 @@ struct ZImageCLI {
         --paths, -v          Show filesystem paths for installed models
 
     Examples:
-      ZImageCLI -p "a cute cat" -o cat.png
-      ZImageCLI -p "a sunset" -m models/z-image-turbo-q8
-      ZImageCLI -p "a forest" -m Tongyi-MAI/Z-Image-Turbo
-      ZImageCLI -p "a cut a cat" --lora ostris/z_image_turbo_childrens_drawings
-      ZImageCLI -p "portrait" --lora mood.safetensors=0.8 --lora detail.safetensors --lora-scale 0.3
-      ZImageCLI -p "cat" --enhance  # Enhanced prompt generation
-      ZImageCLI -p "portrait" --scheduler dpmpp-2m --sigma-schedule beta  # Best photorealism combo
-      ZImageCLI -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
-      ZImageCLI -p "refiner pass" --scheduler res_2s --sigma-schedule beta57  # RES 2s + beta57
-      ZImageCLI -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
-      ZImageCLI serve -m ./models/z-image-turbo --port 7862
-      ZImageCLI -p "portrait" --auto-seeds 5 -o portraits.png  # Generate 5 random variations
-      ZImageCLI -p "cat" --seed 42 --seed 99 --seed 123 -o cats.png  # 3 specific seeds
-      ZImageCLI -p "scene" --auto-seeds 10 --resume-batch progress.jsonl  # Resume interrupted batch
-      ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 2048
+      ComfyBox -p "a cute cat" -o cat.png
+      ComfyBox -p "a sunset" -m models/z-image-turbo-q8
+      ComfyBox -p "a forest" -m Tongyi-MAI/Z-Image-Turbo
+      ComfyBox -p "a cut a cat" --lora ostris/z_image_turbo_childrens_drawings
+      ComfyBox -p "portrait" --lora mood.safetensors=0.8 --lora detail.safetensors --lora-scale 0.3
+      ComfyBox -p "cat" --enhance  # Enhanced prompt generation
+      ComfyBox -p "portrait" --scheduler dpmpp-2m --sigma-schedule beta  # Best photorealism combo
+      ComfyBox -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
+      ComfyBox -p "refiner pass" --scheduler res_2s --sigma-schedule beta57  # RES 2s + beta57
+      ComfyBox -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
+      ComfyBox serve -m ./models/z-image-turbo --port 7862
+      ComfyBox -p "portrait" --auto-seeds 5 -o portraits.png  # Generate 5 random variations
+      ComfyBox -p "cat" --seed 42 --seed 99 --seed 123 -o cats.png  # 3 specific seeds
+      ComfyBox -p "scene" --auto-seeds 10 --resume-batch progress.jsonl  # Resume interrupted batch
+      ComfyBox upscale -i photo.jpg -w ./models/seedvr2 -r 2048
     """)
   }
 
@@ -1391,7 +1391,7 @@ struct ZImageCLI {
     print("""
     Quantize model weights.
 
-    Usage: ZImageCLI quantize -i <input> -o <output> [options]
+    Usage: ComfyBox quantize -i <input> -o <output> [options]
       --input, -i          Input model directory (required)
       --output, -o         Output directory (required)
       --bits               Bit width: 4 or 8 (default: 8)
@@ -1400,7 +1400,7 @@ struct ZImageCLI {
       --help, -h           Show help
 
     Example:
-      ZImageCLI quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --verbose
+      ComfyBox quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --verbose
     """)
   }
 
@@ -1518,7 +1518,7 @@ struct ZImageCLI {
     print("""
     Quantize ControlNet weights.
 
-    Usage: ZImageCLI quantize-controlnet -i <input> -o <output> [options]
+    Usage: ComfyBox quantize-controlnet -i <input> -o <output> [options]
       --input, -i          Input ControlNet path or HuggingFace ID (required)
       --output, -o         Output directory (required)
       --file, -f           Specific .safetensors file to quantize (optional)
@@ -1529,11 +1529,11 @@ struct ZImageCLI {
 
     Examples:
       # From HuggingFace
-      ZImageCLI quantize-controlnet -i alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \\
+      ComfyBox quantize-controlnet -i alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \\
         --file Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors -o controlnet-2.1-q8 --verbose
 
       # From local directory
-      ZImageCLI quantize-controlnet -i ./controlnet-union -o ./controlnet-union-q8 --verbose
+      ComfyBox quantize-controlnet -i ./controlnet-union -o ./controlnet-union-q8 --verbose
     """)
   }
 
@@ -1618,7 +1618,7 @@ struct ZImageCLI {
     print("""
     Start warm HTTP server mode.
 
-    Usage: ZImageCLI serve [options]
+    Usage: ComfyBox serve [options]
       --model, -m               Model path or HuggingFace ID (default: \(ZImageRepository.id))
       --text-encoder-path       Override text encoder directory
       --port                    HTTP port (default: 7862)
@@ -1640,7 +1640,7 @@ struct ZImageCLI {
       POST /v1/shutdown         Gracefully stop the server
 
     Example:
-      ZImageCLI serve -m /path/to/model --text-encoder-path /path/to/encoder --port 7862 \\
+      ComfyBox serve -m /path/to/model --text-encoder-path /path/to/encoder --port 7862 \\
         --lora /path/to/lora.safetensors=0.8
     """)
   }
@@ -1877,7 +1877,7 @@ struct ZImageCLI {
     print("""
     Generate images with ControlNet conditioning (supports v2.0/v2.1 with inpainting).
 
-    Usage: ZImageCLI control --prompt "text" --controlnet-weights <path> [options]
+    Usage: ComfyBox control --prompt "text" --controlnet-weights <path> [options]
       --prompt, -p              Text prompt (required)
       --negative-prompt, --np   Negative prompt
       --control-image, -c       Control image path - Canny, HED, Depth, Pose, or MLSD
@@ -1920,26 +1920,26 @@ struct ZImageCLI {
 
     Examples:
       # T2I with pose control using v2.1 weights (recommended)
-      ZImageCLI control -p "a woman on a beach" -c pose.jpg \\
+      ComfyBox control -p "a woman on a beach" -c pose.jpg \\
         --cw alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \\
         --cf Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors
 
       # I2I inpainting with pose control
-      ZImageCLI control -p "a dancer" -c pose.jpg -i photo.jpg --mask mask.png \\
+      ComfyBox control -p "a dancer" -c pose.jpg -i photo.jpg --mask mask.png \\
         --cw alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \\
         --cf Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors --cs 0.75 -s 25
 
       # Inpainting without control guidance
-      ZImageCLI control -p "a cat sitting" -i photo.jpg --mask mask.png \\
+      ComfyBox control -p "a cat sitting" -i photo.jpg --mask mask.png \\
         --cw alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \\
         --cf Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors
 
       # Using local controlnet weights
-      ZImageCLI control -p "a forest path" -c depth.jpg --cs 0.7 \\
+      ComfyBox control -p "a forest path" -c depth.jpg --cs 0.7 \\
         --cw ./controlnet-q8 -o forest.png
 
       # Custom encoder with stacked LoRAs
-      ZImageCLI control -p "portrait" -c pose.png --cw ./controlnet-q8 \\
+      ComfyBox control -p "portrait" -c pose.png --cw ./controlnet-q8 \\
         -m /path/to/z-image-turbo-bf16 --text-encoder-path "/path/to/z-image-turbo-bf16/text_encoder QWen Large" \\
         --lora mood.safetensors=0.8 --lora detail.safetensors --lora-scale 0.3
     """)
@@ -2111,7 +2111,7 @@ struct ZImageCLI {
         print("""
         SeedVR2 / ESRGAN Image Upscaler
 
-        Usage: ZImageCLI upscale --input <path> (--weights <path> | --esrgan-weights <path>) [options]
+        Usage: ComfyBox upscale --input <path> (--weights <path> | --esrgan-weights <path>) [options]
 
           --input, -i          Input image path (required)
           --output, -o         Output image path (default: input-upscaled.png)
@@ -2125,10 +2125,10 @@ struct ZImageCLI {
           --help, -h           Show this help
 
         Examples:
-          ZImageCLI upscale -i photo.jpg -w ./models/seedvr2
-          ZImageCLI upscale -i photo.jpg -w ./models/seedvr2 -r 4096 --seed 42
-          ZImageCLI upscale -i photo.jpg --esrgan-weights ./models/4x-ultrasharp --tile-size 512
-          ZImageCLI upscale -i low-res.png -w ./models/seedvr2 --softness 0.3 -o high-res.png
+          ComfyBox upscale -i photo.jpg -w ./models/seedvr2
+          ComfyBox upscale -i photo.jpg -w ./models/seedvr2 -r 4096 --seed 42
+          ComfyBox upscale -i photo.jpg --esrgan-weights ./models/4x-ultrasharp --tile-size 512
+          ComfyBox upscale -i low-res.png -w ./models/seedvr2 --softness 0.3 -o high-res.png
         """)
         return
       default:
@@ -2460,7 +2460,7 @@ struct ZImageCLI {
     print("""
     List known model families with installation status.
 
-    Usage: ZImageCLI models [options]
+    Usage: ComfyBox models [options]
       --paths, -v   Show filesystem paths for installed models
       --help, -h    Show help
 
@@ -2470,8 +2470,8 @@ struct ZImageCLI {
       3. ./models
 
     Example:
-      ZImageCLI models
-      ZImageCLI models --paths
+      ComfyBox models
+      ComfyBox models --paths
     """)
   }
 

--- a/Tests/ZImageE2ETests/CLIEndToEndTests.swift
+++ b/Tests/ZImageE2ETests/CLIEndToEndTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Foundation
 
-/// End-to-end tests for ZImageCLI command line interface.
+/// End-to-end tests for ComfyBox command line interface.
 /// These tests build and run the actual CLI executable.
 /// Run with: xcodebuild test -scheme zimage.swift-Package -destination 'platform=macOS' -only-testing:ZImageE2ETests -parallel-testing-enabled NO
 final class CLIEndToEndTests: XCTestCase {
@@ -279,8 +279,8 @@ final class CLIEndToEndTests: XCTestCase {
     let buildDir = Self.projectRoot.appendingPathComponent(".build")
 
     // Check if CLI already exists in local build folder
-    let releasePath = buildDir.appendingPathComponent("Build/Products/Release/ZImageCLI")
-    let debugPath = buildDir.appendingPathComponent("Build/Products/Debug/ZImageCLI")
+    let releasePath = buildDir.appendingPathComponent("Build/Products/Release/ComfyBox")
+    let debugPath = buildDir.appendingPathComponent("Build/Products/Debug/ComfyBox")
     if let existing = [releasePath, debugPath].first(where: { FileManager.default.fileExists(atPath: $0.path) }),
        Self.isCLIBinaryUpToDate(existing) {
       return existing.path
@@ -291,7 +291,7 @@ final class CLIEndToEndTests: XCTestCase {
     buildProcess.executableURL = URL(fileURLWithPath: "/usr/bin/xcodebuild")
     buildProcess.arguments = [
       "build",
-      "-scheme", "ZImageCLI",
+      "-scheme", "ComfyBox",
       "-configuration", "Release",
       "-destination", "platform=macOS",
       "-derivedDataPath", buildDir.path
@@ -358,7 +358,7 @@ final class CLIEndToEndTests: XCTestCase {
 
   private func skipIfNoCLI() throws {
     guard let path = cliPath, !path.isEmpty, FileManager.default.fileExists(atPath: path) else {
-      throw XCTSkip("CLI not built. Run 'swift build -c release --product ZImageCLI' first.")
+      throw XCTSkip("CLI not built. Run 'swift build -c release --product ComfyBox' first.")
     }
   }
 

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-xcodebuild -scheme ZImageCLI -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
+xcodebuild -scheme ComfyBox -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode


### PR DESCRIPTION
## Summary

- Renames Swift package from `zimage.swift` to `comfybox` and executable from `ZImageCLI` to `ComfyBox` (Option B)
- Updates CI workflow: scheme `ComfyBox`, test scheme `comfybox-Package`, artifact `comfybox.macos.arm64.zip`
- Updates README (title, clone URL, binary refs, install paths), CLAUDE.md (project description, build commands), E2E tests, and build.sh

The ZImage Swift module and all ZImage-prefixed types remain unchanged -- those are Option C scope and explicitly out of this PR.

## Files Changed

| File | Change |
|------|--------|
| `Package.swift` | `name: "comfybox"`, executable target `ComfyBox`, path `Sources/ComfyBox` |
| `Sources/ZImageCLI/ -> Sources/ComfyBox/` | Directory rename |
| `Sources/ComfyBox/main.swift` | User-facing help/usage text updated |
| `.github/workflows/ci.yml` | Scheme + artifact names |
| `README.md` | Title, URLs, binary refs, install paths |
| `CLAUDE.md` | Project description, build commands, rename note |
| `Tests/ZImageE2ETests/CLIEndToEndTests.swift` | Binary path + scheme refs |
| `build.sh` | Scheme reference |

## Test plan

- [x] `swift build -c release` succeeds on Mac (M3 Max)
- [x] `.build/release/ComfyBox` binary exists and runs (`ComfyBox --help` shows updated usage text)
- [ ] CI typecheck job passes with new scheme names
- [ ] Unit tests pass via `comfybox-Package` scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)