### PR TITLE
feat: CivitAI checkpoint loader (#139)

### DIFF
--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -163,6 +163,8 @@ public final class ZImagePipeline {
   private var useDynamicLoRA: Bool = false
   private var activeTransformerOverrideURL: URL?
   private var activeAIOCheckpointURL: URL?
+  private var activeCivitAICheckpointURL: URL?
+  private var activeCivitAIVariant: ZImageVariant?
   private var loadedTextEncoderSelection: TextEncoderSelection?
 
   // Stored behind pipeline-local serialized access only. LoRAWeights contains MLXArray.
@@ -201,6 +203,8 @@ public final class ZImagePipeline {
     useDynamicLoRA = false
     activeTransformerOverrideURL = nil
     activeAIOCheckpointURL = nil
+    activeCivitAICheckpointURL = nil
+    activeCivitAIVariant = nil
     loadedTextEncoderSelection = nil
     GPU.clearCache()
     logger.info("Model unloaded from memory")
@@ -383,6 +387,8 @@ public final class ZImagePipeline {
     var transformerOverrideURL: URL?
     var aioCheckpointURL: URL?
     var aioTextEncoderPrefix: String?
+    var civitaiCheckpointURL: URL?
+    var civitaiVariant: ZImageVariant?
   }
 
   func resolveModelSelection(_ modelSpec: String?, forceTransformerOverrideOnly: Bool) -> ModelSelection {
@@ -442,6 +448,16 @@ public final class ZImagePipeline {
       }
     }
 
+    // CivitAI transformer-only detection
+    if !forceTransformerOverrideOnly {
+      let civitaiInspection = CivitAICheckpoint.inspect(fileURL: url)
+      if civitaiInspection.isCivitAI {
+        let variant = civitaiInspection.variant ?? .turbo
+        logger.info("Detected CivitAI checkpoint: \(url.lastPathComponent) (variant=\(variant.rawValue), keys=\(civitaiInspection.keyCount))")
+        return .init(baseModelSpec: nil, transformerOverrideURL: nil, aioCheckpointURL: nil, aioTextEncoderPrefix: nil, civitaiCheckpointURL: url, civitaiVariant: variant)
+      }
+    }
+
     if sourceDirectory != nil {
       logger.info("Using transformer override file from directory: \(url.lastPathComponent)")
     } else {
@@ -452,7 +468,7 @@ public final class ZImagePipeline {
 
   private func applyTransformerOverrideIfNeeded(_ overrideURL: URL?) throws {
     guard overrideURL != activeTransformerOverrideURL else { return }
-    guard activeAIOCheckpointURL == nil else { return }
+    guard activeAIOCheckpointURL == nil && activeCivitAICheckpointURL == nil else { return }
     guard let transformer, let snapshot = modelSnapshot, let configs = modelConfigs else { throw PipelineError.modelNotLoaded }
 
     let weightsMapper = ZImageWeightsMapper(snapshot: snapshot, logger: logger)
@@ -507,6 +523,8 @@ public final class ZImagePipeline {
     textEncoderPath: String? = nil,
     aioCheckpointURL: URL? = nil,
     aioTextEncoderPrefix: String? = nil,
+    civitaiCheckpointURL: URL? = nil,
+    civitaiVariant: ZImageVariant? = nil,
     progressHandler: ProgressHandler? = nil
   ) async throws {
     let modelId = modelSpec ?? ZImageRepository.id
@@ -662,6 +680,61 @@ public final class ZImagePipeline {
       } else {
         logger.info("Reusing cached VAE")
       }
+    } else if let civitaiCheckpointURL {
+      let variant = civitaiVariant ?? .turbo
+      logger.info("Loading CivitAI checkpoint: \(civitaiCheckpointURL.lastPathComponent) (variant=\(variant.rawValue))")
+
+      // Load transformer weights (raw, with model.diffusion_model. prefix)
+      let rawWeights = try CivitAICheckpoint.loadTransformerWeights(
+        from: civitaiCheckpointURL, dtype: .bfloat16, logger: logger)
+
+      // Canonicalize keys (strip prefix, split QKV, remap names)
+      let transformerWeights = canonicalizeTransformerOverride(rawWeights, dim: configs.transformer.dim, logger: logger)
+
+      // Validate
+      if let inferredDim = inferTransformerDim(from: transformerWeights), inferredDim != configs.transformer.dim {
+        throw PipelineError.weightsMissing("CivitAI transformer dim \(inferredDim) mismatches model dim \(configs.transformer.dim)")
+      }
+      try validateStrictAIOTransformerWeights(transformerWeights, config: configs.transformer)
+
+      progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 0, totalSteps: 1))
+      logger.info("Loading transformer architecture...")
+      let trans = try loadTransformer(snapshot: snapshot, config: configs.transformer)
+      try validateAIOTransformerCoverage(transformerWeights, transformer: trans)
+      try ZImageWeightsMapping.applyTransformer(weights: transformerWeights, to: trans, manifest: nil, logger: logger)
+      transformer = trans
+
+      activeTransformerOverrideURL = nil
+      activeAIOCheckpointURL = nil
+      activeCivitAICheckpointURL = civitaiCheckpointURL
+      activeCivitAIVariant = variant
+      quantManifest = nil
+
+      // Text encoder loaded from HuggingFace snapshot (standard path)
+      let weightsMapper = ZImageWeightsMapper(
+        snapshot: snapshot,
+        logger: logger,
+        textEncoderDirectory: textEncoderSelection.directory
+      )
+      let manifest = weightsMapper.loadQuantizationManifest()
+      logger.info("Loading text encoder from HuggingFace snapshot...")
+      let te = try loadTextEncoder(snapshot: snapshot, config: configs.textEncoder)
+      let textEncoderWeights = try weightsMapper.loadTextEncoder()
+      try ZImageWeightsMapping.applyTextEncoder(weights: textEncoderWeights, to: te, manifest: manifest, logger: logger)
+      textEncoder = te
+
+      // VAE loaded from HuggingFace snapshot (standard path)
+      if vae == nil {
+        progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 0, totalSteps: 1))
+        logger.info("Loading VAE from HuggingFace snapshot...")
+        let v = try loadVAEDecoder(snapshot: snapshot, config: configs.vae)
+        let vaeWeights = try weightsMapper.loadVAE()
+        let decoderWeights = vaeWeights.filter { $0.key.hasPrefix("decoder.") }
+        try ZImageWeightsMapping.applyVAE(weights: decoderWeights, to: v, manifest: manifest, logger: logger)
+        vae = v
+      } else {
+        logger.info("Reusing cached VAE")
+      }
     } else {
       let weightsMapper = ZImageWeightsMapper(
         snapshot: snapshot,
@@ -686,6 +759,8 @@ public final class ZImagePipeline {
       transformer = trans
       activeTransformerOverrideURL = nil
       activeAIOCheckpointURL = nil
+      activeCivitAICheckpointURL = nil
+      activeCivitAIVariant = nil
       if vae == nil {
         progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 0, totalSteps: 1))
         logger.info("Loading VAE...")
@@ -726,10 +801,12 @@ public final class ZImagePipeline {
       textEncoderPath: textEncoderPath,
       aioCheckpointURL: selection.aioCheckpointURL,
       aioTextEncoderPrefix: selection.aioTextEncoderPrefix,
+      civitaiCheckpointURL: selection.civitaiCheckpointURL,
+      civitaiVariant: selection.civitaiVariant,
       progressHandler: progressHandler
     )
 
-    if selection.aioCheckpointURL == nil {
+    if selection.aioCheckpointURL == nil && selection.civitaiCheckpointURL == nil {
       try applyTransformerOverrideIfNeeded(selection.transformerOverrideURL)
     }
 

--- a/Sources/ZImage/Server/ModelPool.swift
+++ b/Sources/ZImage/Server/ModelPool.swift
@@ -422,6 +422,20 @@ actor ModelPool {
       return .flux2
     }
 
+    // Check if modelSpec points to a single safetensors file
+    let localURL = URL(fileURLWithPath: modelSpec)
+    if localURL.pathExtension == "safetensors" && FileManager.default.fileExists(atPath: localURL.path) {
+      // Single-file checkpoint — check if CivitAI or AIO
+      let aio = ZImageAIOCheckpoint.inspect(fileURL: localURL)
+      if aio.isAIO { return .flux1 }
+
+      let civitai = CivitAICheckpoint.inspect(fileURL: localURL)
+      if civitai.isCivitAI { return .flux1 }
+
+      // Could also be a single-file transformer override for flux1
+      return .flux1
+    }
+
     // Not detected by name — try resolving and inspecting the snapshot.
     let resolved = try await ModelResolution.resolveOrDefault(
       modelSpec: modelSpec,

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1396,6 +1396,15 @@ private actor WarmServerCoordinator {
       // Detect Z-Image variant (Base vs Turbo)
       if let spec = modelSpec, let variant = ZImageVariant.fromModelSpec(spec) {
         zimageVariant = variant
+      } else if let spec = modelSpec, spec.hasSuffix(".safetensors") {
+        // Detect from CivitAI checkpoint inspection
+        let localURL = URL(fileURLWithPath: spec)
+        if FileManager.default.fileExists(atPath: localURL.path) {
+          let inspection = CivitAICheckpoint.inspect(fileURL: localURL)
+          if let variant = inspection.variant {
+            zimageVariant = variant
+          }
+        }
       } else if let resolvedSnapshot = snapshotURL {
         zimageVariant = ZImageVariant.fromSnapshot(at: resolvedSnapshot)
       } else if let spec = modelSpec {

--- a/Sources/ZImage/Weights/CivitAICheckpoint.swift
+++ b/Sources/ZImage/Weights/CivitAICheckpoint.swift
@@ -64,8 +64,8 @@ public enum CivitAICheckpoint {
         diagnostics: ["has text_encoder or VAE keys — use AIO path"], keyCount: diffusionKeys.count)
     }
 
-    // Must have diffusion model keys (real checkpoints have ~453)
-    guard diffusionKeys.count >= 400 else {
+    // Must have diffusion model keys (Base ~453, Turbo ~201)
+    guard diffusionKeys.count >= 150 else {
       return Inspection(isCivitAI: false, variant: nil,
         diagnostics: ["only \(diffusionKeys.count) diffusion keys (expected >= 400)"], keyCount: diffusionKeys.count)
     }
@@ -87,21 +87,38 @@ public enum CivitAICheckpoint {
 
   /// Detect whether a CivitAI checkpoint is Base or Turbo.
   ///
-  /// Most reliable signal: check if `model.diffusion_model.guidance_in.mlp.0.weight` exists.
-  /// Base Z-Image has a guidance embedding module; Turbo does not.
+  /// Base Z-Image uses `t_embedder` (time embedder) and has `noise_refiner`,
+  /// `context_refiner`, `cap_embedder` modules (~453 keys total).
+  /// Turbo Z-Image uses `time_in` and has a smaller architecture (~201 keys).
+  ///
+  /// The raw CivitAI keys retain the `model.diffusion_model.` prefix.
   static func detectVariant(names: Set<String>) -> ZImageVariant {
-    // Primary signal: guidance embedding layer exists only in Base
-    let guidanceKeys = [
-      "model.diffusion_model.guidance_in.mlp.0.weight",
-      "model.diffusion_model.guidance_in.mlp.2.weight",
-      "model.diffusion_model.g_embedder.mlp.0.weight",
-      "model.diffusion_model.g_embedder.mlp.2.weight",
+    // Primary signal: Base has t_embedder and noise_refiner; Turbo does not
+    let baseSignalKeys = [
+      "model.diffusion_model.t_embedder.mlp.0.weight",
+      "model.diffusion_model.noise_refiner.0.attention.qkv.weight",
+      "model.diffusion_model.context_refiner.0.attention.qkv.weight",
+      "model.diffusion_model.cap_embedder.0.weight",
     ]
-    if guidanceKeys.contains(where: { names.contains($0) }) {
+    if baseSignalKeys.contains(where: { names.contains($0) }) {
       return .base
     }
 
-    // No guidance embedder found — assume Turbo (majority of community checkpoints)
+    // Secondary signal: Turbo has time_in (not t_embedder)
+    let turboSignalKeys = [
+      "model.diffusion_model.time_in.in_layer.weight",
+      "model.diffusion_model.time_in.out_layer.weight",
+    ]
+    if turboSignalKeys.contains(where: { names.contains($0) }) {
+      return .turbo
+    }
+
+    // Tertiary signal: key count — Base has ~453, Turbo has ~201
+    if names.count >= 400 {
+      return .base
+    }
+
+    // Default to Turbo for unrecognized small checkpoints
     return .turbo
   }
 

--- a/Sources/ZImage/Weights/CivitAICheckpoint.swift
+++ b/Sources/ZImage/Weights/CivitAICheckpoint.swift
@@ -1,0 +1,207 @@
+// CivitAICheckpoint.swift — Detection and loading for CivitAI transformer-only checkpoints
+//
+// CivitAI community checkpoints store Z-Image transformer weights in a single
+// .safetensors file with a `model.diffusion_model.` prefix. Unlike AIO checkpoints,
+// they contain only diffusion model weights (no text encoder, no VAE). Text encoder
+// and VAE are loaded from the standard HuggingFace snapshot.
+//
+// Issue: #139
+
+import Foundation
+import MLX
+import Logging
+
+public enum CivitAICheckpoint {
+
+  // MARK: - Types
+
+  public struct Inspection: Sendable {
+    /// True if this is a CivitAI transformer-only checkpoint.
+    public let isCivitAI: Bool
+    /// Detected variant (Base vs Turbo), nil if detection failed.
+    public let variant: ZImageVariant?
+    /// Diagnostic messages for debugging.
+    public let diagnostics: [String]
+    /// Number of diffusion model keys found.
+    public let keyCount: Int
+  }
+
+  // MARK: - Detection
+
+  /// Inspect a safetensors file to determine if it is a CivitAI transformer-only checkpoint.
+  ///
+  /// A CivitAI checkpoint is identified by:
+  /// 1. All (or nearly all) keys have the `model.diffusion_model.` prefix
+  /// 2. No `text_encoders.*` keys present
+  /// 3. No `vae.*` keys present
+  /// 4. Contains `model.diffusion_model.layers.0.attention.qkv.weight` (fused QKV)
+  ///
+  /// This distinguishes it from:
+  /// - AIO checkpoints (have text_encoders.* and vae.*)
+  /// - HuggingFace format (directory with sharded files, no prefix)
+  /// - Transformer-only overrides (no prefix, already in internal format)
+  public static func inspect(fileURL: URL) -> Inspection {
+    do {
+      let reader = try SafeTensorsReader(fileURL: fileURL)
+      return inspect(reader: reader)
+    } catch {
+      return Inspection(isCivitAI: false, variant: nil, diagnostics: ["failed to read: \(error)"], keyCount: 0)
+    }
+  }
+
+  public static func inspect(reader: SafeTensorsReader) -> Inspection {
+    let names = reader.tensorNames
+    let nameSet = Set(names)
+
+    // Count keys by prefix
+    let diffusionKeys = names.filter { $0.hasPrefix("model.diffusion_model.") }
+    let hasTextEncoder = names.contains { $0.hasPrefix("text_encoders.") }
+    let hasVAE = names.contains { $0.hasPrefix("vae.") }
+
+    // If it has text encoder or VAE, it is an AIO checkpoint, not CivitAI-transformer-only
+    if hasTextEncoder || hasVAE {
+      return Inspection(isCivitAI: false, variant: nil,
+        diagnostics: ["has text_encoder or VAE keys — use AIO path"], keyCount: diffusionKeys.count)
+    }
+
+    // Must have diffusion model keys (real checkpoints have ~453)
+    guard diffusionKeys.count >= 400 else {
+      return Inspection(isCivitAI: false, variant: nil,
+        diagnostics: ["only \(diffusionKeys.count) diffusion keys (expected >= 400)"], keyCount: diffusionKeys.count)
+    }
+
+    // Must have fused QKV (the signature of CivitAI format vs already-canonicalized)
+    let hasFusedQKV = nameSet.contains("model.diffusion_model.layers.0.attention.qkv.weight")
+    guard hasFusedQKV else {
+      return Inspection(isCivitAI: false, variant: nil,
+        diagnostics: ["no fused QKV keys found"], keyCount: diffusionKeys.count)
+    }
+
+    // Detect variant
+    let variant = detectVariant(names: nameSet)
+
+    return Inspection(isCivitAI: true, variant: variant, diagnostics: [], keyCount: diffusionKeys.count)
+  }
+
+  // MARK: - Variant Detection
+
+  /// Detect whether a CivitAI checkpoint is Base or Turbo.
+  ///
+  /// Most reliable signal: check if `model.diffusion_model.guidance_in.mlp.0.weight` exists.
+  /// Base Z-Image has a guidance embedding module; Turbo does not.
+  static func detectVariant(names: Set<String>) -> ZImageVariant {
+    // Primary signal: guidance embedding layer exists only in Base
+    let guidanceKeys = [
+      "model.diffusion_model.guidance_in.mlp.0.weight",
+      "model.diffusion_model.guidance_in.mlp.2.weight",
+      "model.diffusion_model.g_embedder.mlp.0.weight",
+      "model.diffusion_model.g_embedder.mlp.2.weight",
+    ]
+    if guidanceKeys.contains(where: { names.contains($0) }) {
+      return .base
+    }
+
+    // No guidance embedder found — assume Turbo (majority of community checkpoints)
+    return .turbo
+  }
+
+  // MARK: - Loading
+
+  /// Load transformer weights from a CivitAI checkpoint.
+  ///
+  /// Steps:
+  /// 1. Read all tensors with `model.diffusion_model.` prefix
+  /// 2. Handle FP8/FP16/FP32 -> BF16 conversion
+  /// 3. Return raw dict (caller applies canonicalizeTransformerOverride)
+  ///
+  /// The returned keys still have the `model.diffusion_model.` prefix.
+  /// The caller (canonicalizeTransformerOverride) strips it.
+  public static func loadTransformerWeights(
+    from fileURL: URL,
+    dtype: DType = .bfloat16,
+    logger: Logger? = nil
+  ) throws -> [String: MLXArray] {
+    let reader = try SafeTensorsReader(fileURL: fileURL)
+    var weights: [String: MLXArray] = [:]
+    weights.reserveCapacity(reader.tensorNames.count)
+
+    var fp8Count = 0
+    var castCount = 0
+
+    for meta in reader.allMetadata() {
+      guard meta.name.hasPrefix("model.diffusion_model.") else { continue }
+
+      var tensor = try reader.tensor(named: meta.name)
+
+      // Handle FP8 (float8_e4m3fn) — SafeTensorsReader maps to .uint8
+      if isFP8Tensor(meta) {
+        tensor = decodeFP8(tensor)
+        fp8Count += 1
+      }
+
+      // Cast to target dtype if needed
+      if tensor.dtype != dtype {
+        tensor = tensor.asType(dtype)
+        castCount += 1
+      }
+
+      weights[meta.name] = tensor
+    }
+
+    logger?.info("CivitAI: loaded \(weights.count) transformer tensors (fp8_decoded=\(fp8Count), dtype_cast=\(castCount))")
+    return weights
+  }
+
+  // MARK: - FP8 Support
+
+  /// Check if a tensor metadata entry represents FP8 data.
+  ///
+  /// CivitAI FP8 checkpoints use dtype "F8_E4M3" or "F8_E4M3FN" in the safetensors header.
+  /// SafeTensorsReader maps these to .uint8 and preserves the original dtype string in rawDType.
+  private static func isFP8Tensor(_ meta: SafeTensorMetadata) -> Bool {
+    let raw = meta.rawDType.uppercased()
+    return raw == "F8_E4M3" || raw == "F8_E4M3FN" || raw == "F8_E5M2"
+  }
+
+  /// Decode FP8 (float8_e4m3fn) tensor to float32, then let caller cast to target dtype.
+  ///
+  /// FP8 E4M3FN: 1 sign bit, 4 exponent bits, 3 mantissa bits.
+  /// Bias = 7, no infinity representation, NaN = 0x7F.
+  ///
+  /// The decode is done via integer arithmetic on the uint8 raw bytes:
+  ///   value = (-1)^sign * 2^(exponent - 7) * (1 + mantissa/8)   [normal]
+  ///   value = (-1)^sign * 2^(-6) * (mantissa/8)                  [subnormal, exp=0]
+  ///   value = NaN                                                 [exp=15, mantissa=7]
+  private static func decodeFP8(_ tensor: MLXArray) -> MLXArray {
+    // Promote to int32 for bit manipulation
+    let u = tensor.asType(.int32)
+
+    let sign = (u >> 7) & 1
+    let exponent = (u >> 3) & 0xF
+    let mantissa = u & 0x7
+
+    // Build float32 values
+    let signF = MLX.where(sign .== 0, MLXArray(Float(1.0)), MLXArray(Float(-1.0)))
+
+    // Normal: exp > 0 => value = sign * 2^(exp-7) * (1 + mantissa/8)
+    // Subnormal: exp == 0 => value = sign * 2^(-6) * (mantissa/8)
+    // NaN: exp==15 && mantissa==7 => 0 (treat as zero for practical use)
+
+    let mantissaF = mantissa.asType(.float32) / MLXArray(Float(8.0))
+    let expF = exponent.asType(.float32)
+
+    // 2^(exp - 7) for normal, 2^(-6) for subnormal
+    let isSubnormal = exponent .== 0
+    let isNaN = (exponent .== 15) & (mantissa .== 7)
+
+    let normalPow = MLX.pow(MLXArray(Float(2.0)), expF - MLXArray(Float(7.0)))
+    let normalVal = signF * normalPow * (MLXArray(Float(1.0)) + mantissaF)
+
+    let subnormalVal = signF * MLXArray(Float(1.0 / 64.0)) * mantissaF
+
+    var result = MLX.where(isSubnormal, subnormalVal, normalVal)
+    result = MLX.where(isNaN, MLXArray(Float(0.0)), result)
+
+    return result
+  }
+}

--- a/Sources/ZImage/Weights/ModelPaths.swift
+++ b/Sources/ZImage/Weights/ModelPaths.swift
@@ -65,6 +65,20 @@ public enum ZImageVariant: String, Sendable {
     if normalized.contains("z-image-turbo") || normalized.contains("z_image_turbo") {
       return .turbo
     }
+
+    // CivitAI checkpoint filename heuristics
+    if normalized.hasSuffix(".safetensors") {
+      let filename = (normalized as NSString).lastPathComponent
+      // Known Turbo-derived checkpoints contain "dpo" or "turbo" in the filename
+      if filename.contains("dpo") || filename.contains("turbo") {
+        return .turbo
+      }
+      // "wild" is a known Base-derived model family
+      if filename.contains("wild") {
+        return .base
+      }
+    }
+
     return nil
   }
 

--- a/Sources/ZImage/Weights/SafeTensorsReader.swift
+++ b/Sources/ZImage/Weights/SafeTensorsReader.swift
@@ -7,6 +7,9 @@ public struct SafeTensorMetadata: Sendable {
   public let shape: [Int]
   public let dataOffset: Int
   public let byteCount: Int
+  /// Original dtype string from the safetensors header (e.g. "BF16", "F8_E4M3FN").
+  /// Useful for detecting FP8 tensors that are mapped to .uint8.
+  public let rawDType: String
 
   public var elementCount: Int {
     shape.reduce(1, *)
@@ -135,7 +138,8 @@ public final class SafeTensorsReader {
         dtype: dtype,
         shape: shape,
         dataOffset: absoluteOffset,
-        byteCount: byteCount
+        byteCount: byteCount,
+        rawDType: dtypeString
       )
     }
 
@@ -286,6 +290,10 @@ public final class SafeTensorsReader {
       return .uint8
     case "BOOL":
       return .bool
+    case "F8_E4M3", "F8_E4M3FN":
+      return .uint8  // Store as uint8; caller decodes via CivitAICheckpoint.decodeFP8()
+    case "F8_E5M2":
+      return .uint8  // Store as uint8; rarely used but handle gracefully
     default:
       throw SafeTensorsReaderError.unsupportedDType(value)
     }

--- a/Tests/ZImageTests/Weights/CivitAICheckpointTests.swift
+++ b/Tests/ZImageTests/Weights/CivitAICheckpointTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+import MLX
+import Logging
+@testable import ZImage
+
+final class CivitAICheckpointTests: XCTestCase {
+
+  // MARK: - Detection Tests
+
+  func testInspectDetectsCivitAICheckpoint() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("civitai_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    // Build a synthetic CivitAI checkpoint with 450+ diffusion model keys
+    var arrays: [String: MLXArray] = [:]
+    let w1d = MLXArray([Float(0.0)]).asType(.bfloat16)
+    let w2d = MLXArray([Float(0.0), Float(0.0)], [1, 2]).asType(.bfloat16)
+
+    // Fused QKV for layers 0-29 (the signature of CivitAI format)
+    for i in 0..<30 {
+      arrays["model.diffusion_model.layers.\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+      arrays["model.diffusion_model.layers.\(i).attention.out.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).attention.q_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention.k_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w2.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w3.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.bias"] = w1d
+    }
+    // Noise/context refiners
+    for prefix in ["noise_refiner", "context_refiner"] {
+      for i in 0..<2 {
+        arrays["model.diffusion_model.\(prefix).\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+        arrays["model.diffusion_model.\(prefix).\(i).attention.out.weight"] = w2d
+      }
+    }
+    // Embedders
+    arrays["model.diffusion_model.t_embedder.mlp.0.weight"] = w2d
+    arrays["model.diffusion_model.t_embedder.mlp.0.bias"] = w1d
+    arrays["model.diffusion_model.t_embedder.mlp.2.weight"] = w2d
+    arrays["model.diffusion_model.t_embedder.mlp.2.bias"] = w1d
+    arrays["model.diffusion_model.cap_embedder.0.weight"] = w1d
+    arrays["model.diffusion_model.cap_embedder.1.weight"] = w2d
+    arrays["model.diffusion_model.cap_embedder.1.bias"] = w1d
+    arrays["model.diffusion_model.x_embedder.weight"] = w2d
+    arrays["model.diffusion_model.final_layer.adaLN_modulation.1.weight"] = w2d
+    arrays["model.diffusion_model.final_layer.linear.weight"] = w2d
+
+    XCTAssertGreaterThanOrEqual(arrays.count, 400, "Synthetic checkpoint should have >= 400 keys")
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertTrue(inspection.isCivitAI, "Should detect as CivitAI: \(inspection.diagnostics)")
+    XCTAssertEqual(inspection.variant, .turbo, "No guidance embedder should mean Turbo")
+    XCTAssertTrue(inspection.diagnostics.isEmpty)
+    XCTAssertGreaterThanOrEqual(inspection.keyCount, 400)
+  }
+
+  func testInspectRejectsAIOCheckpoint() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("aio_reject_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let w = MLXArray([Float(0.0)]).asType(.bfloat16)
+    var arrays: [String: MLXArray] = [:]
+
+    // Add enough diffusion keys
+    for i in 0..<30 {
+      for j in 0..<15 {
+        arrays["model.diffusion_model.layers.\(i).key\(j)"] = w
+      }
+    }
+    // Add text encoder and VAE keys (makes it AIO, not CivitAI-only)
+    arrays["text_encoders.qwen3_4b.transformer.model.embed_tokens.weight"] = w
+    arrays["vae.decoder.conv_in.weight"] = w
+
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertFalse(inspection.isCivitAI, "Should reject AIO checkpoint")
+    XCTAssertTrue(inspection.diagnostics.contains(where: { $0.contains("text_encoder or VAE") }))
+  }
+
+  func testInspectRejectsInternalFormat() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("internal_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let w = MLXArray([Float(0.0)]).asType(.bfloat16)
+    var arrays: [String: MLXArray] = [:]
+
+    // Internal format: no prefix, already split Q/K/V
+    for i in 0..<30 {
+      arrays["layers.\(i).attention.to_q.weight"] = w
+      arrays["layers.\(i).attention.to_k.weight"] = w
+      arrays["layers.\(i).attention.to_v.weight"] = w
+    }
+
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertFalse(inspection.isCivitAI, "Should reject internal format (no prefix)")
+  }
+
+  func testInspectRejectsTooFewKeys() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("fewkeys_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let w = MLXArray([Float(0.0)]).asType(.bfloat16)
+    var arrays: [String: MLXArray] = [:]
+
+    // Only 10 keys with the right prefix
+    for i in 0..<10 {
+      arrays["model.diffusion_model.key\(i)"] = w
+    }
+
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertFalse(inspection.isCivitAI, "Should reject too few keys")
+    XCTAssertTrue(inspection.diagnostics.contains(where: { $0.contains("diffusion keys") }))
+  }
+
+  // MARK: - Variant Detection Tests
+
+  func testDetectsBaseVariantByGuidanceEmbedder() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("base_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let w1d = MLXArray([Float(0.0)]).asType(.bfloat16)
+    let w2d = MLXArray([Float(0.0), Float(0.0)], [1, 2]).asType(.bfloat16)
+    var arrays: [String: MLXArray] = [:]
+
+    // Build minimum viable CivitAI checkpoint
+    for i in 0..<30 {
+      arrays["model.diffusion_model.layers.\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+      arrays["model.diffusion_model.layers.\(i).attention.out.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).attention.q_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention.k_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w2.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w3.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.bias"] = w1d
+    }
+    for prefix in ["noise_refiner", "context_refiner"] {
+      for i in 0..<2 {
+        arrays["model.diffusion_model.\(prefix).\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+        arrays["model.diffusion_model.\(prefix).\(i).attention.out.weight"] = w2d
+      }
+    }
+    arrays["model.diffusion_model.t_embedder.mlp.0.weight"] = w2d
+    arrays["model.diffusion_model.cap_embedder.0.weight"] = w1d
+    arrays["model.diffusion_model.x_embedder.weight"] = w2d
+    arrays["model.diffusion_model.final_layer.adaLN_modulation.1.weight"] = w2d
+
+    // Add guidance embedder keys (Base-only)
+    arrays["model.diffusion_model.guidance_in.mlp.0.weight"] = w2d
+    arrays["model.diffusion_model.guidance_in.mlp.2.weight"] = w2d
+
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertTrue(inspection.isCivitAI)
+    XCTAssertEqual(inspection.variant, .base, "Guidance embedder should indicate Base variant")
+  }
+
+  func testDetectsTurboVariantByAbsenceOfGuidanceEmbedder() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("turbo_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let w1d = MLXArray([Float(0.0)]).asType(.bfloat16)
+    let w2d = MLXArray([Float(0.0), Float(0.0)], [1, 2]).asType(.bfloat16)
+    var arrays: [String: MLXArray] = [:]
+
+    for i in 0..<30 {
+      arrays["model.diffusion_model.layers.\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+      arrays["model.diffusion_model.layers.\(i).attention.out.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).attention.q_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention.k_norm.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).attention_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm1.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).ffn_norm2.weight"] = w1d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w2.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).feed_forward.w3.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.weight"] = w2d
+      arrays["model.diffusion_model.layers.\(i).adaLN_modulation.1.bias"] = w1d
+    }
+    for prefix in ["noise_refiner", "context_refiner"] {
+      for i in 0..<2 {
+        arrays["model.diffusion_model.\(prefix).\(i).attention.qkv.weight"] = MLXArray(Array(repeating: Float(0.0), count: 6 * 2), [6, 2]).asType(.bfloat16)
+        arrays["model.diffusion_model.\(prefix).\(i).attention.out.weight"] = w2d
+      }
+    }
+    arrays["model.diffusion_model.t_embedder.mlp.0.weight"] = w2d
+    arrays["model.diffusion_model.cap_embedder.0.weight"] = w1d
+    arrays["model.diffusion_model.x_embedder.weight"] = w2d
+    arrays["model.diffusion_model.final_layer.adaLN_modulation.1.weight"] = w2d
+    // NO guidance_in keys
+
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let inspection = CivitAICheckpoint.inspect(fileURL: fileURL)
+    XCTAssertTrue(inspection.isCivitAI)
+    XCTAssertEqual(inspection.variant, .turbo, "No guidance embedder should mean Turbo variant")
+  }
+
+  // MARK: - SafeTensorsReader FP8 Dtype Tests
+
+  func testMapDTypeF8E4M3ReturnsUInt8() throws {
+    // Verify FP8 dtype strings are handled (don't throw unsupportedDType)
+    // We test by creating a safetensors file with BF16 and checking rawDType
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("dtype_\(UUID().uuidString).safetensors")
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let arrays: [String: MLXArray] = [
+      "test.weight": MLXArray([Float(1.0)]).asType(.bfloat16)
+    ]
+    try MLX.save(arrays: arrays, metadata: [:], url: fileURL)
+
+    let reader = try SafeTensorsReader(fileURL: fileURL)
+    let meta = reader.metadata(for: "test.weight")
+    XCTAssertNotNil(meta)
+    XCTAssertEqual(meta?.rawDType, "BF16")
+    XCTAssertEqual(meta?.dtype, .bfloat16)
+  }
+
+  // MARK: - ModelPaths Variant Heuristic Tests
+
+  func testFromModelSpecDetectsDPOAsTurbo() {
+    let variant = ZImageVariant.fromModelSpec("/path/to/moodyRealMix_zitV6DPO.safetensors")
+    XCTAssertEqual(variant, .turbo)
+  }
+
+  func testFromModelSpecDetectsWildAsBase() {
+    let variant = ZImageVariant.fromModelSpec("/path/to/moody-wild-v4-fp16-full.safetensors")
+    XCTAssertEqual(variant, .base)
+  }
+
+  func testFromModelSpecReturnsNilForUnknownCheckpoint() {
+    let variant = ZImageVariant.fromModelSpec("/path/to/random-model.safetensors")
+    XCTAssertNil(variant)
+  }
+
+  func testFromModelSpecStillDetectsHuggingFaceModels() {
+    XCTAssertEqual(ZImageVariant.fromModelSpec("Tongyi-MAI/Z-Image"), .base)
+    XCTAssertEqual(ZImageVariant.fromModelSpec("Tongyi-MAI/Z-Image-Turbo"), .turbo)
+  }
+}

--- a/Tests/ZImageTests/Weights/SafeTensorsReaderTests.swift
+++ b/Tests/ZImageTests/Weights/SafeTensorsReaderTests.swift
@@ -105,7 +105,8 @@ final class SafeTensorsReaderTests: XCTestCase {
       dtype: .float32,
       shape: [10, 20, 30],
       dataOffset: 0,
-      byteCount: 10 * 20 * 30 * 4
+      byteCount: 10 * 20 * 30 * 4,
+      rawDType: "F32"
     )
 
     XCTAssertEqual(metadata.elementCount, 6000) // 10 * 20 * 30
@@ -117,7 +118,8 @@ final class SafeTensorsReaderTests: XCTestCase {
       dtype: .float32,
       shape: [],
       dataOffset: 0,
-      byteCount: 4
+      byteCount: 4,
+      rawDType: "F32"
     )
 
     XCTAssertEqual(metadata.elementCount, 1) // Empty product is 1
@@ -129,7 +131,8 @@ final class SafeTensorsReaderTests: XCTestCase {
       dtype: .float16,
       shape: [256],
       dataOffset: 100,
-      byteCount: 256 * 2
+      byteCount: 256 * 2,
+      rawDType: "F16"
     )
 
     XCTAssertEqual(metadata.name, "vector")


### PR DESCRIPTION
## Summary

- Adds `CivitAICheckpoint` module for detecting and loading CivitAI-format `.safetensors` checkpoints containing only transformer weights (no text encoder, no VAE)
- Extends `SafeTensorsReader` with FP8 dtype support (`F8_E4M3`, `F8_E4M3FN`, `F8_E5M2`) and `rawDType` field for original dtype preservation
- Integrates CivitAI loading path into `ZImagePipeline`, `ModelPool`, and `WarmServer` -- transformer from checkpoint, text encoder + VAE from HuggingFace snapshot
- Auto-detects Base vs Turbo variant from guidance embedder key presence + filename heuristics

## Changes

| File | Change |
|------|--------|
| `Sources/ZImage/Weights/CivitAICheckpoint.swift` | **New** -- inspect, detectVariant, loadTransformerWeights, FP8 decode |
| `Sources/ZImage/Weights/SafeTensorsReader.swift` | FP8 dtype mapping, rawDType field |
| `Sources/ZImage/Pipeline/ZImagePipeline.swift` | ModelSelection + resolveLocalSafetensors + loadModel CivitAI path |
| `Sources/ZImage/Server/ModelPool.swift` | Single-file .safetensors detection in detectFamily |
| `Sources/ZImage/Server/WarmServer.swift` | CivitAI variant detection for generation defaults |
| `Sources/ZImage/Weights/ModelPaths.swift` | Filename heuristics (dpo=Turbo, wild=Base) |
| `Tests/ZImageTests/Weights/CivitAICheckpointTests.swift` | **New** -- detection, variant, FP8 dtype, filename heuristic tests |
| `Tests/ZImageTests/Weights/SafeTensorsReaderTests.swift` | Updated for rawDType parameter |

## Design Notes

- Reuses existing `canonicalizeTransformerOverride()` -- no key transform logic was duplicated
- CivitAI checkpoints are distinguished from AIO by absence of `text_encoders.*` and `vae.*` keys
- Variant detection: `model.diffusion_model.guidance_in.mlp.0.weight` present = Base, absent = Turbo
- FP8 decode via bit-level reconstruction (sign/exponent/mantissa), with MLX native support as future upgrade path

## Test Plan

- [x] Release build passes (`swift build -c release`)
- [ ] Unit tests pass (blocked by pre-existing Metal library environment issue on this Mac -- affects all MLX-dependent tests including existing `AIOCheckpointTests`)
- [ ] Smoke test: `./ZImageCLI serve -m /Volumes/Bolt/Models/moody-wild-mix/moody-wild-v4-fp16-full.safetensors --port 7871`
- [ ] Verify LoRA stacking works on CivitAI-loaded model
- [ ] Test `load_model` MCP tool with CivitAI checkpoint path

Closes #139