### PR TITLE
feat(bridge): P0 Krita gaps — ObjectInfo completeness + sampler mapping

### DIFF
--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -230,6 +230,14 @@ enum ComfyBridgeObjectInfo {
       ],
       outputs: ["LATENT"]
     )
+    info["EmptyLatentImage"] = nodeDefinition(
+      required: [
+        "width": intInput(default: 1024),
+        "height": intInput(default: 1024),
+        "batch_size": intInput(default: 1),
+      ],
+      outputs: ["LATENT"]
+    )
     info["SamplerCustomAdvanced"] = nodeDefinition(
       required: [
         "noise": noiseInput(),

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -2888,6 +2888,10 @@ extension GeneratePayload: Decodable {
     switch rawValue {
     case "res_2s":
       return .res2s
+    case "dpmpp_2m":
+      return .dpmplusplus2m
+    case "dpmpp_2s_ancestral":
+      return .dpmplusplus2sa
     default:
       return SchedulerKind(rawValue: rawValue) ?? .euler
     }
@@ -2898,6 +2902,9 @@ extension GeneratePayload: Decodable {
     switch rawValue {
     case "beta57":
       return .beta57
+    case "normal", "simple", "sgm_uniform", "ddim_uniform":
+      // ComfyUI schedule names that map to the model's native flow-matching schedule.
+      return .flow
     default:
       return SigmaScheduleKind(rawValue: rawValue) ?? .flow
     }


### PR DESCRIPTION
## Summary

- Add `EmptyLatentImage` node declaration to ObjectInfo — the workflow parser already handles it (line 184) but Krita's `_check_for_missing_nodes` validation needs it in `/object_info`
- Fix `parseSchedulerKind` to map ComfyUI sampler names (`dpmpp_2m` -> `.dpmplusplus2m`, `dpmpp_2s_ancestral` -> `.dpmplusplus2sa`) — these were falling through to `.euler` because ComfyUI uses underscores while the Swift enum uses dashes
- Fix `parseSigmaScheduleKind` to explicitly map ComfyUI schedule names (`normal`, `simple`, `sgm_uniform`, `ddim_uniform`) to `.flow` for clarity

## What was already done

Most P0 gaps from the Krita bridge gap analysis were already addressed in PR #78 and subsequent work:
- `ImageCrop`, `PreviewImage`, `KSampler`, `KSamplerAdvanced`, `SplitSigmas` already in ObjectInfo
- `res_2s` already in KSamplerSelect options
- `sampler` and `sigmaSchedule` fields already on `ComfyBridgeGenerateRequest`
- Sampler/schedule extraction from workflow nodes already implemented
- Pass-through to `GeneratePayload` already wired

## Test plan

- [ ] Verify `swift build` compiles cleanly on Mac
- [ ] Connect Krita AI Diffusion and confirm `/object_info` includes `EmptyLatentImage`
- [ ] Test DPM++ 2M sampler selection in Krita reaches the correct scheduler
- [ ] Test DPM++ 2S Ancestral sampler selection reaches correct scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)