### PR TITLE
docs: tech architecture, user guide, MCP reference, deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # ComfyBox
 
-Swift port of [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) using [mlx-swift](https://github.com/ml-explore/mlx-swift) for Apple Silicon.
+> ComfyUI performance. Apple silicon native. Zero Python.
 
-This fork adds **SVG vector output** and **multi-LoRA support**.
+ComfyBox is a native Swift image generation engine for Apple Silicon. It runs diffusion models via MLX — no Python runtime, no node graphs, no ComfyUI dependency. Text-to-image, img2img, ControlNet, inpainting, LoRA, batch generation, and AI upscaling in a single binary.
 
-Reviewer handoff for the Barkada fork work lives at [`docs/review-handoff-barkada-fork-2026-03-28.md`](docs/review-handoff-barkada-fork-2026-03-28.md).
+An LLM orchestrator manages models, LoRAs, and generation parameters via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP), enabling AI assistants to generate images without manual configuration.
 
-**Try it with an easy UI:** [Lingdong Desktop App](https://lingdong.app/en)
+## Documentation
 
-## What's New in This Fork
+| Doc | Description |
+|-----|-------------|
+| [User Guide](docs/user-guide.md) | CLI usage, generation modes, LoRA, batch mode |
+| [Architecture](docs/architecture.md) | Engine, orchestrator, and protocol layers |
+| [MCP Tool Reference](docs/mcp-reference.md) | 18 MCP tools for AI assistant integration |
+| [Deployment](docs/deployment.md) | Serve mode, keepalive, remote SSH bridge |
+| [ComfyUI Bridge Spec](docs/comfyui-bridge-protocol-spec.md) | ComfyUI protocol emulation details |
+| [SeedVR2 Porting Guide](docs/seedvr2-porting-guide.md) | SeedVR2 upscaler implementation notes |
 
-- **SVG Export** - Convert generated images to vector SVG format
-- **Multi-LoRA** - Apply multiple LoRA weights simultaneously
-- **Progress Control** - Disable progress output for scripting
+## Quick Start
+
+```bash
+# Generate an image
+ComfyBox -p "A mountain landscape at sunset" -o landscape.png
+
+# Img2img transformation
+ComfyBox -p "oil painting style" --image photo.jpg --creativity 0.7 -o painting.png
+
+# Batch generation (10 random seeds)
+ComfyBox -p "portrait" --auto-seeds 10 -o batch/portrait.png
+
+# Run as warm server
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862
+
+# Start MCP server for AI assistants
+ComfyBox mcp --port 7862
+```
 
 ## System Requirements
 
@@ -20,15 +42,13 @@ Reviewer handoff for the Barkada fork work lives at [`docs/review-handoff-barkad
 |-------------|---------|
 | **macOS** | 14.0+ (Sonoma or later) |
 | **Chip** | Apple Silicon (M1, M2, M3, M4) |
-| **Disk Space** | ~6GB for model files |
-| **Internet** | Required for first-run model download |
-| **Swift** | 5.9+ (only if building from source) |
+| **VRAM** | 4-21 GB depending on model and precision |
+| **Disk** | ~6 GB for base model files |
+| **Swift** | 5.9+ (building from source only) |
 
 ## Installation
 
-### Pre-built Binary (Recommended)
-
-Download and install the latest Barkada release:
+### Pre-built Binary
 
 ```bash
 curl -LO https://github.com/BarkadaBrew/comfybox/releases/download/0.2.3/ComfyBox-0.2.3-macos-arm64.tar.gz
@@ -37,289 +57,111 @@ cd ComfyBox-0.2.3
 sudo ./install.sh
 ```
 
-This installs:
-- Binary to `/usr/local/lib/comfybox/ComfyBox`
-- Metal library to `/usr/local/lib/comfybox/mlx.metallib`
-- Wrapper script to `/usr/local/bin/ComfyBox`
-
 ### Building from Source
 
 ```bash
 git clone https://github.com/BarkadaBrew/comfybox.git
 cd comfybox
-xcodebuild -scheme ComfyBox -configuration Release -destination 'platform=macOS' -derivedDataPath .build/xcode
+xcodebuild -scheme ComfyBox -configuration Release \
+  -destination 'platform=macOS' -derivedDataPath .build/xcode
 ```
 
-The CLI binary and required Metal libraries will be in `.build/xcode/Build/Products/Release/`.
+## Supported Models
 
-> **Note**: SwiftPM builds (`swift build`) may have issues finding the Metal library on some systems. Xcode builds are recommended for production use.
+| Family | Steps | VRAM (BF16) | Notes |
+|--------|-------|-------------|-------|
+| Z-Image Turbo | 4-9 | ~7 GB | Default, fastest |
+| Z-Image Base | 20-50 | ~7 GB | CFG-guided, higher quality |
+| Flux 2 Klein 9B | 20-50 | ~21 GB | High quality, 8-bit available (~12 GB) |
+| FIBO 8B | 20+ | ~21 GB | JSON prompts, CC-BY-NC-4.0 |
+| Chroma 8.9B | 20+ | ~21 GB | Guidance-free |
+| SeedVR2 3B/7B | 1 | 7/16 GB | AI upscaling only |
 
-### Optional: Install vtracer for SVG Export
+## Features
 
-SVG conversion requires [vtracer](https://github.com/visioncortex/vtracer):
+### Generation
+- **Text-to-image** — prompt to pixels via Diffusion Transformer
+- **Image-to-image** — transform existing images with controllable strength
+- **ControlNet** — Canny, HED, Depth, Pose, MLSD conditioning
+- **Inpainting** — mask-guided region replacement
+- **Batch mode** — multi-seed/multi-prompt with checkpoint resume
 
-```bash
-# Install Rust if needed
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source $HOME/.cargo/env
+### Models & LoRA
+- **Multi-model** — Z-Image, Flux 2 Klein, FIBO, Chroma families
+- **Quantization** — 4-bit and 8-bit weight compression
+- **Multi-LoRA** — stack multiple style adapters with per-LoRA scaling
+- **Hot swap** — change LoRAs without model reload (~2s)
+- **LoRA library** — scan, search, quarantine, compatibility checking
 
-# Install vtracer
-cargo install vtracer
-```
+### Upscaling
+- **SeedVR2** — AI-powered 2x upscale with tiled VAE for large images
+- **ESRGAN** — traditional deterministic upscale with tile support
 
-## Usage
+### Server
+- **WarmServer** — HTTP API with warm model pool, hot LoRA swap
+- **Model Pool** — multiple models loaded simultaneously, instant switching
+- **MCP Server** — 18 tools for AI assistant integration via JSON-RPC 2.0
+- **ComfyUI Bridge** — protocol-compatible API for Krita AI Diffusion
 
-```bash
-ComfyBox -p "A beautiful mountain landscape at sunset" -o output.png
-```
+### Post-Processing
+- **SVG export** — vector conversion via vtracer with style presets
+- **Metadata sidecars** — reproducible generation with JSON parameter files
+- **Levels adjustment** — post-decode contrast correction
+- **Prompt enhancement** — built-in LLM prompt expansion
 
-For all available options:
+## Samplers
 
-```bash
-ComfyBox -h
-```
+| Sampler | Speed | Quality | Best For |
+|---------|-------|---------|----------|
+| `euler` | Fastest | Good | Default, distilled models |
+| `heun` | 2x slower | Higher | Fine detail |
+| `dpmpp-2m` | Medium | High | Base models with many steps |
+| `dpmpp-2s-a` | Medium | High | Stochastic variation |
+| `res_2s` | Medium | High | Balanced |
+| `deis` | Medium | High | Smooth outputs |
+| `ddim` | Medium | Good | Animation, deterministic |
 
-### Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-p, --prompt` | Text prompt (required) | - |
-| `--negative-prompt` | Negative prompt | - |
-| `-W, --width` | Output width | 1024 |
-| `-H, --height` | Output height | 1024 |
-| `-s, --steps` | Inference steps | 9 |
-| `-g, --guidance` | Guidance scale | 0.0 |
-| `--seed` | Random seed | random |
-| `-o, --output` | Output path | z-image.png |
-| `-m, --model` | Model path (dir or .safetensors) or HuggingFace ID | Tongyi-MAI/Z-Image-Turbo |
-| `--force-transformer-override-only` | Treat local .safetensors as transformer-only (disable AIO detection) | false |
-| `--cache-limit` | GPU memory cache limit in MB | unlimited |
-| `-l, --lora` | LoRA weights path or HuggingFace ID (single) | - |
-| `--lora-scale` | LoRA scale factor | 1.0 |
-| `--lora-paths` | Multiple LoRA paths (comma-separated) | - |
-| `--lora-scales` | Multiple LoRA scales (comma-separated) | 1.0 each |
-| `-e, --enhance` | Enhance prompt using LLM | false |
-| `--enhance-max-tokens` | Max tokens for prompt enhancement | 512 |
-| `--no-progress` | Disable progress output | false |
-| `--svg` | Generate SVG vector output (requires vtracer) | false |
-| `--svg-preset` | SVG conversion preset | default |
-
-Z-Image-Turbo defaults to guidance `0.0`. Other model families use different recommended guidance defaults.
-
-### SVG Presets
-
-| Preset | Use Case | Output Size |
-|--------|----------|-------------|
-| `default` | Balanced quality and file size | Medium |
-| `logo` | Logos, icons, flat graphics | Smallest |
-| `detailed` | Complex images, preserve detail | Largest |
-| `simplified` | Clean, minimal output | Small |
-| `bw` | Black and white conversion | Varies |
-
-## AIO Checkpoint Usage
-
-You can load a single `.safetensors` file containing the Transformer, Text Encoder, and VAE (AIO) directly:
-
-```bash
-ComfyBox -p "a cozy cabin" -m path/to/z_image_turbo_aio.safetensors
-```
-
-If the file is detected as an AIO checkpoint, it will skip loading base model weights and use the components from the file. To force it to be treated as a transformer-only override (overlaying base weights), use `--force-transformer-override-only`.
+**Sigma schedules:** `flow` (default), `karras`, `exponential`, `beta`, `beta57`
 
 ## Examples
 
 ```bash
-# Basic generation
-ComfyBox -p "a cute cat sitting on a windowsill" -o cat.png
+# Basic generation with seed
+ComfyBox -p "a cute cat sitting on a windowsill" --seed 42 -o cat.png
 
-# Portrait image with custom size
+# Portrait with specific resolution
 ComfyBox -p "portrait of a woman in renaissance style" -W 768 -H 1152 -o portrait.png
 
-# Using quantized model for lower memory usage
+# Quantized model (low VRAM)
 ComfyBox -p "a futuristic city at night" -m mzbac/Z-Image-Turbo-8bit -o city.png
 
-# With memory limit
-ComfyBox -p "abstract art" --cache-limit 2048 -o art.png
-
-# With single LoRA
-ComfyBox -p "a lion" --lora ostris/z_image_turbo_childrens_drawings -o lion.png
-
-# With multiple LoRAs (new in this fork)
-ComfyBox -p "a beautiful portrait" \
-  --lora style1.safetensors=0.8 \
-  --lora style2.safetensors=0.5 \
-  -o portrait.png
-
-# Generate with SVG output (new in this fork)
-ComfyBox -p "minimalist mountain logo" --svg --svg-preset logo -o logo.png
-# Creates: logo.png and logo.svg
-
-# SVG with detailed preset for complex images
-ComfyBox -p "intricate mandala pattern" --svg --svg-preset detailed -o mandala.png
-
-# Scripting without progress bars
-ComfyBox -p "batch image" --no-progress -o batch.png
-```
-
-## LoRA
-
-Apply LoRA weights for style customization.
-
-### Single LoRA
-
-```bash
-ComfyBox -p "a lion" --lora ostris/z_image_turbo_childrens_drawings --lora-scale 1.0 -o lion.png
-```
-
-### Multiple LoRAs (New in This Fork)
-
-Combine multiple LoRA styles:
-
-```bash
+# Multiple LoRAs stacked
 ComfyBox -p "a fantasy portrait" \
-  --lora ~/loras/style.safetensors=0.8 \
-  --lora ~/loras/detail.safetensors=0.6 \
+  --lora style.safetensors=0.8 \
+  --lora detail.safetensors=0.6 \
   -o combined.png
+
+# SVG logo
+ComfyBox -p "minimalist coffee cup logo, flat design" --svg --svg-preset logo -o logo.png
+
+# ControlNet with pose
+ComfyBox control -p "a woman on a beach" -c pose.jpg \
+  --cw alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \
+  --cf Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
+  -o beach.png
+
+# SeedVR2 upscale
+ComfyBox upscale -i photo.jpg -w ~/Models/seedvr2-3b -r 2048 -o photo-2x.png
+
+# Heun sampler with Karras schedule
+ComfyBox -p "detailed landscape" --scheduler heun --sigma-schedule karras -s 20 -o landscape.png
 ```
-
-- `--lora`: Repeatable. Prefer `path=scale` to bind a scale to a specific entry.
-- `--lora-paths`: Comma-separated list of LoRA file paths or HuggingFace IDs
-- `--lora-scales`: Corresponding scale factors (defaults to 1.0 if not specified)
-- `path:scale` is still accepted for backward compatibility when unambiguous
-- Quoted commas are not supported in comma-separated forms
-
-### LoRA Example
-
-<table width="100%">
-<tr>
-<th>Prompt</th>
-<th>LoRA</th>
-<th>Output</th>
-</tr>
-<tr>
-<td>a lion</td>
-<td><a href="https://huggingface.co/ostris/z_image_turbo_childrens_drawings">ostris/z_image_turbo_childrens_drawings</a></td>
-<td><img src="examples/lora_lion.png" height="256"></td>
-</tr>
-</table>
-
-## SVG Export (New in This Fork)
-
-Convert generated images to scalable vector graphics using [vtracer](https://github.com/visioncortex/vtracer).
-
-### Installation
-
-```bash
-# Requires Rust toolchain
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source $HOME/.cargo/env
-cargo install vtracer
-```
-
-### Usage
-
-```bash
-# Basic SVG generation
-ComfyBox -p "geometric pattern" --svg -o pattern.png
-# Creates: pattern.png and pattern.svg
-
-# Logo preset (best for icons, logos, flat graphics)
-ComfyBox -p "minimalist coffee cup logo, flat design, white background" \
-  --svg --svg-preset logo -o coffee_logo.png
-
-# Detailed preset (preserves complex details)
-ComfyBox -p "intricate celtic knot pattern" \
-  --svg --svg-preset detailed -o celtic.png
-```
-
-### Preset Comparison
-
-| Preset | Best For | Colors | Detail Level |
-|--------|----------|--------|--------------|
-| `default` | General purpose | Full color | Medium |
-| `logo` | Logos, icons, UI elements | Simplified | Low (clean edges) |
-| `detailed` | Illustrations, complex art | Full color | High |
-| `simplified` | Clean graphics, web icons | Reduced | Low |
-| `bw` | Silhouettes, line art | Black & white | Medium |
-
-### Tips for Best SVG Results
-
-1. **Use high contrast prompts**: Add "HIGH CONTRAST, bold colors, white background"
-2. **Avoid gradients**: Add "flat design, no gradients" to prompts
-3. **Simple shapes work best**: Vector conversion excels with clean geometric forms
-4. **Logo preset for icons**: Produces the smallest, cleanest SVG files
-
-## ControlNet
-
-Generate images with ControlNet conditioning using Canny, HED, Depth, Pose, or MLSD control images:
-
-```bash
-ComfyBox control \
-  --prompt "A hyper-realistic close-up portrait of a leopard" \
-  --control-image canny_edges.jpg \
-  --controlnet-weights alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \
-  --control-file Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
-  --control-scale 0.75 \
-  --output leopard.png
-```
-
-### ControlNet Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-p, --prompt` | Text prompt (required) | - |
-| `-c, --control-image` | Control image path (Canny/HED/Pose/Depth/MLSD) | - |
-| `-i, --inpaint-image` | Source image for inpainting | - |
-| `--mask, --mask-image` | Mask image for inpainting | - |
-| `--cw, --controlnet-weights` | ControlNet weights path or HuggingFace ID (required) | - |
-| `--cf, --control-file` | Specific .safetensors file within weights directory | - |
-| `--cs, --control-scale` | Control context scale | 0.75 |
-| `-W, --width` | Output width | 1024 |
-| `-H, --height` | Output height | 1024 |
-| `-s, --steps` | Inference steps | 9 |
-| `-g, --guidance` | Guidance scale | 0.0 |
-| `--seed` | Random seed | random |
-| `-o, --output` | Output path | z-image-control.png |
-| `-m, --model` | Model path or HuggingFace ID | Tongyi-MAI/Z-Image-Turbo |
-| `--cache-limit` | GPU memory cache limit in MB | unlimited |
-
-### ControlNet Examples
-
-| Control Type | Prompt | Control Image | Output |
-|--------------|--------|---------------|--------|
-| Canny | A hyper-realistic close-up portrait of a leopard face hiding behind dense green jungle leaves, camouflaged, direct eye contact, intricate fur detail, bright yellow eyes, cinematic lighting, soft shadows, National Geographic photography, 8k, sharp focus, depth of field | ![Canny](images/canny.jpg) | ![Canny Output](examples/canny.png) |
-| HED | A photorealistic film still of a man in a dark shirt sitting at a dining table in a modern kitchen at night, looking down at a bowl of soup. A glass bottle and a glass of white wine are in the foreground. Warm, low, cinematic lighting, soft shadows, shallow depth of field, contemplative atmosphere, highly detailed. | ![HED](images/hed.jpg) | ![HED Output](examples/hed.png) |
-| Depth | A hyperrealistic architectural photograph of a spacious, minimalist modern hallway interior. Large floor-to-ceiling windows on the right wall fill the space with bright natural daylight. A light gray sectional sofa and a low, modern coffee table are placed in the foreground on a light wood floor. A large potted plant is visible further down the hallway. White walls, clean lines, serene atmosphere, highly detailed, 8k resolution, cinematic lighting | ![Depth](images/depth.jpg) | ![Depth Output](examples/depth.png) |
-| Pose | 一位年轻女子站在阳光明媚的海岸线上，白裙在轻拂的海风中微微飘动。她拥有一头鲜艳的紫色长发，在风中轻盈舞动... | ![Pose](images/pose.jpg) | ![Pose Output](examples/pose.png) |
-
-## Example Text To Image Output
-
-| Prompt | Output |
-|--------|--------|
-| A dramatic, cinematic japanese-action scene in a edo era Kyoto city. A woman named Harley Quinn from the movie "Birds of Prey" in colorful, punk-inspired comic-villain attire walks confidently while holding the arm of a serious-looking man named John Wick played by Keanu Reeves from the fantastic film John Wick 2 in a black suit, her t-shirt says "Birds of Prey", the characters are capture in a postcard held by a hand in front of a beautiful realistic city at sunset and there is cursive writing that says "ZImage, Now in MLX" | ![Output](examples/z-image.png) |
-
-## Quantization
-
-Quantize the model to reduce memory usage:
-
-```bash
-ComfyBox quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --bits 8 --group-size 32 --verbose
-```
-
-### Performance
-
-| Model | Memory | Time (1024x1024) |
-|-------|--------|------------------|
-| BF16 | ~21 GB | ~46s |
-| 8-bit quantized | ~7.5 GB | ~44s |
-
-*Tested on Apple M2 Ultra*
 
 ## Dependencies
 
-- [mlx-swift](https://github.com/ml-explore/mlx-swift) - Apple's ML framework for Apple Silicon
-- [swift-transformers](https://github.com/huggingface/swift-transformers) - Tokenizer support
-- [swift-argument-parser](https://github.com/apple/swift-argument-parser) - CLI argument parsing
+- [mlx-swift](https://github.com/ml-explore/mlx-swift) — Apple's ML framework for Apple Silicon
+- [swift-transformers](https://github.com/huggingface/swift-transformers) — Tokenizer support
+- [swift-argument-parser](https://github.com/apple/swift-argument-parser) — CLI argument parsing
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,213 @@
+# ComfyBox Architecture
+
+> ComfyUI performance. Apple silicon native. Zero Python.
+
+ComfyBox is an LLM-enabled image generation engine for Apple Silicon. It runs Z-Image, Flux, Klein, FIBO, Chroma, and SeedVR2 models natively in Swift via MLX — no Python, no ComfyUI runtime, no node graphs. An LLM orchestrator translates user intent into generation parameters, manages models, and self-heals on failure.
+
+## Three Layers
+
+### 1. Engine (Swift/MLX)
+
+The core model runner. Loads safetensors weights, runs inference on Metal, outputs images.
+
+```
+Text Prompt → TextEncoder (Qwen) → Embeddings
+                                      ↓
+Random Noise Latents ──→ DiT Transformer (denoising loop) ──→ Refined Latents
+                              ↑                                     ↓
+                         FlowMatch Scheduler                  VAE Decoder → RGB Image
+```
+
+**Supported pipelines:**
+- **txt2img** — Text-to-image generation
+- **img2img** — Image-to-image with controllable strength
+- **ControlNet** — Canny, HED, Depth, Pose, MLSD conditioning
+- **Inpainting** — Mask-guided region replacement
+- **Upscale** — SeedVR2 (AI upscale) and ESRGAN (traditional upscale)
+- **Quantization** — 4-bit and 8-bit weight compression
+
+**Key components:**
+
+| Module | Purpose |
+|--------|---------|
+| `ZImagePipeline` | Text-to-image orchestration, LoRA application, denoising loop |
+| `ZImageControlPipeline` | ControlNet conditioning and inpainting |
+| `FlowMatchScheduler` | Flow Matching Euler scheduler with dynamic shifting |
+| `QwenTextEncoder` | Qwen-based transformer (encoder + prompt enhancement LLM) |
+| `ZImageTransformer2DModel` | Diffusion Transformer with refiner streams |
+| `AutoencoderKL` | VAE encode/decode (latent ↔ pixel space) |
+| `LoRAApplicator` | Runtime LoRA weight injection (standard, LoKr, quantized) |
+| `SeedVR2Pipeline` | 2x AI upscaling with tiled VAE for large images |
+| `BatchRunner` | Sequential multi-seed/multi-prompt batch generation |
+
+### 2. Orchestrator (LLM)
+
+The product layer. An LLM translates natural language into generation parameters, selects models and LoRAs, diagnoses failures, and retries with corrected settings.
+
+**Key concepts:**
+- **Creative Spectrum** — Deterministic (locked params) ↔ Fully Creative (AI explores). Fields marked "locked" or "AI-discretion" in the prompt JSON.
+- **JSON Prompt** — Universal structured format for any model. Contains prompt, parameters, style, LoRA config — the single source of truth for a render.
+- **Self-healing** — On failure (OOM, bad LoRA, timeout), the orchestrator diagnoses the error, adjusts parameters, and retries without user intervention.
+
+### 3. Protocol (ComfyUI Bridge)
+
+A ComfyUI-compatible API on port 7870. Any ComfyUI client (Krita AI Diffusion, custom UIs) connects without modification.
+
+```
+Krita AI Diffusion → HTTP :7870 → ComfyUI Bridge → WarmServer → Engine
+```
+
+**Emulated endpoints:**
+- `GET /object_info` — Node registry (emulated)
+- `POST /prompt` — Submit generation workflow
+- `GET /ws` — WebSocket progress notifications
+- `GET /view` — Retrieve generated images
+
+> The bridge emulates the ComfyUI protocol only — zero actual ComfyUI runtime.
+
+## Runtime Architecture
+
+### WarmServer (HTTP API)
+
+The WarmServer keeps models loaded in GPU memory between requests. Cold start loads the model once; subsequent renders skip loading entirely.
+
+```bash
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862 --host 0.0.0.0
+```
+
+**Endpoints:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/generate` | POST | Submit render (txt2img or img2img) |
+| `/v1/lora/swap` | POST | Hot-swap LoRA weights without restart |
+| `/health` | GET | Server status, loaded model, memory |
+| `/v1/shutdown` | POST | Graceful shutdown |
+
+**Key features:**
+- Warm model pool — multiple models loaded simultaneously
+- Hot LoRA swap — change styles without model reload (~2s vs ~30s)
+- Request queue — sequential GPU access prevents OOM
+- Allowed output directory — sandboxed file writes
+
+### Model Pool
+
+Multiple models can be loaded simultaneously and switched instantly:
+
+```
+load_model("z-image-turbo-bf16")     # Load Z-Image (~7GB)
+load_model("klein-9b-q8")            # Load Klein (~12GB)
+switch_model("klein-9b-q8")          # Instant switch, no reload
+unload_model("z-image-turbo-bf16")   # Free VRAM
+```
+
+The pool tracks VRAM usage per model and last-used timestamps for eviction decisions.
+
+### MCP Server (Model Context Protocol)
+
+Bridges the WarmServer to AI assistants via JSON-RPC 2.0 over stdio:
+
+```bash
+ComfyBox mcp --port 7862
+```
+
+18 tools exposed — see [MCP Tool Reference](mcp-reference.md) for full details.
+
+**Remote access via SSH:**
+```bash
+ssh user@mac-host "cd /path/to/comfybox && .build/release/ComfyBox mcp --port 7862"
+```
+
+The daemon spawns this as a child process, reads JSON-RPC from stdout, writes to stdin. All 18 tools appear as `mcp_comfybox__<tool_name>` in the daemon's tool registry.
+
+### ComfyUI Bridge
+
+Translates ComfyUI workflow JSON into native WarmServer API calls:
+
+```
+Krita sends ComfyUI workflow → Bridge parses nodes → Maps to /v1/generate params → Returns result
+```
+
+Runs alongside the WarmServer on port 7870. Shares the same warm model — no duplicate loading.
+
+## Supported Models
+
+| Family | Models | Steps | Guidance | Notes |
+|--------|--------|-------|----------|-------|
+| **Z-Image** | Turbo (distilled), Base (CFG) | 4-9 / 20-50 | 0.0 / 3.5-7.0 | Default. Fastest distilled model |
+| **Flux 2 Klein** | 9B, 9B-q4, 9B-q8 | 20-50 | 3.5+ | High quality, CFG-guided |
+| **FIBO** | 8B, 8B-q4 | 20+ | 3.5+ | JSON-structured prompts, CC-BY-NC-4.0 |
+| **Chroma** | 8.9B | 20+ | N/A | Guidance-free architecture |
+| **SeedVR2** | 3B, 7B | 1 | N/A | AI upscaling only (2x) |
+
+## Memory Footprint
+
+| Model | Precision | Approx. VRAM |
+|-------|-----------|-------------|
+| Z-Image Turbo | BF16 | ~7 GB |
+| Z-Image Turbo | 8-bit | ~4 GB |
+| Klein 9B | BF16 | ~21 GB |
+| Klein 9B | 8-bit | ~12 GB |
+| FIBO 8B | 4-bit | ~8 GB |
+| SeedVR2 3B | BF16 | ~7 GB |
+| SeedVR2 7B | BF16 | ~16 GB |
+
+Multiple models can coexist. Example: Z-Image Turbo 8-bit (~4GB) + SeedVR2 3B (~7GB) = ~11GB total.
+
+## File Layout
+
+```
+Sources/
+├── ComfyBox/              # CLI entry point
+│   └── main.swift         # Argument parsing, subcommand dispatch
+├── ZImage/
+│   ├── Pipeline/          # Generation pipelines
+│   │   ├── ZImagePipeline.swift
+│   │   ├── ZImageControlPipeline.swift
+│   │   ├── SeedVR2Pipeline.swift
+│   │   ├── BatchRunner.swift
+│   │   └── FlowMatchScheduler.swift
+│   ├── Model/             # Neural network layers
+│   │   ├── TextEncoder/
+│   │   ├── Transformer/
+│   │   └── VAE/
+│   ├── Server/            # HTTP server mode
+│   │   ├── WarmServer.swift
+│   │   └── ModelPool.swift
+│   ├── MCP/               # Model Context Protocol
+│   │   ├── MCPServer.swift
+│   │   ├── MCPToolRegistry.swift
+│   │   ├── MCPToolExecutor.swift
+│   │   └── WarmServerClient.swift
+│   ├── Bridge/            # ComfyUI protocol bridge
+│   ├── LoRA/              # LoRA weight management
+│   ├── Weights/           # Model downloading and loading
+│   └── Quantization/      # 4-bit and 8-bit compression
+Tests/
+├── ZImageTests/           # Unit tests
+├── ZImageIntegrationTests/# Tests requiring model weights
+└── ZImageE2ETests/        # End-to-end CLI tests
+```
+
+## Build
+
+```bash
+# Release build (recommended)
+xcodebuild -scheme ComfyBox -configuration Release \
+  -destination 'platform=macOS' -derivedDataPath .build/xcode
+
+# Tests
+xcodebuild test -scheme comfybox-Package \
+  -destination 'platform=macOS' -enableCodeCoverage NO
+
+# The binary + Metal library end up in:
+# .build/xcode/Build/Products/Release/ComfyBox
+# .build/xcode/Build/Products/Release/mlx.metallib
+```
+
+## Requirements
+
+- macOS 14.0+ (Sonoma)
+- Apple Silicon (M1/M2/M3/M4)
+- Swift 5.9+
+- ~6-21 GB VRAM depending on model

--- a/docs/bridge-developer-guide.md
+++ b/docs/bridge-developer-guide.md
@@ -1,0 +1,437 @@
+# ComfyBox Bridge Developer Guide
+
+Build integrations that connect any application to ComfyBox's image generation engine.
+
+## Overview
+
+ComfyBox exposes a **ComfyUI-compatible HTTP API** (the "bridge") that any application can connect to. If your app can speak HTTP, it can generate images through ComfyBox.
+
+Three integration paths, from easiest to most powerful:
+
+| Path | Effort | Best For |
+|------|--------|----------|
+| **REST API** | Hours | Scripts, bots, simple tools |
+| **ComfyUI Protocol** | Days | Apps with existing ComfyUI support (Krita, etc.) |
+| **MCP (Model Context Protocol)** | Days | AI assistants, LLM-powered tools |
+
+## Architecture
+
+```
+┌─────────────────────────────┐
+│  Your Application           │
+│  (Krita, Inkscape, custom)  │
+└──────────┬──────────────────┘
+           │ HTTP / WebSocket
+┌──────────▼──────────────────┐
+│  ComfyBox Bridge (:7870)    │  ← ComfyUI-compatible protocol
+│  ComfyBox REST API (:7862)  │  ← Native REST API
+└──────────┬──────────────────┘
+           │
+┌──────────▼──────────────────┐
+│  MLX Engine (Metal GPU)     │
+│  Models, LoRAs, VAE         │
+└─────────────────────────────┘
+```
+
+## Path 1: REST API (Simplest)
+
+The WarmServer exposes a clean REST API on port 7862.
+
+### Generate an Image
+
+```bash
+curl -X POST http://localhost:7862/v1/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "A mountain landscape at sunset",
+    "width": 1024,
+    "height": 1024,
+    "steps": 9,
+    "seed": 42,
+    "output_path": "/tmp/landscape.png"
+  }'
+```
+
+**Response:**
+```json
+{
+  "output_path": "/tmp/landscape.png",
+  "duration_seconds": 12.3,
+  "seed": 42
+}
+```
+
+### Img2img
+
+```bash
+curl -X POST http://localhost:7862/v1/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Oil painting style",
+    "image_path": "/path/to/source.jpg",
+    "image_strength": 0.5,
+    "steps": 9
+  }'
+```
+
+### Hot-Swap LoRAs
+
+```bash
+curl -X POST http://localhost:7862/v1/lora/swap \
+  -H "Content-Type: application/json" \
+  -d '{
+    "loras": [
+      {"path": "/path/to/style.safetensors", "scale": 0.8}
+    ]
+  }'
+```
+
+### Health Check
+
+```bash
+curl http://localhost:7862/health
+```
+
+Returns: loaded model, VRAM usage, active LoRAs, render queue depth.
+
+### Shutdown
+
+```bash
+curl -X POST http://localhost:7862/v1/shutdown \
+  -H "Content-Type: application/json" \
+  -d '{"confirm": true}'
+```
+
+## Path 2: ComfyUI Protocol (For Existing ComfyUI Clients)
+
+ComfyBox emulates the ComfyUI API on port 7870. Applications that already support ComfyUI (like Krita AI Diffusion) connect without modification.
+
+### Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/object_info` | GET | Node type registry (emulated) |
+| `/prompt` | POST | Submit a generation workflow |
+| `/queue` | GET | Queue status |
+| `/view` | GET | Retrieve generated images |
+| `/ws` | WebSocket | Real-time progress notifications |
+
+### Workflow Format
+
+ComfyUI clients send workflow JSON — a graph of nodes. ComfyBox parses the graph and extracts generation parameters:
+
+```json
+{
+  "prompt": {
+    "1": {
+      "class_type": "KSampler",
+      "inputs": {
+        "seed": 42,
+        "steps": 9,
+        "cfg": 0.0,
+        "sampler_name": "euler",
+        "scheduler": "normal",
+        "denoise": 1.0,
+        "model": ["2", 0],
+        "positive": ["3", 0],
+        "negative": ["4", 0],
+        "latent_image": ["5", 0]
+      }
+    },
+    "2": {
+      "class_type": "CheckpointLoaderSimple",
+      "inputs": {
+        "ckpt_name": "z-image-turbo-bf16"
+      }
+    },
+    "3": {
+      "class_type": "CLIPTextEncode",
+      "inputs": {
+        "text": "A mountain landscape at sunset",
+        "clip": ["2", 1]
+      }
+    }
+  }
+}
+```
+
+The bridge walks the node graph, resolves references, and maps to a native `/v1/generate` call.
+
+### WebSocket Progress
+
+Connect to `ws://localhost:7870/ws` for real-time updates:
+
+```json
+{"type": "status", "data": {"status": {"exec_info": {"queue_remaining": 1}}}}
+{"type": "progress", "data": {"value": 3, "max": 9}}
+{"type": "progress", "data": {"value": 9, "max": 9}}
+{"type": "executed", "data": {"node": "1", "output": {"images": [{"filename": "output.png"}]}}}
+```
+
+### Supported Node Types
+
+The bridge recognizes these ComfyUI node types:
+
+| Node | Maps To |
+|------|---------|
+| `KSampler` | Sampler, steps, CFG, scheduler |
+| `CheckpointLoaderSimple` | Model selection |
+| `CLIPTextEncode` | Prompt text |
+| `EmptyLatentImage` | Width, height |
+| `VAEDecode` | (implicit — always runs) |
+| `SaveImage` | Output path |
+| `LoadImage` | Img2img source |
+| `LoraLoader` | LoRA path and scale |
+| `ImageUpscaleWithModel` | SeedVR2/ESRGAN upscale |
+
+Unsupported nodes are silently ignored — the bridge extracts what it can and generates with those parameters.
+
+## Path 3: MCP (For AI Assistants)
+
+The Model Context Protocol exposes 18 tools via JSON-RPC 2.0 over stdio. See [MCP Tool Reference](mcp-reference.md) for the complete tool catalog.
+
+```bash
+# Register with Claude Code
+claude mcp add comfybox -- ComfyBox mcp --port 7862
+
+# Register with any MCP-compatible client
+ComfyBox mcp --port 7862
+# Reads JSON-RPC from stdin, writes to stdout
+```
+
+### Example JSON-RPC Call
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
+  "name": "generate_image",
+  "arguments": {
+    "prompt": "A portrait in renaissance style",
+    "width": 768,
+    "height": 1152,
+    "seed": 42
+  }
+}}
+```
+
+## Writing a New Conduit
+
+A "conduit" is an integration that bridges your application to ComfyBox. Here's the pattern:
+
+### Step 1: Choose Your API
+
+- **REST API** if you're starting from scratch
+- **ComfyUI Protocol** if your app already has ComfyUI support
+- **MCP** if your app is an AI assistant
+
+### Step 2: Discover Capabilities
+
+```bash
+# What model is loaded?
+curl http://localhost:7862/health
+
+# What LoRAs are available?
+# (via MCP: list_loras tool)
+
+# What models are supported?
+# (via MCP: list_models tool)
+```
+
+### Step 3: Generate
+
+```python
+import requests
+import json
+
+COMFYBOX_URL = "http://localhost:7862"
+
+def generate(prompt, width=1024, height=1024, steps=9, seed=None):
+    """Generate an image via ComfyBox REST API."""
+    payload = {
+        "prompt": prompt,
+        "width": width,
+        "height": height,
+        "steps": steps,
+    }
+    if seed is not None:
+        payload["seed"] = seed
+    
+    response = requests.post(f"{COMFYBOX_URL}/v1/generate", json=payload)
+    response.raise_for_status()
+    return response.json()
+
+# Text-to-image
+result = generate("A cat sitting on a windowsill", seed=42)
+print(f"Image saved to: {result['output_path']}")
+
+# Img2img
+result = requests.post(f"{COMFYBOX_URL}/v1/generate", json={
+    "prompt": "Oil painting style",
+    "image_path": "/path/to/photo.jpg",
+    "image_strength": 0.5,
+}).json()
+```
+
+### Step 4: Handle Progress (Optional)
+
+For long-running renders, connect to the WebSocket for progress:
+
+```python
+import websocket
+import json
+
+def on_message(ws, message):
+    data = json.loads(message)
+    if data["type"] == "progress":
+        step = data["data"]["value"]
+        total = data["data"]["max"]
+        print(f"Step {step}/{total}")
+    elif data["type"] == "executed":
+        print("Done!")
+        ws.close()
+
+ws = websocket.WebSocketApp("ws://localhost:7870/ws",
+                            on_message=on_message)
+ws.run_forever()
+```
+
+### Step 5: Manage LoRAs (Optional)
+
+```python
+def swap_loras(loras):
+    """Hot-swap LoRA weights."""
+    requests.post(f"{COMFYBOX_URL}/v1/lora/swap", json={
+        "loras": [{"path": path, "scale": scale} for path, scale in loras]
+    })
+
+# Apply a style LoRA
+swap_loras([("/path/to/watercolor.safetensors", 0.8)])
+
+# Remove all LoRAs
+swap_loras([])
+```
+
+## Swift Conduit Example
+
+For macOS/iOS apps using Swift:
+
+```swift
+import Foundation
+
+struct ComfyBoxClient {
+    let baseURL: URL
+    
+    init(host: String = "localhost", port: Int = 7862) {
+        self.baseURL = URL(string: "http://\(host):\(port)")!
+    }
+    
+    func generate(prompt: String, width: Int = 1024, height: Int = 1024,
+                  steps: Int = 9, seed: Int? = nil) async throws -> GenerateResult {
+        var body: [String: Any] = [
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "steps": steps,
+        ]
+        if let seed { body["seed"] = seed }
+        
+        var request = URLRequest(url: baseURL.appendingPathComponent("/v1/generate"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode(GenerateResult.self, from: data)
+    }
+    
+    func health() async throws -> HealthStatus {
+        let (data, _) = try await URLSession.shared.data(from: baseURL.appendingPathComponent("/health"))
+        return try JSONDecoder().decode(HealthStatus.self, from: data)
+    }
+}
+
+struct GenerateResult: Codable {
+    let outputPath: String
+    let durationSeconds: Double
+    let seed: Int
+}
+
+struct HealthStatus: Codable {
+    let model: String
+    let status: String
+}
+```
+
+## Network Configuration
+
+### Local (Same Machine)
+
+Default setup — app and ComfyBox on the same Mac:
+
+```
+App → http://localhost:7862 (REST)
+App → ws://localhost:7870/ws (ComfyUI WebSocket)
+```
+
+### Remote (Different Machine)
+
+ComfyBox on a Mac, your app elsewhere on the network:
+
+```bash
+# Start WarmServer bound to all interfaces
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862 --host 0.0.0.0
+```
+
+```
+App → http://mac-ip:7862 (REST)
+App → ws://mac-ip:7870/ws (ComfyUI WebSocket)
+```
+
+### SSH Tunnel (Secure Remote)
+
+For remote access without exposing ports:
+
+```bash
+ssh -L 7862:localhost:7862 -L 7870:localhost:7870 user@mac-host
+```
+
+Then connect to `localhost:7862` / `localhost:7870` as if local.
+
+## Error Handling
+
+All endpoints return standard HTTP status codes:
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Bad request (invalid parameters) |
+| 404 | Endpoint not found |
+| 500 | Server error (model crash, OOM) |
+| 503 | Server busy (queue full) |
+
+Error response body:
+```json
+{
+  "error": "Output path not within allowed directory",
+  "code": "INVALID_OUTPUT_PATH"
+}
+```
+
+## Performance Tips
+
+- **Keep the server warm** — first render loads the model (~30s), subsequent renders are fast (~10-15s for 1024x1024)
+- **Reuse connections** — HTTP keep-alive reduces overhead
+- **Batch with seeds** — generate variations by changing only the seed
+- **Hot-swap LoRAs** instead of restarting (~2s vs ~30s)
+- **Never run concurrent GPU renders** — queue them sequentially
+- **Use quantized models** on memory-constrained devices (8-bit: ~4GB vs ~7GB for BF16)
+
+## Existing Conduits
+
+| Conduit | Status | Integration Path |
+|---------|--------|-----------------|
+| Krita AI Diffusion | Working | ComfyUI Protocol |
+| coffeeshop.app | Planned | REST API + WebSocket |
+| Inkscape | Planned | REST API |
+| Telegram ImageBot | Working | MCP via daemon |
+| SDK (Python) | This guide | REST API |
+| SDK (Swift) | This guide | REST API |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,272 @@
+# ComfyBox Deployment Guide
+
+How to run ComfyBox as a persistent service — warm server, keepalive, remote access, and integration with the CoffeeShop daemon.
+
+## Serve Mode
+
+ComfyBox can run as a warm HTTP server that keeps the model loaded in GPU memory:
+
+```bash
+ComfyBox serve \
+  -m Tongyi-MAI/Z-Image-Turbo \
+  --port 7862 \
+  --host 0.0.0.0 \
+  --allowed-output-directory ~/renders
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--model, -m` | Z-Image-Turbo | Model to load on startup |
+| `--port` | 7862 | HTTP port to bind |
+| `--host` | 127.0.0.1 | Interface to bind (0.0.0.0 for network access) |
+| `--allowed-output-directory` | current dir | Sandboxed output path |
+| `--cache-limit` | unlimited | GPU memory cache limit in MB |
+| `--text-encoder-path` | auto-detect | Override text encoder directory |
+| `--lora` | none | Pre-load LoRA weights (repeatable) |
+
+### Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/generate` | POST | Submit a render (txt2img or img2img) |
+| `/v1/lora/swap` | POST | Hot-swap LoRA weights |
+| `/health` | GET | Server health and loaded model info |
+| `/v1/shutdown` | POST | Graceful shutdown |
+
+### Health Check
+
+```bash
+curl http://localhost:7862/health
+```
+
+Returns loaded model, VRAM usage, active LoRAs, render statistics, and queue depth.
+
+## Keepalive with Screen
+
+For production use, wrap the server in a keepalive script that auto-restarts on crashes:
+
+### Keepalive Script
+
+Save as `~/bin/comfybox-keepalive.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMFYBOX="$HOME/Projects/zimage.swift/.build/release/ComfyBox"
+MODEL="Tongyi-MAI/Z-Image-Turbo"
+ENCODER="$HOME/Models/z-image-turbo-bf16/text_encoder QWen Large"
+PORT=7862
+OUTPUT_DIR="$HOME/renders"
+
+CRASH_COUNT=0
+MAX_CRASHES=5
+WINDOW_START=$(date +%s)
+WINDOW_SECS=600  # 10 minute sliding window
+
+# Reset crash counter on SIGHUP
+trap 'CRASH_COUNT=0; WINDOW_START=$(date +%s); echo "[keepalive] Reset crash counter"' HUP
+
+while true; do
+    echo "[keepalive] Starting ComfyBox serve on :${PORT}..."
+    
+    "$COMFYBOX" serve \
+        -m "$MODEL" \
+        --text-encoder-path "$ENCODER" \
+        --port "$PORT" \
+        --host 0.0.0.0 \
+        --allowed-output-directory "$OUTPUT_DIR" \
+    || EXIT_CODE=$?
+    
+    # Clean exit — don't restart
+    if [ "${EXIT_CODE:-0}" -eq 0 ]; then
+        echo "[keepalive] Clean exit. Done."
+        break
+    fi
+    
+    # Crash — check circuit breaker
+    NOW=$(date +%s)
+    ELAPSED=$(( NOW - WINDOW_START ))
+    
+    if [ "$ELAPSED" -gt "$WINDOW_SECS" ]; then
+        # Reset window
+        CRASH_COUNT=1
+        WINDOW_START=$NOW
+    else
+        CRASH_COUNT=$(( CRASH_COUNT + 1 ))
+    fi
+    
+    if [ "$CRASH_COUNT" -ge "$MAX_CRASHES" ]; then
+        echo "[keepalive] CIRCUIT BREAKER: $MAX_CRASHES crashes in ${WINDOW_SECS}s. Giving up."
+        exit 1
+    fi
+    
+    echo "[keepalive] Crash #${CRASH_COUNT}/${MAX_CRASHES}. Restarting in 3s..."
+    sleep 3
+done
+```
+
+### Running in Screen
+
+```bash
+# Start keepalive in a detached screen session
+screen -dmS warmserver ~/bin/comfybox-keepalive.sh
+
+# Attach to see logs
+screen -r warmserver
+
+# Detach: Ctrl+A, then D
+
+# Check if running
+screen -ls | grep warmserver
+
+# Reset crash counter (without restarting)
+screen -S warmserver -X stuff $'\x01'  # Send SIGHUP
+```
+
+### Why Not launchd?
+
+launchd is macOS's native service manager, but ComfyBox's GPU initialization can deadlock under launchd's sandbox. Symptoms: binary spawns at 15MB RSS, 0% CPU, never progresses past Metal device init.
+
+**Workaround:** Use screen-based keepalive instead. The screen approach:
+- Auto-restarts on crashes (up to 5 in 10 minutes)
+- Survives terminal disconnect
+- Logs are visible via `screen -r`
+- Clean exit (code 0) does not restart
+- SIGHUP resets crash counter
+
+## ComfyUI Bridge
+
+Run the ComfyUI-compatible bridge alongside the WarmServer:
+
+```bash
+# WarmServer on 7862, Bridge on 7870
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862 &
+# Bridge connects to WarmServer and exposes ComfyUI protocol
+# (Bridge is built into the serve command on port 7870)
+```
+
+The bridge translates ComfyUI workflow JSON into native WarmServer API calls. Krita AI Diffusion, Lingdong, or any ComfyUI client connects to port 7870.
+
+## MCP Server
+
+Run the MCP server alongside a WarmServer for AI assistant integration:
+
+```bash
+# Start WarmServer first
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862
+
+# Then run MCP server pointing to it
+ComfyBox mcp --port 7862
+```
+
+The MCP server reads JSON-RPC from stdin and writes to stdout. It bridges to the WarmServer via HTTP. See [MCP Tool Reference](mcp-reference.md) for the 18 available tools.
+
+### Remote MCP via SSH
+
+For a daemon on a remote server that needs to control a Mac's GPU:
+
+```bash
+# The daemon spawns this as a child process:
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+  user@mac-host \
+  "cd /path/to/comfybox && .build/release/ComfyBox mcp --port 7862"
+```
+
+**Daemon configuration** (`~/.bree/config.json`):
+```json
+{
+  "mcp": {
+    "servers": [
+      {
+        "id": "comfybox",
+        "name": "ComfyBox",
+        "command": "ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 user@mac \"cd /path/to/comfybox && .build/release/ComfyBox mcp --port 7862\"",
+        "enabled": true,
+        "toolTimeoutMs": 300000
+      }
+    ]
+  }
+}
+```
+
+**Important:** Set `toolTimeoutMs` to at least 300000 (5 minutes) for GPU render servers. The default 60s timeout will kill renders mid-generation.
+
+### Auto-Reconnect
+
+The daemon's MCP manager automatically reconnects when the SSH connection drops:
+- Exponential backoff: 5s → 10s → 20s → ... → 5min cap
+- Maximum 10 reconnect attempts before giving up
+- Tools are automatically re-registered on reconnect
+- All pending requests are rejected on disconnect
+
+## Network Topology
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Linux Server (10.0.100.232)                        │
+│                                                     │
+│  ┌──────────────────────────────────┐               │
+│  │ Bree Daemon (:3777)             │               │
+│  │  ├─ MCP Manager                 │               │
+│  │  │   └─ McpClient (SSH child)  ─┼── SSH ──┐    │
+│  │  ├─ Tool Executor               │          │    │
+│  │  └─ Image Service (:7861)       │          │    │
+│  └──────────────────────────────────┘          │    │
+└────────────────────────────────────────────────┼────┘
+                                                 │
+┌────────────────────────────────────────────────┼────┐
+│  Mac (10.0.100.134, M3 Max 128GB)              │    │
+│                                                │    │
+│  ┌──────────────────┐    ┌─────────────────┐   │    │
+│  │ ComfyBox MCP     │◀───│ SSH connection  │◀──┘    │
+│  │ (stdio JSON-RPC) │    └─────────────────┘        │
+│  └────────┬─────────┘                               │
+│           │ HTTP                                     │
+│  ┌────────▼─────────┐    ┌─────────────────┐        │
+│  │ WarmServer       │    │ ComfyUI Bridge  │        │
+│  │ (:7862)          │    │ (:7870)         │        │
+│  └────────┬─────────┘    └────────┬────────┘        │
+│           │                       │                  │
+│  ┌────────▼───────────────────────▼────────┐        │
+│  │ MLX Engine (Metal GPU)                   │        │
+│  │  ├─ Z-Image Turbo (~7 GB)               │        │
+│  │  ├─ SeedVR2 3B (~7 GB)                  │        │
+│  │  └─ LoRA weights                         │        │
+│  └──────────────────────────────────────────┘        │
+└──────────────────────────────────────────────────────┘
+```
+
+## Monitoring
+
+### Server Health
+
+```bash
+# Quick check
+curl -s http://mac:7862/health | python3 -m json.tool
+
+# Via MCP (from daemon)
+# Tool: mcp_comfybox__server_health
+
+# System stats
+# Tool: mcp_comfybox__system_stats
+```
+
+### Logs
+
+- **WarmServer:** stdout of the screen session (`screen -r warmserver`)
+- **MCP Server:** stderr of the SSH child process (daemon captures this)
+- **Daemon MCP:** `journalctl --user -u bree-channels -f | grep mcp`
+
+### Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Render timeout at 60s | Default tool timeout too low | Set `toolTimeoutMs: 300000` in MCP config |
+| SSH connection drops | Network instability | Auto-reconnect handles this; check `screen -ls` on Mac |
+| Model fails to load | Insufficient VRAM | Use quantized model or unload other models |
+| WarmServer crashes repeatedly | Circuit breaker trips | Check `screen -r warmserver` logs, fix root cause |
+| Port 7862 in use | Previous instance didn't clean up | `lsof -ti:7862 | xargs kill` |
+| Metal library not found | Build artifact missing | Rebuild with xcodebuild, copy `mlx.metallib` next to binary |

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -1,0 +1,257 @@
+# ComfyBox MCP Tool Reference
+
+ComfyBox exposes 18 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). These tools let AI assistants generate images, manage models, swap LoRAs, and monitor server health — all through a standardized JSON-RPC 2.0 interface.
+
+## Setup
+
+### Local
+
+```bash
+ComfyBox mcp --port 7862
+```
+
+Reads JSON-RPC requests from stdin, writes responses to stdout. All logging goes to stderr. Runs until stdin closes.
+
+### Claude Code Registration
+
+```bash
+claude mcp add comfybox -- ComfyBox mcp --port 7862
+```
+
+### Remote (SSH Bridge)
+
+For servers managed by a remote daemon:
+
+```bash
+ssh user@mac-host "cd /path/to/comfybox && .build/release/ComfyBox mcp --port 7862"
+```
+
+The daemon spawns this command as a child process. Tools are registered as `mcp_comfybox__<tool_name>`.
+
+## Tools
+
+### Generation
+
+#### `generate_image`
+
+Generate an image from a text prompt. Supports text-to-image and img2img modes.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `prompt` | string | **Yes** | Text prompt describing the desired image |
+| `negative_prompt` | string | No | Concepts to avoid (non-distilled models only) |
+| `width` | integer | No | Width in pixels, divisible by 16 (default: 1024) |
+| `height` | integer | No | Height in pixels, divisible by 16 (default: 1024) |
+| `steps` | integer | No | Denoising steps. Distilled: 4-9, Base: 20-50 |
+| `guidance` | number | No | CFG scale. 0.0 for distilled, 3.5-7.0 for base |
+| `seed` | integer | No | Random seed for reproducibility |
+| `output_path` | string | No | Output file path (must be in allowed directory) |
+| `scheduler` | string | No | Sampler: euler, heun, res_2s, ddim, dpmpp_2m |
+| `sigma_schedule` | string | No | Schedule: flow, beta, beta57, linear |
+| `image_path` | string | No | Source image for img2img mode |
+| `image_strength` | number | No | Img2img strength 0.0-1.0 (default: 0.7) |
+
+**Returns:** Output file path and render duration.
+
+**Example:**
+```json
+{
+  "prompt": "A red rose in a field of daisies, golden hour lighting",
+  "width": 1024,
+  "height": 1024,
+  "steps": 9,
+  "seed": 42
+}
+```
+
+**Img2img example:**
+```json
+{
+  "prompt": "Oil painting style, vibrant colors",
+  "image_path": "/path/to/source.jpg",
+  "image_strength": 0.5,
+  "steps": 9
+}
+```
+
+---
+
+### LoRA Management
+
+#### `swap_loras`
+
+Hot-swap active LoRA weights on the loaded model. Replaces all currently active LoRAs. Pass an empty array to remove all.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `loras` | array | **Yes** | Array of LoRA configurations |
+| `loras[].path` | string | **Yes** | Path to .safetensors, or HuggingFace ID. Bare filenames resolve to `~/bin/zimage/loras/` |
+| `loras[].scale` | number | No | Weight scale 0.0-2.0 (default: 1.0) |
+
+**Example:**
+```json
+{
+  "loras": [
+    {"path": "/Users/me/loras/style.safetensors", "scale": 0.8},
+    {"path": "ostris/z_image_turbo_childrens_drawings", "scale": 1.0}
+  ]
+}
+```
+
+> **Important:** Use full absolute paths for local files. Bare filenames (e.g., `"nudeart6-e10.safetensors"`) resolve to `~/bin/zimage/loras/`.
+
+#### `list_loras`
+
+List LoRA files in the LoRA directory (`~/bin/zimage/loras/`). Returns filenames that can be passed to `swap_loras`.
+
+*No parameters.*
+
+#### `lora_library`
+
+List all LoRAs in the library with compatibility info.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `model` | string | No | Filter by model family (e.g., "z-image", "klein-9b") |
+| `include_quarantined` | boolean | No | Include quarantined LoRAs (default: false) |
+
+#### `lora_scan`
+
+Scan the LoRA directory for new or changed files and update the library index.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `force` | boolean | No | Force full rescan of all files (default: false) |
+
+#### `lora_quarantine`
+
+Quarantine or un-quarantine a LoRA. Quarantined LoRAs are hidden from model loading.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | **Yes** | LoRA identifier from the library |
+| `quarantine` | boolean | **Yes** | true to quarantine, false to restore |
+| `reason` | string | No | Reason for quarantine action |
+
+---
+
+### Model Management
+
+#### `load_model`
+
+Load a model into the pool. Supports all families: Z-Image, Klein, FIBO, Chroma, SeedVR2.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `model` | string | **Yes** | Model spec (e.g., "z-image-turbo-bf16", "klein-9b-q8", "briaai/FIBO") |
+| `quantization` | string | No | Quantization level ("4bit", "8bit"). Omit for bf16 |
+| `activate` | boolean | No | Activate after loading (default: true) |
+| `wait` | boolean | No | Wait for load to complete (default: true) |
+
+#### `switch_model`
+
+Switch the active model to one already loaded in the pool. Instant — no loading required.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `model` | string | **Yes** | Pool model ID to activate (from `model_pool` results) |
+
+#### `model_pool`
+
+List all models currently loaded in the pool with VRAM usage, active status, and last-used timestamps.
+
+*No parameters.*
+
+#### `unload_model`
+
+Unload a model from the pool to free VRAM. Cannot unload the active model — switch first.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `model` | string | **Yes** | Pool model ID to unload |
+
+#### `list_models`
+
+List all supported model families with capabilities, recommended parameters, and HuggingFace IDs.
+
+*No parameters.*
+
+---
+
+### Styles
+
+#### `list_styles`
+
+List available style presets with prompt templates, parameters, and model pairings.
+
+*No parameters.*
+
+#### `apply_style`
+
+Apply a style preset to a prompt. Returns enhanced prompt, negative prompt, and recommended generation parameters. Does not generate — use `generate_image` with the returned values.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `style_id` | string | **Yes** | Style preset ID (from `list_styles`) |
+| `prompt` | string | **Yes** | Base prompt to enhance |
+| `negative_prompt` | string | No | Negative prompt to merge with style's negative |
+
+---
+
+### Server Control
+
+#### `server_health`
+
+Get server health: loaded model, LoRA state, memory usage, render stats, queue depth.
+
+*No parameters.*
+
+#### `queue_status`
+
+Get current generation queue: pending jobs, running job, and history.
+
+*No parameters.*
+
+#### `clear_queue`
+
+Cancel all pending generation jobs. Does not affect the currently running job.
+
+*No parameters.*
+
+#### `system_stats`
+
+Get hardware info: Apple Silicon device name, total memory, available VRAM.
+
+*No parameters.*
+
+#### `shutdown_server`
+
+Gracefully shut down the WarmServer. In-flight renders complete before exit.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `confirm` | boolean | **Yes** | Must be true (safety guard) |
+
+> **Warning:** Requires manual restart. Use sparingly.
+
+## Timeout Configuration
+
+GPU renders can take 30-300+ seconds depending on model and resolution. When bridging through a daemon, configure timeouts at both layers:
+
+1. **MCP client timeout** — The inner `tools/call` JSON-RPC timeout (default: 60s)
+2. **Tool executor timeout** — The daemon's outer tool timeout guard (default: 60s)
+
+For GPU-heavy servers, set `toolTimeoutMs: 300000` (5 minutes) in the daemon's MCP server config. This propagates to both timeout layers.
+
+## Error Handling
+
+Tool calls return standard MCP results:
+
+- **Success:** `{"content": [{"type": "text", "text": "..."}]}`
+- **Error:** `{"content": [{"type": "text", "text": "error message"}], "isError": true}`
+
+Common errors:
+- `Model not found` — LoRA path doesn't exist (use absolute paths)
+- `Output path not allowed` — File outside the server's allowed directory
+- `No model loaded` — WarmServer started without a model, or model failed to load
+- `VRAM exhausted` — Reduce resolution, use quantized model, or unload unused models

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,393 @@
+# ComfyBox User Guide
+
+## Quick Start
+
+```bash
+# Generate an image
+ComfyBox -p "A mountain landscape at sunset" -o landscape.png
+
+# Generate with a specific seed (reproducible)
+ComfyBox -p "A portrait of a woman" --seed 42 -o portrait.png
+
+# Run as a warm server (keeps model loaded between requests)
+ComfyBox serve -m Tongyi-MAI/Z-Image-Turbo --port 7862
+```
+
+## Installation
+
+### Pre-built Binary
+
+```bash
+curl -LO https://github.com/BarkadaBrew/comfybox/releases/download/latest/ComfyBox-macos-arm64.tar.gz
+tar -xzf ComfyBox-macos-arm64.tar.gz
+cd ComfyBox
+sudo ./install.sh
+```
+
+Installs to `/usr/local/lib/comfybox/ComfyBox` with a wrapper at `/usr/local/bin/ComfyBox`.
+
+### Build from Source
+
+```bash
+git clone https://github.com/BarkadaBrew/comfybox.git
+cd comfybox
+xcodebuild -scheme ComfyBox -configuration Release \
+  -destination 'platform=macOS' -derivedDataPath .build/xcode
+```
+
+Binary and Metal library appear in `.build/xcode/Build/Products/Release/`.
+
+### Requirements
+
+- macOS 14.0+ (Sonoma or later)
+- Apple Silicon (M1, M2, M3, M4)
+- ~6 GB disk for base model (auto-downloaded on first run)
+- Swift 5.9+ (build from source only)
+
+## Text-to-Image
+
+### Basic Generation
+
+```bash
+ComfyBox -p "A beautiful mountain landscape at sunset" -o output.png
+```
+
+### Resolution
+
+Width and height must be divisible by 16:
+
+```bash
+# Landscape (16:9)
+ComfyBox -p "panoramic desert" -W 1920 -H 1080 -o desert.png
+
+# Portrait (2:3)
+ComfyBox -p "portrait of a woman" -W 768 -H 1152 -o portrait.png
+
+# Square (1:1)
+ComfyBox -p "abstract art" -W 1024 -H 1024 -o art.png
+```
+
+For resolutions above 1024px, DyPE (Dynamic Positional Encoding) activates automatically to maintain quality. Disable with `--no-dype` if needed.
+
+### Prompt Enhancement
+
+Use the built-in LLM to expand a short prompt into a detailed one:
+
+```bash
+ComfyBox -p "a cat" --enhance -o cat.png
+```
+
+This loads the Qwen text encoder in generation mode (~5 GB extra VRAM) to write a richer prompt. Control output length with `--enhance-max-tokens`.
+
+### Seeds
+
+Seeds make generation reproducible — same seed + same prompt = same image:
+
+```bash
+# Fixed seed
+ComfyBox -p "a rose" --seed 42 -o rose.png
+
+# Multiple seeds (batch)
+ComfyBox -p "a rose" --seed 42 --seed 99 --seed 7 -o roses/rose.png
+```
+
+### Samplers and Schedules
+
+Different sampler/schedule combinations produce different aesthetics:
+
+```bash
+# Default (euler + flow) — fastest, good quality
+ComfyBox -p "a forest" -o forest.png
+
+# Heun (higher quality, 2x slower)
+ComfyBox -p "a forest" --scheduler heun -s 9 -o forest-heun.png
+
+# DPM++ 2M with Karras schedule
+ComfyBox -p "a forest" --scheduler dpmpp-2m --sigma-schedule karras -s 20 -o forest-dpm.png
+
+# DDIM (deterministic, good for animation)
+ComfyBox -p "a forest" --scheduler ddim -s 20 -o forest-ddim.png
+```
+
+Available samplers: `euler`, `heun`, `res_2s`, `dpmpp-2m`, `dpmpp-2s-a`, `deis`, `ddim`
+Available schedules: `flow`, `karras`, `exponential`, `beta`, `beta57`
+
+### Post-Processing
+
+Adjust output contrast with levels:
+
+```bash
+# Increase contrast (crush blacks, boost whites)
+ComfyBox -p "a portrait" --levels-min 0.05 --levels-max 0.95 -o portrait.png
+```
+
+## Image-to-Image
+
+Transform an existing image using a text prompt:
+
+```bash
+# Heavy rework (strength 0.3 — most change from original)
+ComfyBox -p "oil painting style" --image photo.jpg --image-strength 0.3 -o painting.png
+
+# Light touch (strength 0.7 — preserves most of the original)
+ComfyBox -p "enhance lighting" --image photo.jpg --image-strength 0.7 -o enhanced.png
+
+# Using "creativity" (inverse of strength — more intuitive)
+ComfyBox -p "watercolor style" --image photo.jpg --creativity 0.7 -o watercolor.png
+```
+
+> **Note:** ComfyBox strength is inverted from the typical convention. `--image-strength 0.3` = heavy rework (skips fewer steps, runs more denoising). `--image-strength 0.7` = light touch. The `--creativity` flag provides the intuitive direction: higher = more creative change.
+
+## LoRA
+
+LoRA weights customize the model's style without full fine-tuning:
+
+```bash
+# Single LoRA
+ComfyBox -p "a lion" --lora ostris/z_image_turbo_childrens_drawings -o lion.png
+
+# Single LoRA with scale
+ComfyBox -p "a portrait" --lora style.safetensors=0.8 -o portrait.png
+
+# Multiple LoRAs stacked
+ComfyBox -p "a fantasy portrait" \
+  --lora style.safetensors=0.8 \
+  --lora detail.safetensors=0.6 \
+  -o combined.png
+```
+
+LoRA sources:
+- **HuggingFace ID:** `ostris/z_image_turbo_childrens_drawings` (auto-downloaded)
+- **Absolute path:** `/Users/me/loras/style.safetensors`
+- **Relative path:** `./loras/style.safetensors`
+
+### LoRA Library Management
+
+```bash
+# List available LoRAs
+ComfyBox lora list
+
+# Filter by model compatibility
+ComfyBox lora list --model z-image
+
+# Show detailed info
+ComfyBox lora info my-style-lora
+
+# Scan for new LoRA files
+ComfyBox lora scan
+
+# Check compatibility with a model
+ComfyBox lora check KLEIN-Unchained-V2 --model z-image
+
+# Quarantine an incompatible LoRA
+ComfyBox lora quarantine bad-lora --reason "Wrong architecture"
+
+# Search by text
+ComfyBox lora search portrait
+```
+
+## ControlNet
+
+Generate images conditioned on a control image (edges, depth, pose):
+
+```bash
+# Canny edge control
+ComfyBox control \
+  -p "A leopard face in jungle" \
+  --control-image canny_edges.jpg \
+  --controlnet-weights alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \
+  --control-file Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
+  --control-scale 0.75 \
+  -o leopard.png
+
+# Inpainting
+ComfyBox control \
+  -p "a cat sitting on the chair" \
+  --inpaint-image room.jpg \
+  --mask mask.png \
+  --controlnet-weights alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1 \
+  --control-file Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
+  -o inpainted.png
+```
+
+**Control types:** Canny, HED, Depth, Pose (OpenPose/DWPose), MLSD
+
+**Tips:**
+- `--control-scale 0.65-0.90` — higher = stricter adherence to control image
+- Increase `--steps` for higher control scale values
+- Inpainting mask: white = fill, black = preserve
+
+## Upscaling
+
+### SeedVR2 (AI Upscale)
+
+AI-powered 2x upscaling with intelligent detail synthesis:
+
+```bash
+# Basic 2x upscale to 2048px
+ComfyBox upscale -i photo.jpg -w ~/Models/seedvr2-3b -o photo-2x.png
+
+# Target 4096px with fixed seed
+ComfyBox upscale -i photo.jpg -w ~/Models/seedvr2-3b -r 4096 --seed 42 -o photo-4k.png
+
+# With preprocessing softness (smooths input before upscale)
+ComfyBox upscale -i photo.jpg -w ~/Models/seedvr2-3b --softness 0.3 -o photo-soft.png
+```
+
+SeedVR2 models:
+- **3B** — ~7 GB VRAM, faster, good for most images
+- **7B** — ~16 GB VRAM, higher quality detail synthesis
+
+### ESRGAN (Traditional Upscale)
+
+Deterministic upscaling with tiling for large images:
+
+```bash
+ComfyBox upscale -i photo.jpg --esrgan-weights ./models/4x-ultrasharp --tile-size 512 -o photo-4x.png
+```
+
+## Batch Mode
+
+Generate multiple images from the same prompt with different seeds:
+
+```bash
+# Auto-generate 10 random seeds
+ComfyBox -p "a portrait" --auto-seeds 10 -o batch/portrait.png
+
+# Specific seeds
+ComfyBox -p "a portrait" --seed 42 --seed 99 --seed 7 -o batch/portrait.png
+
+# Resume an interrupted batch
+ComfyBox -p "a portrait" --resume-batch batch/portrait-checkpoint.json
+
+# Re-read prompt from file each iteration (for external prompt mutation)
+ComfyBox --prompt-file prompt.txt --auto-seeds 5 -o batch/output.png
+```
+
+Output files are named with seed suffixes: `portrait-seed42.png`, `portrait-seed99.png`, etc.
+
+Batch runs are sequential (one GPU render at a time) with checkpoint files for resume. If the process is interrupted, `--resume-batch` picks up from the last completed seed.
+
+## Models
+
+### List Installed Models
+
+```bash
+ComfyBox models           # Show model families and status
+ComfyBox models --paths   # Show filesystem paths
+```
+
+### Model Families
+
+| Family | Default ID | Use Case |
+|--------|-----------|----------|
+| Z-Image Turbo | `Tongyi-MAI/Z-Image-Turbo` | Fast generation (4-9 steps) |
+| Z-Image Base | `Tongyi-MAI/Z-Image` | High quality with CFG guidance |
+| Flux 2 Klein | varies | High quality 9B model |
+| FIBO | `briaai/FIBO` | JSON-structured prompts |
+| Chroma | varies | Guidance-free architecture |
+
+### Using Different Models
+
+```bash
+# Z-Image Turbo (default)
+ComfyBox -p "a cat" -o cat.png
+
+# Quantized model (less VRAM)
+ComfyBox -p "a cat" -m mzbac/Z-Image-Turbo-8bit -o cat.png
+
+# Local model directory
+ComfyBox -p "a cat" -m ~/Models/z-image-turbo-bf16 -o cat.png
+
+# AIO checkpoint (single .safetensors with all components)
+ComfyBox -p "a cat" -m path/to/aio-checkpoint.safetensors -o cat.png
+```
+
+### Quantization
+
+Reduce memory usage by quantizing weights:
+
+```bash
+ComfyBox quantize -i models/z-image-turbo -o models/z-image-turbo-q8 --bits 8
+```
+
+| Precision | Memory | Quality | Speed |
+|-----------|--------|---------|-------|
+| BF16 | ~21 GB | Best | Baseline |
+| 8-bit | ~7.5 GB | Near-identical | ~Same |
+| 4-bit | ~4 GB | Slight degradation | Slightly faster |
+
+## SVG Export
+
+Convert generated images to scalable vector graphics:
+
+```bash
+# Basic SVG
+ComfyBox -p "geometric pattern" --svg -o pattern.png
+# Creates: pattern.png AND pattern.svg
+
+# Logo preset (clean, minimal)
+ComfyBox -p "coffee cup logo, flat design" --svg --svg-preset logo -o logo.png
+```
+
+Requires [vtracer](https://github.com/visioncortex/vtracer):
+```bash
+cargo install vtracer
+```
+
+**Presets:** `default`, `logo`, `detailed`, `simplified`, `bw`
+
+**Tips for best SVG results:**
+- Use high contrast prompts: "bold colors, white background"
+- Add "flat design, no gradients" for cleaner conversion
+- `logo` preset produces the smallest, cleanest files
+
+## Metadata
+
+### Generation Metadata
+
+Save generation parameters alongside the output image:
+
+```bash
+ComfyBox -p "a cat" --metadata -o cat.png
+# Creates: cat.png AND cat.json
+```
+
+The JSON sidecar contains all parameters needed to reproduce the image: prompt, seed, steps, guidance, model, LoRAs, scheduler, resolution.
+
+### Reproduce from Metadata
+
+Load parameters from a previous generation's metadata:
+
+```bash
+# Exact reproduction
+ComfyBox --config-from-metadata cat.json -o cat-copy.png
+
+# Override specific parameters
+ComfyBox --config-from-metadata cat.json --steps 20 -o cat-hq.png
+```
+
+## Scripting
+
+For automation and pipelines:
+
+```bash
+# Disable progress bars
+ComfyBox -p "batch image" --no-progress -o output.png
+
+# Audit model weight coverage (diagnostic)
+ComfyBox -p "" --audit-weights -m ~/Models/my-model
+```
+
+## GPU Memory Management
+
+```bash
+# Set cache limit (prevents OOM on constrained devices)
+ComfyBox -p "a scene" --cache-limit 8192 -o scene.png
+```
+
+**Rules of thumb:**
+- M1/M2 (16 GB): Use 8-bit models, avoid SeedVR2 7B
+- M1/M2 Pro (32 GB): BF16 models work fine, one at a time
+- M3 Max (128 GB): Multiple BF16 models simultaneously
+- Never run multiple GPU renders concurrently — sequential only


### PR DESCRIPTION
## Summary
- **architecture.md** — Engine/Orchestrator/Protocol layers, model families, memory footprint, file layout
- **user-guide.md** — Complete CLI reference: txt2img, img2img, LoRA, ControlNet, batch mode, upscaling, SVG, metadata
- **mcp-reference.md** — All 18 MCP tools with parameter tables, examples, timeout configuration
- **deployment.md** — Serve mode, keepalive script, SSH bridge, network topology diagram, troubleshooting

README.md rewritten to reflect current project state: multi-model support, MCP integration, batch mode, samplers, and links to all docs.

## Changes
- 4 new docs (~1,135 lines)
- README rewrite (~380 lines, net +977)
- No code changes

## Test plan
- [ ] Verify all internal doc links resolve
- [ ] Spot-check CLI examples against current --help output
- [ ] Confirm MCP tool list matches MCPToolRegistry.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)