### PR TITLE
feat(bridge): Krita model auto-detection + pool integration

### DIFF
--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -31,6 +31,11 @@ final class ComfyBridge {
   /// Queue clear handler — set by WarmServer to clear pending coordinator jobs.
   var queueClearHandler: (() async -> Void)?
 
+  /// Model switch handler — set by WarmServer to auto-switch models when Krita
+  /// selects a different checkpoint. Returns true if the model was switched successfully.
+  /// The handler receives the detected model ID from the workflow's CheckpointLoaderSimple node.
+  var modelSwitchHandler: ((_ modelId: String) async throws -> Bool)?
+
   /// LoRA Library reference — set by WarmServer for library-aware LoRA discovery.
   /// When set, invalidates the cached object_info so the next request picks up
   /// library-sourced LoRA listings filtered by model compatibility.
@@ -341,7 +346,22 @@ final class ComfyBridge {
     logger.info("ComfyBridge: /prompt — \(generateRequest.width)x\(generateRequest.height), \(generateRequest.steps) steps, cfg=\(generateRequest.guidance), seed=\(generateRequest.seed.map(String.init) ?? "random")")
 
     // Acknowledge immediately — generation runs async via WebSocket events.
+    // Model switch (if detected) happens inside the async Task before generation starts.
+    let detectedModel = generateRequest.detectedModel
+    let switchHandler = modelSwitchHandler
     Task {
+      // Auto-switch model if the workflow specifies a different checkpoint.
+      if let modelId = detectedModel, let handler = switchHandler {
+        do {
+          let switched = try await handler(modelId)
+          if switched {
+            self.logger.info("ComfyBridge: auto-switched to model '\(modelId)' for this render")
+          }
+        } catch {
+          self.logger.error("ComfyBridge: model switch to '\(modelId)' failed — \(error.localizedDescription)")
+          // Continue with current model rather than failing the entire render.
+        }
+      }
       await executor.execute(generateRequest)
     }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -599,10 +599,18 @@ enum ComfyBridgeObjectInfo {
 
   private static func zimageUnetModels() -> [String] {
     [
+      // Z-Image (Flux 1) family
       "z-image-turbo",
       "z-image-turbo-bf16",
       "z-image-turbo-q8",
       "z-image-turbo-q4",
+      // Klein (Flux 2) family
+      "klein-4b-q8",
+      "klein-9b-q8",
+      // FIBO family
+      "briaai/FIBO",
+      // Chroma family
+      "chroma-8.9b",
     ]
   }
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeWorkflowParser.swift
@@ -66,6 +66,12 @@ struct ComfyBridgeGenerateRequest: Sendable {
   /// Image cache ID of the control image (depth map, canny edges, etc.).
   let controlImageId: String?
 
+  // --- Model detection fields ---
+
+  /// Model ID detected from CheckpointLoaderSimple node in the workflow.
+  /// Used for automatic model switching when Krita selects a different checkpoint.
+  let detectedModel: String?
+
   /// Whether this is an inpainting request.
   var isInpaint: Bool { inpaintImageId != nil }
 
@@ -375,11 +381,18 @@ enum ComfyBridgeWorkflowParser {
       controlnetModel = nil
     }
 
+
+    // --- Model detection from CheckpointLoaderSimple ---
+    // Krita sends a CheckpointLoaderSimple node with ckpt_name indicating the user's
+    // selected model. We extract this and map it to a ComfyBox pool model ID.
+    let detectedModel = Self.extractDetectedModel(from: nodes)
+
     // Debug: log workflow structure
     let _nodeTypes = nodes.values.map { $0.classType }.sorted()
     let _loraDesc = loras.isEmpty ? "none" : loras.map { "\($0.name)@\($0.scale)" }.joined(separator: ", ")
     let _cnDesc = controlnetModel ?? "none"
-    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise) loras=\(_loraDesc) controlnet=\(_cnDesc)")
+    let _modelDesc = detectedModel ?? "none"
+    print("[ComfyBridge] workflow nodes: \(_nodeTypes.joined(separator: ", ")), parsed: \(width)x\(height) denoise=\(denoise) loras=\(_loraDesc) controlnet=\(_cnDesc) model=\(_modelDesc)")
 
     return ComfyBridgeGenerateRequest(
       promptId: promptId,
@@ -409,7 +422,8 @@ enum ComfyBridgeWorkflowParser {
       controlnetStrength: controlnetStrength,
       controlnetStart: controlnetStart,
       controlnetEnd: controlnetEnd,
-      controlImageId: controlImageId
+      controlImageId: controlImageId,
+      detectedModel: detectedModel
     )
   }
 
@@ -666,6 +680,60 @@ enum ComfyBridgeWorkflowParser {
 
   private static func roundTo16(_ value: Int) -> Int {
     return ((value + 15) / 16) * 16
+  }
+
+  // MARK: - Model Detection
+
+  /// Known exact model name to pool ID mappings.
+  private static let exactModelMap: [String: String] = [
+    "z-image-turbo-bf16": "z-image-turbo-bf16",
+    "z-image-turbo-q8": "z-image-turbo-q8",
+    "z-image-turbo-q4": "z-image-turbo-q4",
+    "z-image-turbo": "z-image-turbo-bf16",
+    "klein-4b-q8": "klein-4b-q8",
+    "klein-9b-q8": "klein-9b-q8",
+    "briaai/FIBO": "briaai/FIBO",
+    "chroma-8.9b": "chroma-8.9b",
+  ]
+
+  /// Partial model name patterns for fuzzy matching (checked in order).
+  private static let partialModelPatterns: [(pattern: String, poolId: String)] = [
+    ("z-image-turbo-bf16", "z-image-turbo-bf16"),
+    ("z-image-turbo-q8", "z-image-turbo-q8"),
+    ("z-image-turbo-q4", "z-image-turbo-q4"),
+    ("z-image-turbo", "z-image-turbo-bf16"),
+    ("z-image", "z-image-turbo-bf16"),
+    ("klein-9b", "klein-9b-q8"),
+    ("klein-4b", "klein-4b-q8"),
+    ("klein", "klein-4b-q8"),
+    ("fibo", "briaai/FIBO"),
+    ("chroma", "chroma-8.9b"),
+  ]
+
+  /// Extract the detected model ID from a CheckpointLoaderSimple node.
+  /// Returns nil if no checkpoint node is found or the model name is unrecognized.
+  private static func extractDetectedModel(from nodes: [String: WorkflowNode]) -> String? {
+    guard let checkpointNode = nodes.values.first(where: { $0.classType == "CheckpointLoaderSimple" }),
+          let ckptName = checkpointNode.inputs["ckpt_name"] as? String,
+          !ckptName.isEmpty else {
+      return nil
+    }
+
+    // Try exact match first.
+    if let exactMatch = exactModelMap[ckptName] {
+      return exactMatch
+    }
+
+    // Try partial/prefix matching (case-insensitive).
+    let lowered = ckptName.lowercased()
+    for (pattern, poolId) in partialModelPatterns {
+      if lowered.contains(pattern.lowercased()) {
+        return poolId
+      }
+    }
+
+    // Unrecognized model — return the raw name so the caller can attempt pool lookup.
+    return ckptName
   }
 }
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -202,6 +202,32 @@ public final class WarmServer {
       let cleared = await self.coordinator.clearPending()
       self.logger.info("ComfyBridge: cleared \(cleared) pending job(s) from queue")
     }
+
+    // Wire model switch handler for Krita checkpoint auto-detection.
+    // When Krita sends a workflow with a different checkpoint, this handler
+    // checks if the model is already in the pool (activate) or needs loading.
+    self.comfyBridge.modelSwitchHandler = { [unowned self] (modelId: String) async throws -> Bool in
+      // Check if this model is already active — no switch needed.
+      let currentActive = await self.coordinator.modelPool.activeModelId()
+      let requestedKey = ModelPool.poolKey(for: modelId)
+      if currentActive == requestedKey {
+        return false
+      }
+
+      // Check if the model is already in the pool — just activate it (instant).
+      if let existing = await self.coordinator.modelPool.findEntry(for: modelId) {
+        try await self.coordinator.poolActivate(modelId: existing.id)
+        self.logger.info("ComfyBridge: activated pool model '\(existing.id)' for Krita checkpoint switch")
+        return true
+      }
+
+      // Model not in pool — load and activate it.
+      let quantization = Self.parseQuantization(from: modelId)
+      let modelSpec = Self.parseModelSpec(from: modelId)
+      let result = try await self.coordinator.poolLoad(modelSpec: modelSpec, quantization: quantization, activate: true)
+      self.logger.info("ComfyBridge: loaded + activated '\(result.model)' (\(result.loadTimeMs)ms) for Krita checkpoint switch")
+      return true
+    }
   }
 
   public func run() throws {
@@ -1154,6 +1180,40 @@ public final class WarmServer {
     }
     guard result == KERN_SUCCESS else { return 0 }
     return info.phys_footprint
+  }
+
+  // MARK: - Krita Model Detection Helpers
+
+  /// Parse quantization suffix from a model ID string.
+  /// e.g. "z-image-turbo-q8" -> "q8", "klein-4b-q8" -> "q8", "briaai/FIBO" -> nil
+  static func parseQuantization(from modelId: String) -> String? {
+    let lowered = modelId.lowercased()
+    if lowered.hasSuffix("-q4") { return "q4" }
+    if lowered.hasSuffix("-q8") { return "q8" }
+    if lowered.hasSuffix("-bf16") { return "bf16" }
+    return nil
+  }
+
+  /// Parse the model spec from a pool-style model ID.
+  /// Strips quantization suffixes since poolLoad takes them separately.
+  /// e.g. "z-image-turbo-q8" -> "z-image-turbo", "briaai/FIBO" -> "briaai/FIBO"
+  static func parseModelSpec(from modelId: String) -> String {
+    let knownSpecs = [
+      "briaai/FIBO",
+      "chroma-8.9b",
+      "z-image-turbo",
+      "z-image-turbo-bf16",
+      "klein-4b",
+      "klein-9b",
+    ]
+    if knownSpecs.contains(modelId) { return modelId }
+    let suffixes = ["-q4", "-q8", "-bf16"]
+    for suffix in suffixes {
+      if modelId.lowercased().hasSuffix(suffix) {
+        return String(modelId.dropLast(suffix.count))
+      }
+    }
+    return modelId
   }
 }
 


### PR DESCRIPTION
## Summary

- Extract `ckpt_name` from `CheckpointLoaderSimple` node in Krita workflows to detect which model the user selected
- Auto-switch the active model pool entry before generation starts (activate if already loaded, load+activate if not)
- Update `/object_info` model lists to expose all supported model families (Z-Image, Klein, FIBO, Chroma) in Krita's model picker

## Changes

**ComfyBridgeWorkflowParser.swift**
- Added `detectedModel: String?` field to `ComfyBridgeGenerateRequest`
- Added `extractDetectedModel(from:)` with exact + partial name mapping for all pool model IDs
- Model detection logged in workflow debug output

**ComfyBridge.swift**
- Added `modelSwitchHandler` callback property (follows existing `queueStatusProvider`/`queueClearHandler` pattern)
- `handlePrompt` calls the handler before dispatching generation; failures are logged but don't block the render

**ComfyBridgeObjectInfo.swift**
- `zimageUnetModels()` now includes klein-4b-q8, klein-9b-q8, briaai/FIBO, chroma-8.9b
- This feeds `CheckpointLoaderSimple.ckpt_name`, `UNETLoader.unet_name`, and `NunchakuZImageDiTLoader.model_name`

**WarmServer.swift**
- Wires `modelSwitchHandler` in init: checks pool active → pool activate → pool load+activate
- Added `parseQuantization(from:)` and `parseModelSpec(from:)` helpers for model ID decomposition

## Test plan

- [ ] Start ComfyBox with z-image-turbo-bf16 (default), connect Krita, verify generation works as before
- [ ] In Krita, switch checkpoint to klein-4b-q8, submit render — verify log shows auto-switch + model loads
- [ ] Switch back to z-image-turbo-bf16 — verify instant activate (already in pool)
- [ ] Verify Krita model picker dropdown shows all 8 model options
- [ ] Submit a workflow without CheckpointLoaderSimple (standard Krita txt2img) — verify no model switch attempted

Does **not** close #88 — this is Phase 2 of the Krita integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)