### PR TITLE
feat(bridge+mcp): upscale routing via parseWorkflow + unload_model tool

### DIFF
--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -52,6 +52,8 @@ public final class MCPToolExecutor: @unchecked Sendable {
         return try await executeSwitchModel(arguments)
       case "model_pool":
         return try await executeGet("/v1/model/pool")
+      case "unload_model":
+        return try await executeUnloadModel(arguments)
       default:
         return MCPToolResult(error: "Unknown tool: \(name)")
       }
@@ -317,6 +319,18 @@ public final class MCPToolExecutor: @unchecked Sendable {
     let body: [String: Any] = ["model": model]
     let jsonData = try JSONSerialization.data(withJSONObject: body)
     let (status, data) = try await client.post("/v1/model/activate", body: jsonData)
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+
+  /// unload_model -> POST /v1/model/unload
+  private func executeUnloadModel(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let model = params?.string("model"), !model.isEmpty else {
+      return MCPToolResult(error: "Error: 'model' is required")
+    }
+    let body: [String: Any] = ["model": model]
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/model/unload", body: jsonData)
     return mapHTTPResponse(status: status, data: data)
   }
 

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -28,6 +28,7 @@ public enum MCPToolRegistry {
     loadModel,
     switchModel,
     modelPool,
+    unloadModel,
   ]
 
   // MARK: - Tool Definitions
@@ -326,6 +327,21 @@ public enum MCPToolRegistry {
     inputSchema: [
       "type": "object",
       "properties": [:] as [String: Any],
+    ] as [String: Any]
+  )
+
+  static let unloadModel = MCPToolDefinition(
+    name: "unload_model",
+    description: "Unload a model from the pool to free VRAM. Cannot unload the currently active model — switch to another model first.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "model": [
+          "type": "string",
+          "description": "Pool model ID to unload (from model_pool results).",
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["model"] as [String],
     ] as [String: Any]
   )
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridge.swift
@@ -331,38 +331,45 @@ final class ComfyBridge {
       }
     }
 
-    // Parse the workflow into generation parameters.
-    // TODO(seedvr2-merge): After PR 1 (parser) merges, change this to use
-    // ComfyBridgeWorkflowParser.parseWorkflow(json) which returns
-    // ComfyBridgeParsedWorkflow (.generate or .upscale) and route accordingly.
-    let generateRequest: ComfyBridgeGenerateRequest
+    // Parse the workflow — detects generate vs upscale from node types.
+    let parsedWorkflow: ComfyBridgeParsedWorkflow
     do {
-      generateRequest = try ComfyBridgeWorkflowParser.parse(json)
+      parsedWorkflow = try ComfyBridgeWorkflowParser.parseWorkflow(json)
     } catch {
       logger.error("ComfyBridge: workflow parse failed — \(error)")
       return .error(.error(status: 400, message: "Workflow parse error: \(error)"))
     }
 
-    logger.info("ComfyBridge: /prompt — \(generateRequest.width)x\(generateRequest.height), \(generateRequest.steps) steps, cfg=\(generateRequest.guidance), seed=\(generateRequest.seed.map(String.init) ?? "random")")
+    // Route to the correct executor based on workflow type.
+    switch parsedWorkflow {
+    case .generate(let generateRequest):
+      logger.info("ComfyBridge: /prompt [generate] — \(generateRequest.width)x\(generateRequest.height), \(generateRequest.steps) steps, cfg=\(generateRequest.guidance), seed=\(generateRequest.seed.map(String.init) ?? "random")")
 
-    // Acknowledge immediately — generation runs async via WebSocket events.
-    // Model switch (if detected) happens inside the async Task before generation starts.
-    let detectedModel = generateRequest.detectedModel
-    let switchHandler = modelSwitchHandler
-    Task {
-      // Auto-switch model if the workflow specifies a different checkpoint.
-      if let modelId = detectedModel, let handler = switchHandler {
-        do {
-          let switched = try await handler(modelId)
-          if switched {
-            self.logger.info("ComfyBridge: auto-switched to model '\(modelId)' for this render")
+      // Acknowledge immediately — generation runs async via WebSocket events.
+      // Model switch (if detected) happens inside the async Task before generation starts.
+      let detectedModel = generateRequest.detectedModel
+      let switchHandler = modelSwitchHandler
+      Task {
+        // Auto-switch model if the workflow specifies a different checkpoint.
+        if let modelId = detectedModel, let handler = switchHandler {
+          do {
+            let switched = try await handler(modelId)
+            if switched {
+              self.logger.info("ComfyBridge: auto-switched to model '\(modelId)' for this render")
+            }
+          } catch {
+            self.logger.error("ComfyBridge: model switch to '\(modelId)' failed — \(error.localizedDescription)")
+            // Continue with current model rather than failing the entire render.
           }
-        } catch {
-          self.logger.error("ComfyBridge: model switch to '\(modelId)' failed — \(error.localizedDescription)")
-          // Continue with current model rather than failing the entire render.
         }
+        await executor.execute(generateRequest)
       }
-      await executor.execute(generateRequest)
+
+    case .upscale(let upscaleRequest):
+      logger.info("ComfyBridge: /prompt [upscale] — model=\(upscaleRequest.upscaleModelName), input=\(upscaleRequest.inputImageNodeId)")
+      Task {
+        await executor.executeUpscale(upscaleRequest)
+      }
     }
 
     let response: [String: Any] = ["prompt_id": promptId]


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Bridge Upscale Routing (#100)
- Replaces `parse()` with `parseWorkflow()` in the bridge prompt handler
- Routes `.generate` workflows to `executor.execute()` and `.upscale` workflows to `executor.executeUpscale()`
- Preserves the Krita model auto-detection logic (from PR #102) within the generate case
- Removes the `TODO(seedvr2-merge)` that's been waiting for this wiring
- **Impact**: SeedVR2 and ESRGAN upscaling now works through the Krita bridge

### 2. unload_model MCP Tool (#101)
- Adds the 18th MCP tool: `unload_model`
- Maps to `POST /v1/model/unload` — frees VRAM by removing a model from the pool
- Completes the pool management set: load_model, switch_model, model_pool, unload_model

## Test plan
- [x] swift build -c release passes (57s)
- [x] 18 MCP tool definitions in registry
- [x] 0 TODO markers remaining in ComfyBridge.swift
- [ ] Runtime: send upscale workflow from Krita → routes to SeedVR2
- [ ] Runtime: MCP tools/list returns 18 tools

Closes #100, closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)