### PR TITLE
feat(mcp): add LoRA library tools — list, scan, quarantine

### DIFF
--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -40,6 +40,12 @@ public final class MCPToolExecutor: @unchecked Sendable {
         return try await executeGet("/system_stats")
       case "apply_style":
         return executeApplyStyle(arguments)
+      case "lora_library":
+        return try await executeLoraLibrary(arguments)
+      case "lora_scan":
+        return try await executeLoraScan(arguments)
+      case "lora_quarantine":
+        return try await executeLoraQuarantine(arguments)
       default:
         return MCPToolResult(error: "Unknown tool: \(name)")
       }
@@ -213,6 +219,62 @@ public final class MCPToolExecutor: @unchecked Sendable {
       return MCPToolResult(error: "Error: Failed to serialize style result")
     }
     return MCPToolResult(text: text)
+  }
+
+
+  /// lora_library -> GET /v1/loras (with optional query params)
+  private func executeLoraLibrary(_ params: MCPParams?) async throws -> MCPToolResult {
+    var path = "/v1/loras"
+    var queryItems: [String] = []
+
+    if let model = params?.string("model") {
+      queryItems.append("model=\(model)")
+    }
+    if params?.bool("include_quarantined") == true {
+      queryItems.append("include_quarantined=true")
+    }
+    if !queryItems.isEmpty {
+      path += "?" + queryItems.joined(separator: "&")
+    }
+
+    let (status, data) = try await client.get(path)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// lora_scan -> POST /v1/loras/scan
+  private func executeLoraScan(_ params: MCPParams?) async throws -> MCPToolResult {
+    var body: [String: Any] = [:]
+    if params?.bool("force") == true {
+      body["force"] = true
+    }
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/loras/scan", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// lora_quarantine -> POST /v1/loras/{id}/quarantine or DELETE /v1/loras/{id}/quarantine
+  private func executeLoraQuarantine(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let id = params?.string("id"), !id.isEmpty else {
+      return MCPToolResult(error: "Error: 'id' is required")
+    }
+    guard let quarantine = params?.bool("quarantine") else {
+      return MCPToolResult(error: "Error: 'quarantine' (boolean) is required")
+    }
+
+    let path = "/v1/loras/\(id)/quarantine"
+
+    if quarantine {
+      var body: [String: Any] = [:]
+      if let reason = params?.string("reason") {
+        body["reason"] = reason
+      }
+      let jsonData = try JSONSerialization.data(withJSONObject: body)
+      let (status, data) = try await client.post(path, body: jsonData)
+      return mapHTTPResponse(status: status, data: data)
+    } else {
+      let (status, data) = try await client.delete(path)
+      return mapHTTPResponse(status: status, data: data)
+    }
   }
 
   // MARK: - Helpers

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -22,6 +22,9 @@ public enum MCPToolRegistry {
     shutdownServer,
     systemStats,
     applyStyle,
+    loraLibrary,
+    loraScan,
+    loraQuarantine,
   ]
 
   // MARK: - Tool Definitions
@@ -212,6 +215,62 @@ public enum MCPToolRegistry {
         ] as [String: Any],
       ] as [String: Any],
       "required": ["style_id", "prompt"] as [String],
+    ] as [String: Any]
+  )
+
+
+  static let loraLibrary = MCPToolDefinition(
+    name: "lora_library",
+    description: "List all LoRAs in the library with compatibility info. Filter by model family.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "model": [
+          "type": "string",
+          "description": "Filter by model family (e.g. \"z-image\", \"klein-9b\").",
+        ] as [String: Any],
+        "include_quarantined": [
+          "type": "boolean",
+          "description": "Include quarantined LoRAs in results. Default: false.",
+        ] as [String: Any],
+      ] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let loraScan = MCPToolDefinition(
+    name: "lora_scan",
+    description: "Scan the LoRA directory for new or changed files and update the library index.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "force": [
+          "type": "boolean",
+          "description": "Force full rescan of all LoRA files. Default: false.",
+        ] as [String: Any],
+      ] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let loraQuarantine = MCPToolDefinition(
+    name: "lora_quarantine",
+    description: "Quarantine or un-quarantine a LoRA. Quarantined LoRAs are hidden from model loading.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "id": [
+          "type": "string",
+          "description": "LoRA identifier from the library.",
+        ] as [String: Any],
+        "quarantine": [
+          "type": "boolean",
+          "description": "True to quarantine, false to un-quarantine.",
+        ] as [String: Any],
+        "reason": [
+          "type": "string",
+          "description": "Reason for quarantine action.",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["id", "quarantine"] as [String],
     ] as [String: Any]
   )
 

--- a/Sources/ZImage/MCP/WarmServerClient.swift
+++ b/Sources/ZImage/MCP/WarmServerClient.swift
@@ -54,6 +54,19 @@ public final class WarmServerClient: @unchecked Sendable {
     return (response.statusCode, data)
   }
 
+  /// Perform a DELETE request. Returns (HTTP status code, response body).
+  public func delete(_ path: String) async throws -> (Int, Data) {
+    guard let url = URL(string: baseURL + path) else {
+      throw WarmServerClientError.invalidURL(path)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+    let (data, response) = try await perform(request)
+    return (response.statusCode, data)
+  }
+
   // MARK: - Private
 
   private func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {


### PR DESCRIPTION
## Summary

- Add 3 new MCP tools exposing the LoRA Library API (PR #96) to LLM agents:
  - `lora_library` — list LoRAs with optional model family filter and quarantine visibility
  - `lora_scan` — trigger directory rescan to update the library index
  - `lora_quarantine` — quarantine/un-quarantine LoRAs (POST to quarantine, DELETE to un-quarantine)
- Add `delete()` method to `WarmServerClient` for the un-quarantine DELETE endpoint
- Tool count: 11 → 14

## Files Changed

- `Sources/ZImage/MCP/MCPToolRegistry.swift` — 3 new tool definitions
- `Sources/ZImage/MCP/MCPToolExecutor.swift` — 3 new executor cases with HTTP mapping
- `Sources/ZImage/MCP/WarmServerClient.swift` — new `delete()` method

## Test plan

- [ ] `swift build -c release` passes (verified locally)
- [ ] `lora_library` returns LoRA entries from `GET /v1/loras`
- [ ] `lora_library` with `model` param appends query string correctly
- [ ] `lora_scan` triggers `POST /v1/loras/scan`
- [ ] `lora_quarantine` with `quarantine: true` sends POST
- [ ] `lora_quarantine` with `quarantine: false` sends DELETE

🤖 Generated with [Claude Code](https://claude.com/claude-code)