### PR TITLE
fix(mcp): restore 3 model pool tools lost in parallel merge

### DIFF
--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -46,6 +46,12 @@ public final class MCPToolExecutor: @unchecked Sendable {
         return try await executeLoraScan(arguments)
       case "lora_quarantine":
         return try await executeLoraQuarantine(arguments)
+      case "load_model":
+        return try await executeLoadModel(arguments)
+      case "switch_model":
+        return try await executeSwitchModel(arguments)
+      case "model_pool":
+        return try await executeGet("/v1/model/pool")
       default:
         return MCPToolResult(error: "Unknown tool: \(name)")
       }
@@ -275,6 +281,43 @@ public final class MCPToolExecutor: @unchecked Sendable {
       let (status, data) = try await client.delete(path)
       return mapHTTPResponse(status: status, data: data)
     }
+  }
+
+
+  /// load_model -> POST /v1/model/load
+  private func executeLoadModel(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let model = params?.string("model"), !model.isEmpty else {
+      return MCPToolResult(error: "Error: 'model' is required")
+    }
+    var body: [String: Any] = ["model": model]
+    if let quantization = params?.string("quantization") {
+      body["quantization"] = quantization
+    }
+    if let activate = params?.bool("activate") {
+      body["activate"] = activate
+    }
+    if let wait = params?.bool("wait") {
+      body["wait"] = wait
+    }
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/model/load", body: jsonData)
+    // 202 is valid (async load in progress)
+    if status == 200 || status == 202 {
+      let text = String(data: data, encoding: .utf8) ?? "{}"
+      return MCPToolResult(text: text)
+    }
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// switch_model -> POST /v1/model/activate
+  private func executeSwitchModel(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let model = params?.string("model"), !model.isEmpty else {
+      return MCPToolResult(error: "Error: 'model' is required")
+    }
+    let body: [String: Any] = ["model": model]
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/model/activate", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
   }
 
   // MARK: - Helpers

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -25,6 +25,9 @@ public enum MCPToolRegistry {
     loraLibrary,
     loraScan,
     loraQuarantine,
+    loadModel,
+    switchModel,
+    modelPool,
   ]
 
   // MARK: - Tool Definitions
@@ -271,6 +274,58 @@ public enum MCPToolRegistry {
         ] as [String: Any],
       ] as [String: Any],
       "required": ["id", "quarantine"] as [String],
+    ] as [String: Any]
+  )
+
+
+  static let loadModel = MCPToolDefinition(
+    name: "load_model",
+    description: "Load a model into the pool. Optionally activate it and wait for completion. Supports all model families: Z-Image, Klein, FIBO, Chroma, SeedVR2.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "model": [
+          "type": "string",
+          "description": "Model spec to load (e.g. \"z-image-turbo-bf16\", \"klein-9b-q8\", \"briaai/FIBO\", \"chroma-8.9b\").",
+        ] as [String: Any],
+        "quantization": [
+          "type": "string",
+          "description": "Quantization level (e.g. \"4bit\", \"8bit\"). Omit for default (typically bf16).",
+        ] as [String: Any],
+        "activate": [
+          "type": "boolean",
+          "description": "Activate the model after loading. Default: true.",
+        ] as [String: Any],
+        "wait": [
+          "type": "boolean",
+          "description": "Wait for load to complete before returning. Default: true. Set false for background loading.",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["model"] as [String],
+    ] as [String: Any]
+  )
+
+  static let switchModel = MCPToolDefinition(
+    name: "switch_model",
+    description: "Switch the active model to one already loaded in the pool. Instant — no loading required.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "model": [
+          "type": "string",
+          "description": "Pool model ID to activate (from model_pool results).",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["model"] as [String],
+    ] as [String: Any]
+  )
+
+  static let modelPool = MCPToolDefinition(
+    name: "model_pool",
+    description: "List all models currently loaded in the pool with VRAM usage, active status, and last-used timestamps.",
+    inputSchema: [
+      "type": "object",
+      "properties": [:] as [String: Any],
     ] as [String: Any]
   )
 


### PR DESCRIPTION
## Summary

- **load_model**, **switch_model**, and **model_pool** were dropped when PR #98 (LoRA tools) squash-merged over PR #97 (pool tools) due to a parallel agent conflict on the same files
- Re-adds all 3 tool definitions to MCPToolRegistry.swift and executor cases to MCPToolExecutor.swift
- MCP server now exposes all 17 tools (11 original + 3 LoRA + 3 pool)
- Clean release build verified

## Changes
- `MCPToolRegistry.swift`: +3 tool definitions, +3 entries in tools array
- `MCPToolExecutor.swift`: +3 switch cases, +2 executor methods (model_pool reuses executeGet)

## Test plan
- [x] swift build -c release passes
- [x] 17 tool definitions in registry
- [x] 17 executor cases in switch
- [ ] MCP tools/list returns 17 tools (runtime test after merge)

Generated with [Claude Code](https://claude.com/claude-code)