### PR TITLE
feat(mcp): add MCP server — 11 tools bridging WarmServer API

### DIFF
--- a/Sources/ComfyBox/main.swift
+++ b/Sources/ComfyBox/main.swift
@@ -217,6 +217,9 @@ struct ZImageCLI {
       case "models":
         runModels(args: Array(args.dropFirst()))
         return
+      case "mcp":
+        try runMCP(args: Array(args.dropFirst()))
+        return
       default:
         logger.warning("Unknown argument: \(arg)")
       }
@@ -1297,6 +1300,12 @@ struct ZImageCLI {
 
       models                 List known model families with installation status
         --paths, -v          Show filesystem paths for installed models
+
+
+      mcp                    Start MCP server (stdio JSON-RPC bridge to WarmServer)
+        --port               WarmServer port (default: 7862)
+        --host               WarmServer host (default: 127.0.0.1)
+        Use 'ComfyBox mcp --help' for full options
 
     Examples:
       ComfyBox -p "a cute cat" -o cat.png
@@ -2475,6 +2484,73 @@ struct ZImageCLI {
     Example:
       ComfyBox models
       ComfyBox models --paths
+    """)
+  }
+
+
+
+  // MARK: - MCP Server Subcommand
+
+  private static func runMCP(args: [String]) throws {
+    var port: UInt16 = 7862
+    var host = "127.0.0.1"
+
+    var iterator = args.makeIterator()
+    while let arg = iterator.next() {
+      switch arg {
+      case "--port":
+        let rawPort = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: Int(port))
+        guard rawPort <= Int(UInt16.max) else {
+          logger.error("Invalid port: \(rawPort)")
+          return
+        }
+        port = UInt16(rawPort)
+      case "--host":
+        host = nextValue(for: arg, iterator: &iterator)
+      case "--help", "-h":
+        printMCPUsage()
+        return
+      default:
+        logger.warning("Unknown mcp argument: \(arg)")
+      }
+    }
+
+    // Print server info to stderr (stdout is reserved for JSON-RPC)
+    fputs("ComfyBox MCP server v\(MCPServer.version)\n", stderr)
+    fputs("Bridging to WarmServer at \(host):\(port)\n", stderr)
+
+    let server = MCPServer(host: host, port: port)
+    server.run()
+  }
+
+  private static func printMCPUsage() {
+    print("""
+    Start MCP (Model Context Protocol) server mode.
+    Bridges stdio JSON-RPC 2.0 to WarmServer HTTP API.
+
+    Usage: ComfyBox mcp [options]
+      --port                    WarmServer port to connect to (default: 7862)
+      --host                    WarmServer host to connect to (default: 127.0.0.1)
+      --help, -h                Show help
+
+    The MCP server reads JSON-RPC requests from stdin and writes responses
+    to stdout. All logging goes to stderr. Runs until stdin closes.
+
+    Registration:
+      claude mcp add comfybox -- comfybox mcp --port 7862
+
+    Tools:
+      generate_image    Text-to-image / img2img generation
+      swap_loras        Hot-swap active LoRA weights
+      list_models       List supported model families
+      list_styles       List style presets
+      server_health     Server health and loaded model info
+      queue_status      Generation queue status
+      clear_queue       Cancel pending generation jobs
+      list_loras        List available LoRA files
+      shutdown_server   Graceful server shutdown
+      system_stats      Hardware and system info
+      apply_style       Apply style preset to prompt
     """)
   }
 

--- a/Sources/ZImage/MCP/MCPServer.swift
+++ b/Sources/ZImage/MCP/MCPServer.swift
@@ -1,0 +1,230 @@
+// MCPServer.swift — Main MCP server orchestrator
+//
+// Combines transport (stdio), registry (tool catalog), and executor (HTTP proxy).
+// Handles the full MCP protocol flow:
+//   initialize -> initialized notification -> tools/list -> tools/call
+//
+// Reads JSON-RPC from stdin, writes responses to stdout, logs to stderr.
+// Blocks on stdin until it closes or the process is interrupted.
+
+import Foundation
+
+/// MCP server that bridges stdio JSON-RPC 2.0 to WarmServer HTTP API.
+public final class MCPServer {
+  private let client: WarmServerClient
+  private let executor: MCPToolExecutor
+
+  /// Whether the server has been initialized (client sent initialize request).
+  private var initialized = false
+
+  /// Server version reported in initialize response.
+  public static let version = "1.0.0"
+
+  public init(host: String = "127.0.0.1", port: UInt16 = 7862) {
+    self.client = WarmServerClient(host: host, port: port)
+    self.executor = MCPToolExecutor(client: client)
+  }
+
+  /// Run the MCP server — blocks on stdin until it closes.
+  public func run() {
+    log("Starting — bridging to WarmServer at \(client.host):\(client.port)")
+
+    let decoder = JSONDecoder()
+
+    while let line = readLine(strippingNewline: true) {
+      guard !line.isEmpty else { continue }
+
+      guard let data = line.data(using: .utf8) else {
+        log("Invalid UTF-8 input")
+        continue
+      }
+
+      // Parse JSON-RPC request
+      let request: MCPRequest
+      do {
+        request = try decoder.decode(MCPRequest.self, from: data)
+      } catch {
+        log("Invalid JSON: \(line.prefix(200)) — \(error)")
+        // Per JSON-RPC spec, respond with parse error
+        sendError(id: nil, error: .parseError)
+        continue
+      }
+
+      if let id = request.id {
+        // Request — dispatch and respond synchronously.
+        // We use a semaphore to bridge async tool execution into the
+        // synchronous readline loop. This is intentional: MCP over stdio
+        // is inherently serial (one request at a time).
+        let semaphore = DispatchSemaphore(value: 0)
+        var response: MCPResponse?
+        Task {
+          response = await handleRequest(id: id, method: request.method, params: request.params)
+          semaphore.signal()
+        }
+        semaphore.wait()
+        if let resp = response {
+          send(resp)
+        }
+      } else {
+        // Notification — no response needed
+        handleNotification(method: request.method)
+      }
+    }
+
+    log("stdin closed — shutting down")
+  }
+
+  // MARK: - Request Handling
+
+  private func handleRequest(id: MCPRequestId, method: String, params: MCPParams?) async -> MCPResponse {
+    switch method {
+    case MCPMethod.initialize:
+      return handleInitialize(id: id, params: params)
+
+    case MCPMethod.toolsList:
+      return handleToolsList(id: id)
+
+    case MCPMethod.toolsCall:
+      return await handleToolsCall(id: id, params: params)
+
+    case MCPMethod.ping:
+      return MCPResponse(id: id, result: AnyCodable([:] as [String: Any]))
+
+    default:
+      log("Unknown method: \(method)")
+      return MCPResponse(id: id, error: .methodNotFound)
+    }
+  }
+
+  // MARK: - Initialize
+
+  private func handleInitialize(id: MCPRequestId, params: MCPParams?) -> MCPResponse {
+    initialized = true
+
+    let clientName = params?.dict("clientInfo")?["name"]?.stringValue ?? "unknown"
+    let protocolVersion = params?.string("protocolVersion") ?? "2024-11-05"
+    log("Client connected: \(clientName) (protocol \(protocolVersion))")
+
+    let result: [String: Any] = [
+      "protocolVersion": "2024-11-05",
+      "capabilities": [
+        "tools": [
+          "listChanged": false,
+        ] as [String: Any],
+      ] as [String: Any],
+      "serverInfo": [
+        "name": "comfybox",
+        "version": MCPServer.version,
+      ] as [String: Any],
+    ]
+
+    return MCPResponse(id: id, result: AnyCodable(result))
+  }
+
+  // MARK: - Tools List
+
+  private func handleToolsList(id: MCPRequestId) -> MCPResponse {
+    // Build tools list using JSONSerialization to ensure clean JSON output.
+    // MCPToolDefinition stores inputSchema as [String: Any] which serializes
+    // cleanly via JSONSerialization without AnyCodable debug descriptions.
+    var toolDicts: [[String: Any]] = []
+    for tool in MCPToolRegistry.tools {
+      toolDicts.append([
+        "name": tool.name,
+        "description": tool.description,
+        "inputSchema": tool.inputSchema,
+      ] as [String: Any])
+    }
+    let result: [String: Any] = ["tools": toolDicts]
+    return MCPResponse(id: id, result: AnyCodable(result))
+  }
+
+  // MARK: - Tools Call
+
+  private func handleToolsCall(id: MCPRequestId, params: MCPParams?) async -> MCPResponse {
+    guard let toolName = params?.string("name") else {
+      return MCPResponse(id: id, error: MCPError.invalidParams)
+    }
+
+    // Verify tool exists in the registry
+    guard MCPToolRegistry.tool(named: toolName) != nil else {
+      return MCPResponse(id: id, error: MCPError(code: -32602, message: "Unknown tool: \(toolName)"))
+    }
+
+    // Extract tool arguments from params.arguments
+    let arguments: MCPParams?
+    if let argsDict = params?.dict("arguments") {
+      arguments = MCPParams(argsDict)
+    } else {
+      arguments = nil
+    }
+
+    log("Executing tool: \(toolName)")
+    let result = await executor.execute(name: toolName, arguments: arguments)
+    log("Tool \(toolName) completed (isError=\(result.isError))")
+
+    return MCPResponse(id: id, result: AnyCodable(result.toResponseDict()))
+  }
+
+  // MARK: - Notifications
+
+  private func handleNotification(method: String) {
+    switch method {
+    case MCPMethod.notificationsInitialized:
+      log("Client initialized")
+    default:
+      log("Notification: \(method)")
+    }
+  }
+
+  // MARK: - Transport
+
+  /// Send a JSON-RPC response to stdout using JSONSerialization for reliable output.
+  private func send(_ response: MCPResponse) {
+    // Build the response dict manually to avoid AnyCodable encoding issues.
+    var dict: [String: Any] = ["jsonrpc": response.jsonrpc]
+
+    if let id = response.id {
+      switch id {
+      case .integer(let i): dict["id"] = i
+      case .string(let s): dict["id"] = s
+      }
+    }
+
+    if let result = response.result {
+      dict["result"] = result.rawValue
+    }
+
+    if let error = response.error {
+      var errorDict: [String: Any] = [
+        "code": error.code,
+        "message": error.message,
+      ]
+      if let data = error.data {
+        errorDict["data"] = data.rawValue
+      }
+      dict["error"] = errorDict
+    }
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+          let line = String(data: data, encoding: .utf8) else {
+      log("Failed to encode response")
+      return
+    }
+    // Write to stdout with newline, then flush
+    print(line)
+    fflush(stdout)
+  }
+
+  /// Send an error response.
+  private func sendError(id: MCPRequestId?, error: MCPError) {
+    let response = MCPResponse(id: id, error: error)
+    send(response)
+  }
+
+  /// Log a message to stderr (stdout is reserved for JSON-RPC).
+  private func log(_ message: String) {
+    let logLine = "[mcp-server:comfybox] \(message)\n"
+    FileHandle.standardError.write(Data(logLine.utf8))
+  }
+}

--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -1,0 +1,241 @@
+// MCPToolExecutor.swift — Executes tool calls by proxying to WarmServer
+//
+// Maps MCP tool names to WarmServer REST endpoints.
+// Uses WarmServerClient for all HTTP calls except apply_style,
+// which resolves locally using ComfyBoxStylePresets.
+
+import Foundation
+
+/// Executes MCP tool calls by dispatching to WarmServer HTTP endpoints.
+public final class MCPToolExecutor: @unchecked Sendable {
+  private let client: WarmServerClient
+
+  public init(client: WarmServerClient) {
+    self.client = client
+  }
+
+  /// Execute a tool call. Returns an MCPToolResult.
+  public func execute(name: String, arguments: MCPParams?) async -> MCPToolResult {
+    do {
+      switch name {
+      case "generate_image":
+        return try await executeGenerateImage(arguments)
+      case "swap_loras":
+        return try await executeSwapLoras(arguments)
+      case "list_models":
+        return try await executeGet("/v1/models")
+      case "list_styles":
+        return try await executeGet("/v1/styles")
+      case "server_health":
+        return try await executeGet("/health")
+      case "queue_status":
+        return try await executeGet("/queue")
+      case "clear_queue":
+        return try await executeClearQueue()
+      case "list_loras":
+        return try await executeListLoras()
+      case "shutdown_server":
+        return try await executeShutdown(arguments)
+      case "system_stats":
+        return try await executeGet("/system_stats")
+      case "apply_style":
+        return executeApplyStyle(arguments)
+      default:
+        return MCPToolResult(error: "Unknown tool: \(name)")
+      }
+    } catch let error as WarmServerClientError {
+      return MCPToolResult(error: "Error: \(error.errorDescription ?? String(describing: error))")
+    } catch {
+      return MCPToolResult(error: "Error: \(error.localizedDescription)")
+    }
+  }
+
+  // MARK: - Tool Implementations
+
+  /// generate_image -> POST /v1/generate
+  private func executeGenerateImage(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let prompt = params?.string("prompt"), !prompt.isEmpty else {
+      return MCPToolResult(error: "Error: 'prompt' is required")
+    }
+
+    var body: [String: Any] = ["prompt": prompt]
+
+    if let negativePrompt = params?.string("negative_prompt") {
+      body["negative_prompt"] = negativePrompt
+    }
+    if let width = params?.integer("width") {
+      body["width"] = width
+    }
+    if let height = params?.integer("height") {
+      body["height"] = height
+    }
+    if let steps = params?.integer("steps") {
+      body["steps"] = steps
+    }
+    if let guidance = params?.number("guidance") {
+      body["guidance"] = guidance
+    }
+    if let seed = params?.integer("seed") {
+      body["seed"] = seed
+    }
+    if let outputPath = params?.string("output_path") {
+      body["output_path"] = outputPath
+    }
+    if let scheduler = params?.string("scheduler") {
+      body["scheduler"] = scheduler
+    }
+    if let sigmaSchedule = params?.string("sigma_schedule") {
+      body["sigma_schedule"] = sigmaSchedule
+    }
+    if let imagePath = params?.string("image_path") {
+      body["image_path"] = imagePath
+    }
+    if let imageStrength = params?.number("image_strength") {
+      body["image_strength"] = imageStrength
+    }
+
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/generate", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// swap_loras -> POST /v1/lora/swap
+  private func executeSwapLoras(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let lorasArray = params?.array("loras") else {
+      return MCPToolResult(error: "Error: 'loras' array is required")
+    }
+
+    var loraEntries: [[String: Any]] = []
+    for item in lorasArray {
+      guard let dict = item.dictValue else { continue }
+      guard let path = dict["path"]?.stringValue else { continue }
+      var entry: [String: Any] = ["path": path]
+      if let scale = dict["scale"]?.doubleValue {
+        entry["scale"] = scale
+      }
+      loraEntries.append(entry)
+    }
+
+    let body: [String: Any] = ["loras": loraEntries]
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/lora/swap", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// clear_queue -> POST /queue with {"clear": true}
+  private func executeClearQueue() async throws -> MCPToolResult {
+    let body: [String: Any] = ["clear": true]
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/queue", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// list_loras -> GET /object_info, extract LoraLoader lora_name options
+  private func executeListLoras() async throws -> MCPToolResult {
+    let (status, data) = try await client.get("/object_info")
+
+    guard status == 200 else {
+      return mapHTTPResponse(status: status, data: data)
+    }
+
+    // Parse /object_info JSON and extract LoraLoader.input.required.lora_name options
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let loraLoader = json["LoraLoader"] as? [String: Any],
+          let input = loraLoader["input"] as? [String: Any],
+          let required = input["required"] as? [String: Any],
+          let loraName = required["lora_name"] as? [Any],
+          let options = loraName.first as? [String] else {
+      return MCPToolResult(error: "Error: Could not parse LoRA list from /object_info")
+    }
+
+    let result: [String: Any] = [
+      "loras": options,
+      "count": options.count,
+      "directory": "~/bin/zimage/loras",
+    ]
+    let resultData = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
+    return MCPToolResult(text: String(data: resultData, encoding: .utf8) ?? "{}")
+  }
+
+  /// shutdown_server -> POST /v1/shutdown (with confirm check)
+  private func executeShutdown(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard params?.bool("confirm") == true else {
+      return MCPToolResult(error: "Error: 'confirm' must be true to shut down the server. This is a safety guard.")
+    }
+
+    let (status, data) = try await client.post("/v1/shutdown", body: Data("{}".utf8))
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// apply_style — local-only, no HTTP call.
+  /// Looks up the style from ComfyBoxStylePresets and applies prompt transforms.
+  private func executeApplyStyle(_ params: MCPParams?) -> MCPToolResult {
+    guard let styleId = params?.string("style_id") else {
+      return MCPToolResult(error: "Error: 'style_id' is required")
+    }
+    guard let prompt = params?.string("prompt") else {
+      return MCPToolResult(error: "Error: 'prompt' is required")
+    }
+
+    guard let preset = ComfyBoxStylePresets.presets[styleId] else {
+      let available = ComfyBoxStylePresets.allPresets.map { $0.id }.joined(separator: ", ")
+      return MCPToolResult(error: "Error: Unknown style '\(styleId)'. Available: \(available)")
+    }
+
+    let negativePrompt = params?.string("negative_prompt")
+    let (enhanced, combinedNegative) = preset.apply(prompt: prompt, negativePrompt: negativePrompt)
+
+    var result: [String: Any] = [
+      "enhanced_prompt": enhanced,
+      "style_id": preset.id,
+      "style_name": preset.name,
+      "category": preset.category.rawValue,
+      "recommended_model": preset.recommendedModel,
+    ]
+
+    if let neg = combinedNegative {
+      result["negative_prompt"] = neg
+    }
+
+    // Include recommended parameters where they differ from defaults
+    var recommended: [String: Any] = [:]
+    if let steps = preset.steps { recommended["steps"] = steps }
+    if let guidance = preset.guidance { recommended["guidance"] = guidance }
+    if let w = preset.width { recommended["width"] = w }
+    if let h = preset.height { recommended["height"] = h }
+    if let strength = preset.img2imgStrength { recommended["img2img_strength"] = strength }
+    if !recommended.isEmpty {
+      result["recommended"] = recommended
+    }
+
+    guard let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+          let text = String(data: data, encoding: .utf8) else {
+      return MCPToolResult(error: "Error: Failed to serialize style result")
+    }
+    return MCPToolResult(text: text)
+  }
+
+  // MARK: - Helpers
+
+  /// Generic GET endpoint handler.
+  private func executeGet(_ path: String) async throws -> MCPToolResult {
+    let (status, data) = try await client.get(path)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// Map WarmServer HTTP response to MCP tool result.
+  /// 200 -> success text, any other -> error text.
+  private func mapHTTPResponse(status: Int, data: Data) -> MCPToolResult {
+    let text = String(data: data, encoding: .utf8) ?? "{}"
+    if status == 200 {
+      return MCPToolResult(text: text)
+    } else {
+      // Try to extract error message from JSON response
+      if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+         let message = json["error"] as? String {
+        return MCPToolResult(error: "Error (\(status)): \(message)")
+      }
+      return MCPToolResult(error: "Error (\(status)): \(text)")
+    }
+  }
+}

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -1,0 +1,224 @@
+// MCPToolRegistry.swift — Tool definitions with JSON Schema parameter schemas
+//
+// Registers all 11 MCP tools from the ComfyBox MCP server design doc.
+// Each tool has: name, description, inputSchema (JSON Schema object).
+// Tools are compiled statically — no runtime registration.
+
+import Foundation
+
+/// Static catalog of all MCP tool definitions for ComfyBox.
+public enum MCPToolRegistry {
+
+  /// All registered tool definitions.
+  public static let tools: [MCPToolDefinition] = [
+    generateImage,
+    swapLoras,
+    listModels,
+    listStyles,
+    serverHealth,
+    queueStatus,
+    clearQueue,
+    listLoras,
+    shutdownServer,
+    systemStats,
+    applyStyle,
+  ]
+
+  // MARK: - Tool Definitions
+
+  static let generateImage = MCPToolDefinition(
+    name: "generate_image",
+    description: "Generate an image from a text prompt using the loaded model. Supports text-to-image and img2img. Returns the output file path and render duration.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "prompt": [
+          "type": "string",
+          "description": "Text prompt describing the desired image.",
+        ] as [String: Any],
+        "negative_prompt": [
+          "type": "string",
+          "description": "Negative prompt — concepts to avoid. Only effective on non-distilled models (Z-Image Base, Flux 2 Klein Base, FIBO).",
+        ] as [String: Any],
+        "width": [
+          "type": "integer",
+          "description": "Image width in pixels. Must be divisible by 16. Default: model-dependent (typically 1024).",
+        ] as [String: Any],
+        "height": [
+          "type": "integer",
+          "description": "Image height in pixels. Must be divisible by 16. Default: model-dependent (typically 1024).",
+        ] as [String: Any],
+        "steps": [
+          "type": "integer",
+          "description": "Number of denoising steps. More steps = higher quality but slower. Distilled models (Turbo): 4-9. Base models: 20-50.",
+        ] as [String: Any],
+        "guidance": [
+          "type": "number",
+          "description": "CFG guidance scale. Higher values = stronger prompt adherence. 0.0 for distilled models; 3.5-7.0 for base models.",
+        ] as [String: Any],
+        "seed": [
+          "type": "integer",
+          "description": "Random seed for reproducibility. Omit for random.",
+        ] as [String: Any],
+        "output_path": [
+          "type": "string",
+          "description": "Output file path. Must be within the server's allowed output directory. Omit to write to a temp file.",
+        ] as [String: Any],
+        "scheduler": [
+          "type": "string",
+          "description": "Sampler/scheduler algorithm. Options: euler (default), heun, res_2s, ddim, dpmpp_2m.",
+        ] as [String: Any],
+        "sigma_schedule": [
+          "type": "string",
+          "description": "Sigma noise schedule. Options: flow (default), beta, beta57, linear.",
+        ] as [String: Any],
+        "image_path": [
+          "type": "string",
+          "description": "Source image path for img2img. The loaded model must support img2img.",
+        ] as [String: Any],
+        "image_strength": [
+          "type": "number",
+          "description": "Img2img denoise strength (0.0-1.0). 1.0 = full txt2img, 0.5 = preserve composition. Default: 0.7.",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["prompt"] as [String],
+    ] as [String: Any]
+  )
+
+  static let swapLoras = MCPToolDefinition(
+    name: "swap_loras",
+    description: "Hot-swap active LoRA weights on the loaded model. Replaces all currently active LoRAs with the provided set. Pass an empty array to remove all LoRAs.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "loras": [
+          "type": "array",
+          "description": "LoRA configurations to activate.",
+          "items": [
+            "type": "object",
+            "properties": [
+              "path": [
+                "type": "string",
+                "description": "Path to .safetensors file, or HuggingFace model ID. Bare filenames resolve to ~/bin/zimage/loras/.",
+              ] as [String: Any],
+              "scale": [
+                "type": "number",
+                "description": "LoRA weight scale (0.0-2.0). Default: 1.0.",
+              ] as [String: Any],
+            ] as [String: Any],
+            "required": ["path"] as [String],
+          ] as [String: Any],
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["loras"] as [String],
+    ] as [String: Any]
+  )
+
+  static let listModels = MCPToolDefinition(
+    name: "list_models",
+    description: "List all supported ComfyBox model families with capabilities, recommended parameters, and HuggingFace IDs.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let listStyles = MCPToolDefinition(
+    name: "list_styles",
+    description: "List available style presets with prompt engineering templates, recommended parameters, and model pairings.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let serverHealth = MCPToolDefinition(
+    name: "server_health",
+    description: "Get ComfyBox server health: loaded model, LoRA state, memory usage, render stats, and queue depth.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let queueStatus = MCPToolDefinition(
+    name: "queue_status",
+    description: "Get the current generation queue status: pending jobs, running job, and history.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let clearQueue = MCPToolDefinition(
+    name: "clear_queue",
+    description: "Cancel all pending generation jobs in the queue. Does not affect the currently running job.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let listLoras = MCPToolDefinition(
+    name: "list_loras",
+    description: "List LoRA files available in the LoRA directory (~/bin/zimage/loras/). Returns filenames that can be passed to swap_loras.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let shutdownServer = MCPToolDefinition(
+    name: "shutdown_server",
+    description: "Gracefully shut down the ComfyBox WarmServer. In-flight renders complete before exit. Use sparingly — requires manual restart.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "confirm": [
+          "type": "boolean",
+          "description": "Must be true to confirm shutdown. Safety guard against accidental invocation.",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["confirm"] as [String],
+    ] as [String: Any]
+  )
+
+  static let systemStats = MCPToolDefinition(
+    name: "system_stats",
+    description: "Get system hardware information: Apple Silicon device name, total memory, and VRAM available for generation.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let applyStyle = MCPToolDefinition(
+    name: "apply_style",
+    description: "Apply a style preset to a prompt. Returns the enhanced prompt with prefix/suffix, negative prompt, and recommended generation parameters. Does not generate an image — use generate_image with the returned parameters.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "style_id": [
+          "type": "string",
+          "description": "Style preset ID (from list_styles).",
+        ] as [String: Any],
+        "prompt": [
+          "type": "string",
+          "description": "Base prompt to enhance with the style.",
+        ] as [String: Any],
+        "negative_prompt": [
+          "type": "string",
+          "description": "Optional negative prompt to merge with the style's negative prompt.",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["style_id", "prompt"] as [String],
+    ] as [String: Any]
+  )
+
+  // MARK: - Lookup
+
+  /// Find a tool definition by name.
+  public static func tool(named name: String) -> MCPToolDefinition? {
+    tools.first { $0.name == name }
+  }
+}

--- a/Sources/ZImage/MCP/MCPTypes.swift
+++ b/Sources/ZImage/MCP/MCPTypes.swift
@@ -1,0 +1,336 @@
+// MCPTypes.swift — JSON-RPC 2.0 protocol types for MCP server
+//
+// Implements the Model Context Protocol (MCP) 2024-11-05 wire format.
+// All types are Codable for direct JSON serialization over stdio.
+
+import Foundation
+
+// MARK: - JSON-RPC 2.0 Request
+
+/// Incoming JSON-RPC 2.0 message (request or notification).
+/// Notifications have no `id` field.
+public struct MCPRequest: Codable, Sendable {
+  public let jsonrpc: String
+  public let id: MCPRequestId?
+  public let method: String
+  public let params: MCPParams?
+
+  public init(jsonrpc: String = "2.0", id: MCPRequestId? = nil, method: String, params: MCPParams? = nil) {
+    self.jsonrpc = jsonrpc
+    self.id = id
+    self.method = method
+    self.params = params
+  }
+}
+
+/// Request ID — can be a string or integer per JSON-RPC 2.0 spec.
+public enum MCPRequestId: Codable, Sendable, Equatable {
+  case string(String)
+  case integer(Int)
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let intVal = try? container.decode(Int.self) {
+      self = .integer(intVal)
+      return
+    }
+    if let strVal = try? container.decode(String.self) {
+      self = .string(strVal)
+      return
+    }
+    throw DecodingError.typeMismatch(
+      MCPRequestId.self,
+      DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or Int for JSON-RPC id")
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let s): try container.encode(s)
+    case .integer(let i): try container.encode(i)
+    }
+  }
+}
+
+/// Params object — decoded lazily as raw JSON to avoid schema coupling.
+public struct MCPParams: Codable, Sendable {
+  public let raw: [String: AnyCodable]
+
+  public init(_ dict: [String: AnyCodable] = [:]) {
+    self.raw = dict
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.raw = try container.decode([String: AnyCodable].self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(raw)
+  }
+
+  /// Get a string value from params.
+  public func string(_ key: String) -> String? {
+    raw[key]?.stringValue
+  }
+
+  /// Get an integer value from params.
+  public func integer(_ key: String) -> Int? {
+    raw[key]?.intValue
+  }
+
+  /// Get a boolean value from params.
+  public func bool(_ key: String) -> Bool? {
+    raw[key]?.boolValue
+  }
+
+  /// Get a double value from params.
+  public func number(_ key: String) -> Double? {
+    raw[key]?.doubleValue
+  }
+
+  /// Get an array value from params.
+  public func array(_ key: String) -> [AnyCodable]? {
+    raw[key]?.arrayValue
+  }
+
+  /// Get a nested dictionary from params.
+  public func dict(_ key: String) -> [String: AnyCodable]? {
+    raw[key]?.dictValue
+  }
+}
+
+// MARK: - JSON-RPC 2.0 Response
+
+/// Outgoing JSON-RPC 2.0 response.
+public struct MCPResponse: Codable, Sendable {
+  public let jsonrpc: String
+  public let id: MCPRequestId?
+  public let result: AnyCodable?
+  public let error: MCPError?
+
+  public init(id: MCPRequestId?, result: AnyCodable) {
+    self.jsonrpc = "2.0"
+    self.id = id
+    self.result = result
+    self.error = nil
+  }
+
+  public init(id: MCPRequestId?, error: MCPError) {
+    self.jsonrpc = "2.0"
+    self.id = id
+    self.result = nil
+    self.error = error
+  }
+}
+
+// MARK: - JSON-RPC Error
+
+/// JSON-RPC 2.0 error object.
+public struct MCPError: Codable, Sendable {
+  public let code: Int
+  public let message: String
+  public let data: AnyCodable?
+
+  public init(code: Int, message: String, data: AnyCodable? = nil) {
+    self.code = code
+    self.message = message
+    self.data = data
+  }
+
+  // Standard JSON-RPC error codes
+  public static let parseError = MCPError(code: -32700, message: "Parse error")
+  public static let invalidRequest = MCPError(code: -32600, message: "Invalid Request")
+  public static let methodNotFound = MCPError(code: -32601, message: "Method not found")
+  public static let invalidParams = MCPError(code: -32602, message: "Invalid params")
+  public static let internalError = MCPError(code: -32603, message: "Internal error")
+
+  /// Application-level error for tool execution failures.
+  public static func toolError(_ message: String) -> MCPError {
+    MCPError(code: -32000, message: message)
+  }
+}
+
+// MARK: - MCP Tool Definition
+
+/// Tool definition for the MCP tools/list response.
+public struct MCPToolDefinition: Sendable {
+  public let name: String
+  public let description: String
+  public let inputSchema: [String: Any]
+
+  public init(name: String, description: String, inputSchema: [String: Any]) {
+    self.name = name
+    self.description = description
+    self.inputSchema = inputSchema
+  }
+
+  /// Serialize inputSchema to JSON-compatible dictionary (for tools/list response).
+  public func inputSchemaJSON() -> Any {
+    return inputSchema
+  }
+}
+
+// MARK: - MCP Content Block
+
+/// A content block in an MCP tool result.
+public struct MCPContentBlock: Sendable {
+  public let type: String
+  public let text: String?
+
+  public init(text: String) {
+    self.type = "text"
+    self.text = text
+  }
+}
+
+// MARK: - MCP Tool Result
+
+/// Result of a tools/call invocation.
+public struct MCPToolResult: Sendable {
+  public let content: [MCPContentBlock]
+  public let isError: Bool
+
+  public init(text: String) {
+    self.content = [MCPContentBlock(text: text)]
+    self.isError = false
+  }
+
+  public init(error: String) {
+    self.content = [MCPContentBlock(text: error)]
+    self.isError = true
+  }
+
+  /// Encode as a JSON-serializable dictionary for the MCP response.
+  func toResponseDict() -> [String: Any] {
+    var result: [String: Any] = [
+      "content": content.map { block -> [String: Any] in
+        var dict: [String: Any] = ["type": block.type]
+        if let text = block.text { dict["text"] = text }
+        return dict
+      }
+    ]
+    if isError {
+      result["isError"] = true
+    }
+    return result
+  }
+}
+
+// MARK: - AnyCodable (type-erased JSON wrapper)
+
+/// Type-erased Codable wrapper for arbitrary JSON values.
+/// Supports null, bool, int, double, string, array, and dictionary.
+public struct AnyCodable: Codable, Sendable {
+  public let value: Any
+
+  public init(_ value: Any) {
+    self.value = AnyCodable.sanitize(value)
+  }
+
+  // MARK: Accessors
+
+  public var stringValue: String? { value as? String }
+  public var intValue: Int? { value as? Int }
+  public var doubleValue: Double? {
+    if let d = value as? Double { return d }
+    if let i = value as? Int { return Double(i) }
+    return nil
+  }
+  public var boolValue: Bool? { value as? Bool }
+  public var arrayValue: [AnyCodable]? { value as? [AnyCodable] }
+  public var dictValue: [String: AnyCodable]? { value as? [String: AnyCodable] }
+  public var isNil: Bool { value is NSNull }
+
+  /// Recursively unwrap AnyCodable wrappers back to plain [String: Any] / [Any].
+  /// Used when embedding an AnyCodable tree inside another [String: Any] dict.
+  public var rawValue: Any {
+    switch value {
+    case let dict as [String: AnyCodable]:
+      return dict.mapValues { $0.rawValue }
+    case let arr as [AnyCodable]:
+      return arr.map { $0.rawValue }
+    default:
+      return value
+    }
+  }
+
+  // MARK: Codable
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      value = NSNull()
+    } else if let b = try? container.decode(Bool.self) {
+      value = b
+    } else if let i = try? container.decode(Int.self) {
+      value = i
+    } else if let d = try? container.decode(Double.self) {
+      value = d
+    } else if let s = try? container.decode(String.self) {
+      value = s
+    } else if let arr = try? container.decode([AnyCodable].self) {
+      value = arr
+    } else if let dict = try? container.decode([String: AnyCodable].self) {
+      value = dict
+    } else {
+      throw DecodingError.typeMismatch(
+        AnyCodable.self,
+        DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unsupported JSON value type")
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch value {
+    case is NSNull:
+      try container.encodeNil()
+    case let b as Bool:
+      try container.encode(b)
+    case let i as Int:
+      try container.encode(i)
+    case let d as Double:
+      try container.encode(d)
+    case let s as String:
+      try container.encode(s)
+    case let arr as [AnyCodable]:
+      try container.encode(arr)
+    case let dict as [String: AnyCodable]:
+      try container.encode(dict)
+    default:
+      if let dict = value as? [String: Any] {
+        try container.encode(dict.mapValues { AnyCodable($0) })
+      } else if let arr = value as? [Any] {
+        try container.encode(arr.map { AnyCodable($0) })
+      } else {
+        try container.encode(String(describing: value))
+      }
+    }
+  }
+
+  /// Sanitize a value from [String: Any] into properly nested AnyCodable types.
+  private static func sanitize(_ value: Any) -> Any {
+    switch value {
+    case let dict as [String: Any]:
+      return dict.mapValues { AnyCodable($0) } as [String: AnyCodable]
+    case let arr as [Any]:
+      return arr.map { AnyCodable($0) } as [AnyCodable]
+    default:
+      return value
+    }
+  }
+}
+
+// MARK: - MCP Method Constants
+
+/// Standard MCP method names.
+public enum MCPMethod {
+  public static let initialize = "initialize"
+  public static let notificationsInitialized = "notifications/initialized"
+  public static let toolsList = "tools/list"
+  public static let toolsCall = "tools/call"
+  public static let ping = "ping"
+}

--- a/Sources/ZImage/MCP/WarmServerClient.swift
+++ b/Sources/ZImage/MCP/WarmServerClient.swift
@@ -1,0 +1,96 @@
+// WarmServerClient.swift — Minimal HTTP client for localhost WarmServer
+//
+// Uses Foundation URLSession for HTTP calls to the WarmServer REST API.
+// All requests are localhost-only. Timeout: 300 seconds (renders can take minutes).
+
+import Foundation
+
+/// Lightweight HTTP client targeting the local WarmServer instance.
+public final class WarmServerClient: @unchecked Sendable {
+  public let host: String
+  public let port: UInt16
+
+  private let session: URLSession
+  private let baseURL: String
+
+  public init(host: String = "127.0.0.1", port: UInt16 = 7862) {
+    self.host = host
+    self.port = port
+    self.baseURL = "http://\(host):\(port)"
+
+    let config = URLSessionConfiguration.ephemeral
+    config.timeoutIntervalForRequest = 300
+    config.timeoutIntervalForResource = 300
+    self.session = URLSession(configuration: config)
+  }
+
+  // MARK: - Public API
+
+  /// Perform a GET request. Returns (HTTP status code, response body).
+  public func get(_ path: String) async throws -> (Int, Data) {
+    guard let url = URL(string: baseURL + path) else {
+      throw WarmServerClientError.invalidURL(path)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+    let (data, response) = try await perform(request)
+    return (response.statusCode, data)
+  }
+
+  /// Perform a POST request with a raw Data body. Returns (HTTP status code, response body).
+  public func post(_ path: String, body: Data) async throws -> (Int, Data) {
+    guard let url = URL(string: baseURL + path) else {
+      throw WarmServerClientError.invalidURL(path)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.httpBody = body
+
+    let (data, response) = try await perform(request)
+    return (response.statusCode, data)
+  }
+
+  // MARK: - Private
+
+  private func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    do {
+      let (data, response) = try await session.data(for: request)
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw WarmServerClientError.invalidResponse
+      }
+      return (data, httpResponse)
+    } catch let error as URLError where error.code == .cannotConnectToHost || error.code == .networkConnectionLost {
+      throw WarmServerClientError.connectionRefused(host: host, port: port)
+    } catch let error as WarmServerClientError {
+      throw error
+    } catch {
+      throw WarmServerClientError.networkError(error.localizedDescription)
+    }
+  }
+}
+
+// MARK: - Errors
+
+public enum WarmServerClientError: Error, LocalizedError {
+  case invalidURL(String)
+  case invalidResponse
+  case connectionRefused(host: String, port: UInt16)
+  case networkError(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidURL(let path):
+      return "Invalid URL path: \(path)"
+    case .invalidResponse:
+      return "Invalid HTTP response"
+    case .connectionRefused(let host, let port):
+      return "WarmServer not running at \(host):\(port)"
+    case .networkError(let message):
+      return "Network error: \(message)"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) server to ComfyBox, enabling Claude Code and other MCP clients to interact with the WarmServer image generation API over stdio JSON-RPC 2.0
- 5 new files under `Sources/ZImage/MCP/`: protocol types, tool registry (11 tools), server orchestrator, tool executor (HTTP proxy to WarmServer), and HTTP client
- New `comfybox mcp [--port] [--host]` CLI subcommand that blocks on stdin for JSON-RPC requests
- Implements MCP 2024-11-05 protocol: initialize handshake, tools/list (static catalog), tools/call dispatch
- Tools: generate_image, swap_loras, list_models, list_styles, server_health, queue_status, clear_queue, list_loras, shutdown_server, system_stats, apply_style
- apply_style resolves locally via ComfyBoxStylePresets (no HTTP call); all other tools proxy to WarmServer REST API

Closes #86

## Test plan

- [x] `swift build -c release` succeeds
- [x] Smoke test: initialize handshake returns correct protocol version and server info
- [x] Smoke test: tools/list returns all 11 tools with valid JSON Schema inputSchema
- [x] Smoke test: tools/call apply_style returns enhanced prompt with correct style parameters
- [ ] Integration: `claude mcp add comfybox -- comfybox mcp` registers successfully
- [ ] Integration: generate_image tool produces an image when WarmServer is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)