### PR TITLE
feat(bridge): CyberRealistic V5 checkpoint support

### DIFF
--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
@@ -344,6 +344,21 @@ public enum ComfyBoxModelRegistry {
       description: "CivitAI Z-Image checkpoint. Realistic style, undistilled. 40 steps, CFG 4.0."
     ),
 
+    ComfyBoxModel(
+      id: "cyberrealistic-v5",
+      family: .zImage, variant: .turbo, quantization: .none,
+      huggingFaceId: "",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 8, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 12.5,
+      displayName: "CyberRealistic V5",
+      description: "CivitAI Z-Image Turbo fine-tune. Enhanced photorealism and NSFW. Apache 2.0 license."
+    ),
+
+
     // ─── SeedVR2 Family ──────────────────────────────────────────────
     // 3B upscaler — 2× resolution enhancement.
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -583,6 +583,35 @@ enum ComfyBridgeObjectInfo {
     requiredOrder: [String]? = nil,
     optional: [String: Any] = [:],
     optionalOrder: [String]? = nil,
+    outputs: [String],
+    outputNames: [String]? = nil
+  ) -> [String: Any] {
+    let orderedRequired: Any
+    if let order = requiredOrder {
+      orderedRequired = OrderedDict(order.compactMap { key in
+        required[key].map { (key, $0) }
+      })
+    } else {
+      orderedRequired = required
+    }
+
+    let orderedOptional: Any?
+    if !optional.isEmpty {
+      if let order = optionalOrder {
+        orderedOptional = OrderedDict(order.compactMap { key in
+          optional[key].map { (key, $0) }
+        })
+      } else {
+        orderedOptional = optional
+      }
+    } else {
+      orderedOptional = nil
+    }
+
+    var input: [String: Any] = ["required": orderedRequired]
+    if let opt = orderedOptional {
+      input["optional"] = opt
+    }
     let names = outputNames ?? outputs
     return [
       "name": "",

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -781,6 +781,7 @@ enum ComfyBridgeObjectInfo {
       "moody-wild-v4-distilled",
       "moody-wild-v4-fp8",
       "moody-real-v6",
+      "cyberrealistic-v5",
     ]
   }
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1437,6 +1437,7 @@ public final class WarmServer {
       "moody-wild-v4-distilled": "~/Models-working/moody-wild-mix/moody-wild-v4-distilled-10step-fp16.safetensors",
       "moody-wild-v4-fp8": "~/Models-working/moody-wild-mix/moody-wild-v4-fp8.safetensors",
       "moody-real-v6": "~/Models-working/moody-real-v6/moody-real-v6.safetensors",
+      "cyberrealistic-v5": "~/Models-working/cyberrealistic-z-image/cyberrealisticZImage_v50.safetensors",
     ]
     if let path = civitaiPaths[modelId] {
       return NSString(string: path).expandingTildeInPath

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -459,10 +459,14 @@ public final class WarmServer {
         let shouldActivate = payload.activate ?? true
         let shouldWait = payload.wait ?? true
 
+        // Resolve CivitAI model IDs (e.g. 'cyberrealistic-v5') to file paths
+        let resolvedSpec = Self.parseModelSpec(from: payload.model)
+        let resolvedQuantization = payload.quantization ?? Self.parseQuantization(from: payload.model)
+
         if shouldWait {
           let result = try await coordinator.poolLoad(
-            modelSpec: payload.model,
-            quantization: payload.quantization,
+            modelSpec: resolvedSpec,
+            quantization: resolvedQuantization,
             activate: shouldActivate
           )
           return .json(status: 200, payload: result)
@@ -471,8 +475,8 @@ public final class WarmServer {
           Task {
             do {
               try await coordinator.poolLoad(
-                modelSpec: payload.model,
-                quantization: payload.quantization,
+                modelSpec: resolvedSpec,
+                quantization: resolvedQuantization,
                 activate: shouldActivate
               )
             } catch {

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1966,7 +1966,7 @@ private actor WarmServerCoordinator {
     // Cancel all pending continuations with an error.
     for op in pending {
       switch op {
-      case .generate(_, let cont, _):
+      case .generate(_, let cont, _, _):
         cont.resume(throwing: ServerError.shuttingDown)
       case .controlGenerate(_, let cont):
         cont.resume(throwing: ServerError.shuttingDown)


### PR DESCRIPTION
## Summary
- Register CyberRealistic V5 (cyberrealistic-z-image) in model registry, object info, and warm server path mapping
- Fix broken nodeDefinition() and clearPending tuple from merge commit fe065f3
- Resolve CivitAI model IDs in /v1/model/load API endpoint (parseModelSpec + parseQuantization)

## Test plan
- [x] CyberRealistic loads via pool API
- [x] Generates clean images with euler + flow schedule (8 steps, ~50s)
- [x] 19 models visible in /object_info checkpoint list
- [ ] Krita checkpoint picker shows cyberrealistic-v5
- [ ] Daemon generate_image routes to CyberRealistic when loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)