### PR TITLE
feat(mcp): add SeedVR2 upscale tool

### DIFF
--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -54,6 +54,12 @@ public final class MCPToolExecutor: @unchecked Sendable {
         return try await executeGet("/v1/model/pool")
       case "unload_model":
         return try await executeUnloadModel(arguments)
+      case "generate_video":
+        return try await executeGenerateVideo(arguments)
+      case "video_status":
+        return try await executeVideoStatus(arguments)
+      case "upscale":
+        return try await executeUpscale(arguments)
       default:
         return MCPToolResult(error: "Unknown tool: \(name)")
       }
@@ -379,6 +385,35 @@ public final class MCPToolExecutor: @unchecked Sendable {
     }
 
     let (status, data) = try await client.get("/v1/video/status/\(jobId)")
+    return mapHTTPResponse(status: status, data: data)
+  }
+
+  /// upscale -> POST /v1/upscale
+  private func executeUpscale(_ params: MCPParams?) async throws -> MCPToolResult {
+    guard let imagePath = params?.string("image_path"), !imagePath.isEmpty else {
+      return MCPToolResult(error: "Error: 'image_path' is required")
+    }
+
+    var body: [String: Any] = ["image_path": imagePath]
+
+    if let targetResolution = params?.integer("target_resolution") {
+      body["target_resolution"] = targetResolution
+    }
+    if let seed = params?.integer("seed") {
+      body["seed"] = seed
+    }
+    if let softness = params?.number("softness") {
+      body["softness"] = softness
+    }
+    if let outputPath = params?.string("output_path") {
+      body["output_path"] = outputPath
+    }
+    if let model = params?.string("model") {
+      body["model"] = model
+    }
+
+    let jsonData = try JSONSerialization.data(withJSONObject: body)
+    let (status, data) = try await client.post("/v1/upscale", body: jsonData)
     return mapHTTPResponse(status: status, data: data)
   }
 

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -31,6 +31,7 @@ public enum MCPToolRegistry {
     unloadModel,
     generateVideo,
     videoStatus,
+    upscale,
   ]
 
   // MARK: - Tool Definitions
@@ -348,6 +349,7 @@ public enum MCPToolRegistry {
   )
 
 
+
   // MARK: - Video Tools
 
   static let generateVideo = MCPToolDefinition(
@@ -401,6 +403,44 @@ public enum MCPToolRegistry {
         ] as [String: Any],
       ] as [String: Any],
       "required": ["job_id"] as [String],
+    ] as [String: Any]
+  )
+
+  // MARK: - Upscale Tool
+
+  static let upscale = MCPToolDefinition(
+    name: "upscale",
+    description: "Upscale an image using the SeedVR2 super-resolution pipeline. Accepts a file path and returns the upscaled output file path. Default target resolution is 1024px (safe). 2048px is experimental and may OOM.",
+    inputSchema: [
+      "type": "object",
+      "properties": [
+        "image_path": [
+          "type": "string",
+          "description": "Absolute path to the input image file to upscale.",
+        ] as [String: Any],
+        "target_resolution": [
+          "type": "integer",
+          "description": "Target resolution in pixels for the long edge. Default: 1024. Values above 1024 are experimental and may cause OOM errors.",
+        ] as [String: Any],
+        "seed": [
+          "type": "integer",
+          "description": "Random seed for reproducibility. Omit for random.",
+        ] as [String: Any],
+        "softness": [
+          "type": "number",
+          "description": "Softness factor (0.0-1.0). Higher values produce softer results. Default: 0.0.",
+        ] as [String: Any],
+        "output_path": [
+          "type": "string",
+          "description": "Output file path. Omit to auto-generate from input filename with '-upscaled' suffix.",
+        ] as [String: Any],
+        "model": [
+          "type": "string",
+          "description": "SeedVR2 variant: 'seedvr2-3b' (default, ~7GB) or 'seedvr2-7b' (~16GB). Auto-detected from available weights.",
+          "enum": ["seedvr2-3b", "seedvr2-7b"],
+        ] as [String: Any],
+      ] as [String: Any],
+      "required": ["image_path"] as [String],
     ] as [String: Any]
   )
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -4,6 +4,8 @@ import Logging
 import Network
 import Darwin
 import MLX
+import CoreGraphics
+import ImageIO
 
 public struct WarmServerConfiguration: Sendable {
   public var port: UInt16
@@ -718,10 +720,21 @@ public final class WarmServer {
         return .error(.error(status: 500, message: "Failed to encode job status"))
       }
 
+    // MARK: - Upscale Endpoint
+
+    case ("POST", "/v1/upscale"):
+      do {
+        let payload = try decode(UpscalePayload.self, from: request.body)
+        let result = try await handleUpscale(payload)
+        return .json(status: 200, payload: result)
+      } catch {
+        return .error(response(for: error))
+      }
+
     default:
       if ["/v1/generate", "/v1/lora/swap", "/v1/shutdown", "/health",
           "/v1/model/load", "/v1/model/activate", "/v1/model/pool", "/v1/model/unload",
-          "/v1/loras", "/v1/loras/scan", "/v1/video/generate"
+          "/v1/loras", "/v1/loras/scan", "/v1/video/generate", "/v1/upscale"
       ].contains(request.path) || request.path.hasPrefix("/v1/loras/")
          || request.path.hasPrefix("/v1/video/status/") {
         return .error(.error(status: 405, message: "Method not allowed"))
@@ -1145,6 +1158,122 @@ public final class WarmServer {
     }
   }
 
+  // MARK: - Upscale Handler
+
+  /// Handle a direct upscale request via the REST API.
+  /// Lazy-loads the SeedVR2 pipeline on first call.
+  private func handleUpscale(_ payload: UpscalePayload) async throws -> UpscaleResponse {
+    guard let weightsPath = seedvr2WeightsPath else {
+      throw WarmServerError.invalidRequest(
+        message: "SeedVR2 upscale not available: no weights path configured"
+      )
+    }
+
+    // Validate input file exists
+    guard FileManager.default.fileExists(atPath: payload.imagePath) else {
+      throw WarmServerError.invalidRequest(
+        message: "Input image not found: \(payload.imagePath)"
+      )
+    }
+
+    let targetResolution = payload.targetResolution ?? 1024
+    let softness = payload.softness ?? 0.0
+
+    // Resolution guard
+    if let error = UpscalePayload.validateResolution(targetResolution) {
+      throw WarmServerError.invalidRequest(message: error)
+    }
+
+    // Validate softness range
+    if let error = UpscalePayload.validateSoftness(softness) {
+      throw WarmServerError.invalidRequest(message: error)
+    }
+
+    // Model variant validation
+    if let error = UpscalePayload.validateModel(payload.model) {
+      throw WarmServerError.invalidRequest(message: error)
+    }
+
+    // Lazy-load pipeline
+    if seedvr2Pipeline == nil {
+      logger.info("WarmServer: lazy-loading SeedVR2 pipeline from \(weightsPath)...")
+      let pipeline = try SeedVR2Pipeline(weightsPath: weightsPath, logger: logger)
+      seedvr2Pipeline = pipeline
+      logger.info("WarmServer: SeedVR2 pipeline ready (\(pipeline.modelConfig == .preset7B ? "7B" : "3B"))")
+    }
+
+    guard let pipeline = seedvr2Pipeline else {
+      throw WarmServerError.invalidRequest(
+        message: "SeedVR2 pipeline failed to initialize"
+      )
+    }
+
+    // Check model variant matches request
+    if let requestedModel = payload.model {
+      let is7B = pipeline.modelConfig == .preset7B
+      let requested7B = requestedModel == "seedvr2-7b"
+      if is7B != requested7B {
+        let loaded = is7B ? "seedvr2-7b" : "seedvr2-3b"
+        throw WarmServerError.invalidRequest(
+          message: "Requested \(requestedModel) but loaded weights are \(loaded)"
+        )
+      }
+    }
+
+    // Build warning for experimental resolutions
+    let warning = UpscalePayload.resolutionWarning(for: targetResolution)
+
+    let start = Date()
+
+    // Resolve output path
+    let resolvedOutputPath: String?
+    if let op = payload.outputPath {
+      resolvedOutputPath = try WarmServerOutputPathValidator
+        .resolveOutputPath(op, allowedOutputDirectory: configuration.allowedOutputDirectory)
+        .path
+    } else {
+      resolvedOutputPath = nil
+    }
+
+    let outputPath = try pipeline.upscaleAndSave(
+      imagePath: payload.imagePath,
+      outputPath: resolvedOutputPath,
+      targetResolution: targetResolution,
+      seed: payload.seed,
+      softness: softness
+    )
+
+    let durationMs = Int(Date().timeIntervalSince(start) * 1000.0)
+    let modelName = pipeline.modelConfig == .preset7B ? "seedvr2-7b" : "seedvr2-3b"
+
+    // Read output image dimensions for the response
+    let outputResolution = readImageDimensions(at: outputPath)
+    let inputResolution = readImageDimensions(at: payload.imagePath)
+
+    return UpscaleResponse(
+      success: true,
+      outputPath: outputPath,
+      durationMs: durationMs,
+      inputResolution: inputResolution,
+      outputResolution: outputResolution,
+      model: modelName,
+      warning: warning
+    )
+  }
+
+  /// Read image dimensions as "WxH" string. Returns "unknown" on failure.
+  private func readImageDimensions(at path: String) -> String {
+    guard let source = CGImageSourceCreateWithURL(
+      URL(fileURLWithPath: path) as CFURL, nil
+    ),
+    let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+    let width = properties[kCGImagePropertyPixelWidth] as? Int,
+    let height = properties[kCGImagePropertyPixelHeight] as? Int else {
+      return "unknown"
+    }
+    return "\(width)x\(height)"
+  }
+
   fileprivate func requestShutdownAfterResponse() {
     initiateShutdown()
   }
@@ -1200,7 +1329,7 @@ public final class WarmServer {
       switch error {
       case .loraSwapNotSupported, .controlNetNotSupported:
         return .error(status: 400, message: error.localizedDescription ?? error.localizedDescription)
-      case .invalidOutputPath:
+      case .invalidOutputPath, .invalidRequest:
         return .error(status: 400, message: error.localizedDescription ?? error.localizedDescription)
       case .flux2NotLoaded, .flux2DetectionFailed, .fiboNotLoaded, .fiboDetectionFailed,
            .chromaNotLoaded, .chromaDetectionFailed:
@@ -2748,6 +2877,59 @@ private struct GenerateResponse: Encodable, Sendable {
   let durationMs: Int
 }
 
+// MARK: - Upscale Payload & Response
+
+struct UpscalePayload: Decodable, Sendable {
+  let imagePath: String
+  let targetResolution: Int?
+  let seed: Int?
+  let softness: Float?
+  let outputPath: String?
+  let model: String?   // "seedvr2-3b" or "seedvr2-7b"
+
+  /// Validate target resolution. Returns an error message if invalid, nil if valid.
+  static func validateResolution(_ resolution: Int) -> String? {
+    guard resolution >= 256 && resolution <= 2048 else {
+      return "target_resolution must be between 256 and 2048"
+    }
+    return nil
+  }
+
+  /// Validate softness. Returns an error message if invalid, nil if valid.
+  static func validateSoftness(_ softness: Float) -> String? {
+    guard softness >= 0.0 && softness <= 1.0 else {
+      return "softness must be between 0.0 and 1.0"
+    }
+    return nil
+  }
+
+  /// Validate model variant. Returns an error message if invalid, nil if valid.
+  static func validateModel(_ model: String?) -> String? {
+    guard let model = model else { return nil }
+    guard model == "seedvr2-3b" || model == "seedvr2-7b" else {
+      return "Invalid model: '\(model)'. Must be 'seedvr2-3b' or 'seedvr2-7b'."
+    }
+    return nil
+  }
+
+  /// Return a warning string if resolution is experimental (>1024), nil otherwise.
+  static func resolutionWarning(for resolution: Int) -> String? {
+    resolution > 1024
+      ? "target_resolution \(resolution) is experimental and may cause OOM errors. Safe maximum is 1024."
+      : nil
+  }
+}
+
+struct UpscaleResponse: Encodable, Sendable {
+  let success: Bool
+  let outputPath: String
+  let durationMs: Int
+  let inputResolution: String     // e.g. "512x512"
+  let outputResolution: String    // e.g. "1024x1024"
+  let model: String               // "seedvr2-3b" or "seedvr2-7b"
+  let warning: String?            // non-nil if target_resolution > 1024
+}
+
 private struct LoRASwapPayload: Decodable, Sendable {
   let loras: [LoRAEntry]
 
@@ -2876,6 +3058,7 @@ private final class SyncResult<Value> {
 public enum WarmServerError: Error, LocalizedError {
   case invalidPort(UInt16)
   case invalidOutputPath(path: String, allowedDirectory: String)
+  case invalidRequest(message: String)
   case flux2DetectionFailed(String)
   case flux2NotLoaded
   case fiboDetectionFailed(String)
@@ -2891,6 +3074,8 @@ public enum WarmServerError: Error, LocalizedError {
       return "Invalid server port: \(port)"
     case .invalidOutputPath(let path, let allowedDirectory):
       return "Output path '\(path)' must be under allowed output directory '\(allowedDirectory)'"
+    case .invalidRequest(let message):
+      return message
     case .flux2DetectionFailed(let model):
       return "Model '\(model)' was identified as Flux 2 but detection failed at the snapshot directory"
     case .flux2NotLoaded:

--- a/Tests/ZImageTests/MCP/MCPUpscaleToolTests.swift
+++ b/Tests/ZImageTests/MCP/MCPUpscaleToolTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import ZImage
+
+/// Tests for the MCP `upscale` tool: registry, executor, payload decoding, and validation.
+/// Phase 1 — Stories 1, 2, 4.
+final class MCPUpscaleToolTests: XCTestCase {
+
+  // MARK: - Tool Registration (Story 1)
+
+  func testUpscaleToolRegistered() {
+    let tool = MCPToolRegistry.tool(named: "upscale")
+    XCTAssertNotNil(tool, "upscale tool should be registered in MCPToolRegistry")
+  }
+
+  func testUpscaleToolInToolsList() {
+    let names = MCPToolRegistry.tools.map(\.name)
+    XCTAssertTrue(names.contains("upscale"), "tools array should contain 'upscale'")
+  }
+
+  func testUpscaleToolHasRequiredImagePath() {
+    let tool = MCPToolRegistry.tool(named: "upscale")!
+    let required = tool.inputSchema["required"] as? [String]
+    XCTAssertEqual(required, ["image_path"])
+  }
+
+  func testUpscaleToolSchemaHasAllProperties() {
+    let tool = MCPToolRegistry.tool(named: "upscale")!
+    let properties = tool.inputSchema["properties"] as? [String: Any]
+    XCTAssertNotNil(properties)
+    let expectedKeys = ["image_path", "target_resolution", "seed", "softness", "output_path", "model"]
+    for key in expectedKeys {
+      XCTAssertNotNil(properties?[key], "Schema should contain property '\(key)'")
+    }
+  }
+
+  // MARK: - Executor: Missing image_path (Story 1)
+
+  func testExecuteUpscaleMissingImagePathReturnsError() async {
+    let client = WarmServerClient(host: "127.0.0.1", port: 19999)
+    let executor = MCPToolExecutor(client: client)
+
+    let result = await executor.execute(name: "upscale", arguments: nil)
+    XCTAssertTrue(result.isError)
+    XCTAssertTrue(result.content.first?.text?.contains("image_path") == true)
+  }
+
+  func testExecuteUpscaleEmptyImagePathReturnsError() async {
+    let client = WarmServerClient(host: "127.0.0.1", port: 19999)
+    let executor = MCPToolExecutor(client: client)
+
+    let params = MCPParams(["image_path": AnyCodable("")])
+    let result = await executor.execute(name: "upscale", arguments: params)
+    XCTAssertTrue(result.isError)
+    XCTAssertTrue(result.content.first?.text?.contains("image_path") == true)
+  }
+
+  // MARK: - UpscalePayload Decoding (Story 1)
+
+  func testUpscalePayloadDecodesMinimalJSON() throws {
+    let json = Data("""
+    {"image_path": "/tmp/test.png"}
+    """.utf8)
+
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let payload = try decoder.decode(UpscalePayload.self, from: json)
+
+    XCTAssertEqual(payload.imagePath, "/tmp/test.png")
+    XCTAssertNil(payload.targetResolution)
+    XCTAssertNil(payload.seed)
+    XCTAssertNil(payload.softness)
+    XCTAssertNil(payload.outputPath)
+    XCTAssertNil(payload.model)
+  }
+
+  func testUpscalePayloadDecodesFullJSON() throws {
+    let json = Data("""
+    {
+      "image_path": "/tmp/input.png",
+      "target_resolution": 2048,
+      "seed": 42,
+      "softness": 0.5,
+      "output_path": "/tmp/output.png",
+      "model": "seedvr2-7b"
+    }
+    """.utf8)
+
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let payload = try decoder.decode(UpscalePayload.self, from: json)
+
+    XCTAssertEqual(payload.imagePath, "/tmp/input.png")
+    XCTAssertEqual(payload.targetResolution, 2048)
+    XCTAssertEqual(payload.seed, 42)
+    XCTAssertEqual(payload.softness, 0.5)
+    XCTAssertEqual(payload.outputPath, "/tmp/output.png")
+    XCTAssertEqual(payload.model, "seedvr2-7b")
+  }
+
+  func testUpscalePayloadPreservesHighResValue() throws {
+    let json = Data("""
+    {"image_path": "/tmp/test.png", "target_resolution": 2048}
+    """.utf8)
+
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let payload = try decoder.decode(UpscalePayload.self, from: json)
+
+    XCTAssertEqual(payload.targetResolution, 2048)
+  }
+
+  // MARK: - Resolution Validation (Story 4)
+
+  func testResolutionRejectBelow256() {
+    let error = UpscalePayload.validateResolution(128)
+    XCTAssertNotNil(error, "Resolution 128 should be rejected")
+    XCTAssertTrue(error!.contains("256"))
+    XCTAssertTrue(error!.contains("2048"))
+  }
+
+  func testResolutionRejectAbove2048() {
+    let error = UpscalePayload.validateResolution(4096)
+    XCTAssertNotNil(error, "Resolution 4096 should be rejected")
+  }
+
+  func testResolutionAccept256() {
+    let error = UpscalePayload.validateResolution(256)
+    XCTAssertNil(error, "Resolution 256 should be accepted")
+  }
+
+  func testResolutionAccept1024() {
+    let error = UpscalePayload.validateResolution(1024)
+    XCTAssertNil(error, "Resolution 1024 should be accepted")
+  }
+
+  func testResolutionAccept2048() {
+    let error = UpscalePayload.validateResolution(2048)
+    XCTAssertNil(error, "Resolution 2048 should be accepted (experimental)")
+  }
+
+  func testResolutionAcceptMiddleRange() {
+    let error = UpscalePayload.validateResolution(512)
+    XCTAssertNil(error, "Resolution 512 should be accepted")
+  }
+
+  // MARK: - Softness Validation (Story 4)
+
+  func testSoftnessRejectNegative() {
+    let error = UpscalePayload.validateSoftness(-0.1)
+    XCTAssertNotNil(error, "Softness -0.1 should be rejected")
+  }
+
+  func testSoftnessRejectAboveOne() {
+    let error = UpscalePayload.validateSoftness(1.5)
+    XCTAssertNotNil(error, "Softness 1.5 should be rejected")
+  }
+
+  func testSoftnessAcceptZero() {
+    let error = UpscalePayload.validateSoftness(0.0)
+    XCTAssertNil(error, "Softness 0.0 should be accepted")
+  }
+
+  func testSoftnessAcceptOne() {
+    let error = UpscalePayload.validateSoftness(1.0)
+    XCTAssertNil(error, "Softness 1.0 should be accepted")
+  }
+
+  func testSoftnessAcceptMiddle() {
+    let error = UpscalePayload.validateSoftness(0.5)
+    XCTAssertNil(error, "Softness 0.5 should be accepted")
+  }
+
+  // MARK: - Resolution Warning (Story 4)
+
+  func testWarningForResolutionAbove1024() {
+    let warning = UpscalePayload.resolutionWarning(for: 1025)
+    XCTAssertNotNil(warning)
+    XCTAssertTrue(warning!.contains("experimental"))
+    XCTAssertTrue(warning!.contains("OOM"))
+  }
+
+  func testNoWarningForResolution1024() {
+    let warning = UpscalePayload.resolutionWarning(for: 1024)
+    XCTAssertNil(warning)
+  }
+
+  func testNoWarningForResolution512() {
+    let warning = UpscalePayload.resolutionWarning(for: 512)
+    XCTAssertNil(warning)
+  }
+
+  // MARK: - Model Variant Validation (Story 2)
+
+  func testModelValidationAcceptsSeedvr23b() {
+    let error = UpscalePayload.validateModel("seedvr2-3b")
+    XCTAssertNil(error)
+  }
+
+  func testModelValidationAcceptsSeedvr27b() {
+    let error = UpscalePayload.validateModel("seedvr2-7b")
+    XCTAssertNil(error)
+  }
+
+  func testModelValidationAcceptsNil() {
+    let error = UpscalePayload.validateModel(nil)
+    XCTAssertNil(error)
+  }
+
+  func testModelValidationRejectsInvalid() {
+    let error = UpscalePayload.validateModel("esrgan")
+    XCTAssertNotNil(error)
+    XCTAssertTrue(error!.contains("esrgan"))
+    XCTAssertTrue(error!.contains("seedvr2-3b"))
+    XCTAssertTrue(error!.contains("seedvr2-7b"))
+  }
+
+  // MARK: - UpscaleResponse Encoding
+
+  func testUpscaleResponseEncodesCorrectly() throws {
+    let response = UpscaleResponse(
+      success: true,
+      outputPath: "/tmp/output.png",
+      durationMs: 5000,
+      inputResolution: "512x512",
+      outputResolution: "1024x1024",
+      model: "seedvr2-3b",
+      warning: nil
+    )
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(response)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    XCTAssertEqual(json["success"] as? Bool, true)
+    XCTAssertEqual(json["output_path"] as? String, "/tmp/output.png")
+    XCTAssertEqual(json["duration_ms"] as? Int, 5000)
+    XCTAssertEqual(json["input_resolution"] as? String, "512x512")
+    XCTAssertEqual(json["output_resolution"] as? String, "1024x1024")
+    XCTAssertEqual(json["model"] as? String, "seedvr2-3b")
+  }
+
+  func testUpscaleResponseEncodesWarning() throws {
+    let response = UpscaleResponse(
+      success: true,
+      outputPath: "/tmp/output.png",
+      durationMs: 90000,
+      inputResolution: "512x512",
+      outputResolution: "2048x2048",
+      model: "seedvr2-3b",
+      warning: "target_resolution 2048 is experimental and may cause OOM errors. Safe maximum is 1024."
+    )
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(response)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    XCTAssertNotNil(json["warning"])
+    XCTAssertEqual(json["warning"] as? String,
+      "target_resolution 2048 is experimental and may cause OOM errors. Safe maximum is 1024.")
+  }
+}


### PR DESCRIPTION
## Summary
- Adds MCP tool #19: `upscale` for SeedVR2 super-resolution
- New `POST /v1/upscale` WarmServer endpoint with full validation
- Parameters: image_path (required), target_resolution (default 1024), seed, softness, output_path, model variant (3b/7b)
- Resolution guard: default 1024px safe, 2048px experimental with warning
- Model variant validation against loaded weights
- 29 unit tests covering registration, validation, encoding

## Test plan
- [ ] Build on Mac: `swift build`
- [ ] Run tests: `swift test --filter MCPUpscaleToolTests`
- [ ] Manual: `curl -X POST localhost:7862/v1/upscale -d '{"image_path":"/tmp/test.png"}'`
- [ ] Verify tool appears in MCP `tools/list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)