### PR TITLE
fix: CivitAI Base checkpoint loads correct model config (#138)

### DIFF
--- a/Sources/ZImage/Pipeline/ZImagePipeline.swift
+++ b/Sources/ZImage/Pipeline/ZImagePipeline.swift
@@ -454,7 +454,14 @@ public final class ZImagePipeline {
       if civitaiInspection.isCivitAI {
         let variant = civitaiInspection.variant ?? .turbo
         logger.info("Detected CivitAI checkpoint: \(url.lastPathComponent) (variant=\(variant.rawValue), keys=\(civitaiInspection.keyCount))")
-        return .init(baseModelSpec: nil, transformerOverrideURL: nil, aioCheckpointURL: nil, aioTextEncoderPrefix: nil, civitaiCheckpointURL: url, civitaiVariant: variant)
+        // Use the correct base model for the detected variant so that the
+        // transformer config (nRefinerLayers, etc.) matches the checkpoint
+        // architecture.  Without this, a Base CivitAI checkpoint defaults
+        // to the Turbo snapshot config, creating a transformer without
+        // noise_refiner / context_refiner blocks.  That mismatch causes
+        // crashes during subsequent LoRA swap operations (#138).
+        let baseSpec = variant == .base ? ZImageRepository.baseId : ZImageRepository.id
+        return .init(baseModelSpec: baseSpec, transformerOverrideURL: nil, aioCheckpointURL: nil, aioTextEncoderPrefix: nil, civitaiCheckpointURL: url, civitaiVariant: variant)
       }
     }
 
@@ -527,7 +534,16 @@ public final class ZImagePipeline {
     civitaiVariant: ZImageVariant? = nil,
     progressHandler: ProgressHandler? = nil
   ) async throws {
-    let modelId = modelSpec ?? ZImageRepository.id
+    // When loading a CivitAI Base checkpoint, ensure the snapshot comes from
+    // the Base model repo so the transformer config has nRefinerLayers > 0.
+    let modelId: String
+    if let modelSpec {
+      modelId = modelSpec
+    } else if civitaiCheckpointURL != nil, civitaiVariant == .base {
+      modelId = ZImageRepository.baseId
+    } else {
+      modelId = ZImageRepository.id
+    }
     let normalizedAIOPath = aioCheckpointURL?.standardizedFileURL.path
     let currentAIOPath = activeAIOCheckpointURL?.standardizedFileURL.path
     let hasLoadedComponents = tokenizer != nil && textEncoder != nil && transformer != nil && vae != nil && modelConfigs != nil && modelSnapshot != nil

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1225,7 +1225,7 @@ private actor WarmServerCoordinator {
 
   private let configuration: WarmServerConfiguration
   private let logger: Logger
-  private let pipeline: ZImagePipeline
+  private var pipeline: ZImagePipeline
   /// Flux 2 pipeline — created when the model is detected as Flux 2 Klein.
   private var flux2Pipeline: Flux2Pipeline?
   /// FIBO pipeline — created when the model is detected as FIBO.
@@ -1548,12 +1548,10 @@ private actor WarmServerCoordinator {
       flux2Pipeline = entry.box.pipeline as? Flux2Pipeline
       detectedFlux2Model = entry.detectedInfo as? Flux2DetectedModel
     case .flux1:
-      // The ZImagePipeline is stored in the pool box; the coordinator's
-      // `pipeline` property is still the original one created at init.
-      // For pool-loaded flux1 models, we use the box pipeline directly.
+      // Reassign the pipeline so that runSwap and runFlux1Generate
+      // operate on the pool-loaded pipeline, not the original one (#138).
       if let poolZImage = entry.box.pipeline as? ZImagePipeline {
-        // Cannot reassign let pipeline, but pool-based flux1 will go through pool path.
-        _ = poolZImage
+        pipeline = poolZImage
       }
       zimageVariant = (entry.detectedInfo as? ZImageVariant) ?? .turbo
     }


### PR DESCRIPTION
## Summary
- CivitAI Base checkpoints were resolving to the Turbo HuggingFace config (nRefinerLayers=0), causing the transformer to be built without noise_refiner/context_refiner blocks. The ~252 extra Base weights were silently discarded, and subsequent LoRA swaps crashed.
- Fixed `resolveLocalSafetensors` to use `ZImageRepository.baseId` when CivitAI variant is `.base`
- Added defense-in-depth fallback in `loadModel` for nil modelSpec with Base variant
- Fixed pipeline reassignment in `poolActivate` so pool-loaded models are actually used

## Test plan
- [ ] Load Moody Wild V4 FP16 checkpoint on warm server
- [ ] Verify variant detected as Base (not Turbo)
- [ ] Swap LoRAs while Base checkpoint is active — should not crash
- [ ] Generate image with Base + LoRA to verify quality

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)