### PR TITLE
fix(lora): restore LoRA swap — deadlock, path resolution, queue hang prevention

### DIFF
--- a/Sources/ZImage/LoRA/LoRAWeightLoader.swift
+++ b/Sources/ZImage/LoRA/LoRAWeightLoader.swift
@@ -25,7 +25,14 @@ public final class LoRAWeightLoader {
 
     public static func load(from config: LoRAConfiguration) async throws -> LoRAWeights {
         let url = try await resolveSource(config.source)
-        return try load(from: url)
+        // Use a detached task to avoid Swift concurrency deadlock:
+        // When called from an actor-isolated method, the synchronous
+        // load(from: url) can block the cooperative pool and prevent
+        // the actor from resuming. A detached task runs independently.
+        let weights = try await Task.detached(priority: .userInitiated) {
+            try load(from: url)
+        }.value
+        return weights
     }
 
     public static func load(from url: URL) throws -> LoRAWeights {

--- a/Sources/ZImage/MCP/MCPToolExecutor.swift
+++ b/Sources/ZImage/MCP/MCPToolExecutor.swift
@@ -171,7 +171,7 @@ public final class MCPToolExecutor: @unchecked Sendable {
     let result: [String: Any] = [
       "loras": options,
       "count": options.count,
-      "directory": "~/bin/zimage/loras",
+      "directory": "~/Models/loras",
     ]
     let resultData = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
     return MCPToolResult(text: String(data: resultData, encoding: .utf8) ?? "{}")

--- a/Sources/ZImage/MCP/MCPToolRegistry.swift
+++ b/Sources/ZImage/MCP/MCPToolRegistry.swift
@@ -109,7 +109,7 @@ public enum MCPToolRegistry {
             "properties": [
               "path": [
                 "type": "string",
-                "description": "Path to .safetensors file, or HuggingFace model ID. Bare filenames resolve to ~/bin/zimage/loras/.",
+                "description": "Path to .safetensors file, or HuggingFace model ID. Bare filenames resolve to ~/Models/loras/.",
               ] as [String: Any],
               "scale": [
                 "type": "number",
@@ -171,7 +171,7 @@ public enum MCPToolRegistry {
 
   static let listLoras = MCPToolDefinition(
     name: "list_loras",
-    description: "List LoRA files available in the LoRA directory (~/bin/zimage/loras/). Returns filenames that can be passed to swap_loras.",
+    description: "List LoRA files available in the LoRA directory (~/Models/loras/). Returns filenames that can be passed to swap_loras.",
     inputSchema: [
       "type": "object",
       "properties": [:] as [String: Any],

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
@@ -346,7 +346,7 @@ public enum ComfyBoxModelRegistry {
 
     ComfyBoxModel(
       id: "cyberrealistic-v5",
-      family: .zImage, variant: .turbo, quantization: .none,
+      family: .zImage, variant: .base, quantization: .none,
       huggingFaceId: "",
       parametersBillions: 6.0, latentChannels: 128,
       defaultSteps: 8, defaultGuidance: 1.0,

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeModelRegistry.swift
@@ -344,6 +344,21 @@ public enum ComfyBoxModelRegistry {
       description: "CivitAI Z-Image checkpoint. Realistic style, undistilled. 40 steps, CFG 4.0."
     ),
 
+    ComfyBoxModel(
+      id: "cyberrealistic-v5",
+      family: .zImage, variant: .turbo, quantization: .none,
+      huggingFaceId: "",
+      parametersBillions: 6.0, latentChannels: 128,
+      defaultSteps: 8, defaultGuidance: 1.0,
+      supportsGuidance: false, supportsLoRA: true,
+      supportsControlNet: true, supportsImg2Img: true,
+      defaultWidth: 1024, defaultHeight: 1024,
+      estimatedVRAM_GB: 12.5,
+      displayName: "CyberRealistic V5",
+      description: "CivitAI Z-Image Turbo fine-tune. Enhanced photorealism and NSFW. Apache 2.0 license."
+    ),
+
+
     // ─── SeedVR2 Family ──────────────────────────────────────────────
     // 3B upscaler — 2× resolution enhancement.
 

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -583,6 +583,35 @@ enum ComfyBridgeObjectInfo {
     requiredOrder: [String]? = nil,
     optional: [String: Any] = [:],
     optionalOrder: [String]? = nil,
+    outputs: [String],
+    outputNames: [String]? = nil
+  ) -> [String: Any] {
+    let orderedRequired: Any
+    if let order = requiredOrder {
+      orderedRequired = OrderedDict(order.compactMap { key in
+        required[key].map { (key, $0) }
+      })
+    } else {
+      orderedRequired = required
+    }
+
+    let orderedOptional: Any?
+    if !optional.isEmpty {
+      if let order = optionalOrder {
+        orderedOptional = OrderedDict(order.compactMap { key in
+          optional[key].map { (key, $0) }
+        })
+      } else {
+        orderedOptional = optional
+      }
+    } else {
+      orderedOptional = nil
+    }
+
+    var input: [String: Any] = ["required": orderedRequired]
+    if let opt = orderedOptional {
+      input["optional"] = opt
+    }
     let names = outputNames ?? outputs
     return [
       "name": "",

--- a/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
+++ b/Sources/ZImage/Server/ComfyBridge/ComfyBridgeObjectInfo.swift
@@ -781,6 +781,7 @@ enum ComfyBridgeObjectInfo {
       "moody-wild-v4-distilled",
       "moody-wild-v4-fp8",
       "moody-real-v6",
+      "cyberrealistic-v5",
     ]
   }
 

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1437,6 +1437,7 @@ public final class WarmServer {
       "moody-wild-v4-distilled": "~/Models-working/moody-wild-mix/moody-wild-v4-distilled-10step-fp16.safetensors",
       "moody-wild-v4-fp8": "~/Models-working/moody-wild-mix/moody-wild-v4-fp8.safetensors",
       "moody-real-v6": "~/Models-working/moody-real-v6/moody-real-v6.safetensors",
+      "cyberrealistic-v5": "~/Models-working/cyberrealistic-z-image/cyberrealisticZImage_v50.safetensors",
     ]
     if let path = civitaiPaths[modelId] {
       return NSString(string: path).expandingTildeInPath

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1932,7 +1932,7 @@ private actor WarmServerCoordinator {
 
     return HealthResponse(
       status: shuttingDown ? "shutting_down" : (activeAgeMs.map { $0 > Self.renderStaleThresholdMs } ?? false ? "render_stale" : "ok"),
-      model: configuration.modelSpec ?? ZImageRepository.id,
+      model: activePoolModelSpec ?? configuration.modelSpec ?? ZImageRepository.id,
       modelFamily: currentModelFamily.rawValue,
       modelVariant: currentModelFamily == .fibo ? "fibo" : (currentModelFamily == .flux1 ? zimageVariant.rawValue : detectedFlux2Model?.variant),
       textEncoderPath: configuration.textEncoderPath,
@@ -2036,6 +2036,18 @@ private actor WarmServerCoordinator {
     activeRenderStartedAt = Date()
     let start = Date()
 
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runFlux1Generate: continuation was not resumed — resuming with error.")
+        failedRenderCount += 1
+        lastError = "Flux1 generation failed unexpectedly (continuation not resumed)"
+        activeRenderStartedAt = nil
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "Flux1 generation failed unexpectedly"))
+      }
+    }
+
     // When a pool model is active, override configuration.modelSpec so
     // that generateCore loads/validates the pool model, not the startup model.
     let effectiveConfig: WarmServerConfiguration
@@ -2068,6 +2080,7 @@ private actor WarmServerCoordinator {
       lastError = nil
       activeRenderStartedAt = nil
 
+      resumed = true
       continuation.resume(
         returning: GenerateResponse(
           success: true,
@@ -2079,6 +2092,7 @@ private actor WarmServerCoordinator {
       failedRenderCount += 1
       lastError = error.localizedDescription
       activeRenderStartedAt = nil
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -2086,6 +2100,18 @@ private actor WarmServerCoordinator {
   private func runFlux2Generate(_ payload: GeneratePayload, continuation: ContinuationBox<GenerateResponse>) async {
     activeRenderStartedAt = Date()
     let start = Date()
+
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runFlux2Generate: continuation was not resumed — resuming with error.")
+        failedRenderCount += 1
+        lastError = "Flux2 generation failed unexpectedly (continuation not resumed)"
+        activeRenderStartedAt = nil
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "Flux2 generation failed unexpectedly"))
+      }
+    }
 
     do {
       guard let f2 = flux2Pipeline else {
@@ -2149,6 +2175,7 @@ private actor WarmServerCoordinator {
       lastError = nil
       activeRenderStartedAt = nil
 
+      resumed = true
       continuation.resume(
         returning: GenerateResponse(
           success: true,
@@ -2160,6 +2187,7 @@ private actor WarmServerCoordinator {
       failedRenderCount += 1
       lastError = error.localizedDescription
       activeRenderStartedAt = nil
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -2167,6 +2195,18 @@ private actor WarmServerCoordinator {
   private func runFiboGenerate(_ payload: GeneratePayload, continuation: ContinuationBox<GenerateResponse>) async {
     activeRenderStartedAt = Date()
     let start = Date()
+
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runFiboGenerate: continuation was not resumed — resuming with error.")
+        failedRenderCount += 1
+        lastError = "FIBO generation failed unexpectedly (continuation not resumed)"
+        activeRenderStartedAt = nil
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "FIBO generation failed unexpectedly"))
+      }
+    }
 
     do {
       guard let fp = fiboPipeline else {
@@ -2200,6 +2240,7 @@ private actor WarmServerCoordinator {
       lastError = nil
       activeRenderStartedAt = nil
 
+      resumed = true
       continuation.resume(
         returning: GenerateResponse(
           success: true,
@@ -2211,6 +2252,7 @@ private actor WarmServerCoordinator {
       failedRenderCount += 1
       lastError = error.localizedDescription
       activeRenderStartedAt = nil
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -2218,6 +2260,18 @@ private actor WarmServerCoordinator {
   private func runChromaGenerate(_ payload: GeneratePayload, continuation: ContinuationBox<GenerateResponse>) async {
     activeRenderStartedAt = Date()
     let start = Date()
+
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runChromaGenerate: continuation was not resumed — resuming with error.")
+        failedRenderCount += 1
+        lastError = "Chroma generation failed unexpectedly (continuation not resumed)"
+        activeRenderStartedAt = nil
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "Chroma generation failed unexpectedly"))
+      }
+    }
 
     do {
       guard let pipeline = chromaPipeline else {
@@ -2279,6 +2333,7 @@ private actor WarmServerCoordinator {
       lastError = nil
       activeRenderStartedAt = nil
 
+      resumed = true
       continuation.resume(
         returning: GenerateResponse(
           success: true,
@@ -2290,6 +2345,7 @@ private actor WarmServerCoordinator {
       failedRenderCount += 1
       lastError = error.localizedDescription
       activeRenderStartedAt = nil
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -2302,6 +2358,18 @@ private actor WarmServerCoordinator {
 
     activeRenderStartedAt = Date()
     let start = Date()
+
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runControlGenerate: continuation was not resumed — resuming with error.")
+        failedRenderCount += 1
+        lastError = "ControlNet generation failed unexpectedly (continuation not resumed)"
+        activeRenderStartedAt = nil
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "ControlNet generation failed unexpectedly"))
+      }
+    }
 
     do {
       // Lazy-init the control pipeline on first ControlNet request
@@ -2317,6 +2385,7 @@ private actor WarmServerCoordinator {
       lastError = nil
       activeRenderStartedAt = nil
 
+      resumed = true
       continuation.resume(
         returning: GenerateResponse(
           success: true,
@@ -2328,6 +2397,7 @@ private actor WarmServerCoordinator {
       failedRenderCount += 1
       lastError = error.localizedDescription
       activeRenderStartedAt = nil
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -2338,12 +2408,28 @@ private actor WarmServerCoordinator {
       return
     }
 
+    var resumed = false
+
+    defer {
+      if !resumed {
+        logger.error("runSwap: continuation was not resumed — likely a crash in LoRA application. Resuming with error.")
+        if currentModelFamily == .flux2 {
+          activeLoRAs = flux2Pipeline?.loadedLoRAConfigs ?? []
+        } else {
+          activeLoRAs = pipeline.loadedLoRAConfigs
+        }
+        lastError = "LoRA swap failed unexpectedly (continuation not resumed)"
+        continuation.resume(throwing: WarmServerError.invalidRequest(message: "LoRA swap failed unexpectedly"))
+      }
+    }
+
     do {
       let newLoRAs = try payload.makeConfigurations()
 
       if currentModelFamily == .flux2 {
         // Flux 2 LoRA swap via Flux2Pipeline.loadLoRAs()
         guard let f2 = flux2Pipeline else {
+          resumed = true
           continuation.resume(throwing: WarmServerError.flux2NotLoaded)
           return
         }
@@ -2356,6 +2442,7 @@ private actor WarmServerCoordinator {
       }
 
       lastError = nil
+      resumed = true
       continuation.resume(
         returning: LoRASwapResponse(
           success: true,
@@ -2370,6 +2457,7 @@ private actor WarmServerCoordinator {
         activeLoRAs = pipeline.loadedLoRAConfigs
       }
       lastError = error.localizedDescription
+      resumed = true
       continuation.resume(throwing: error)
     }
   }
@@ -3044,9 +3132,26 @@ private struct LoRAEntry: Codable, Sendable {
 
   func makeConfiguration() throws -> LoRAConfiguration {
     let expanded = (path as NSString).expandingTildeInPath
-    if path.hasPrefix("/") || path.hasPrefix("./") || path.hasPrefix("../") || path.hasPrefix("~") || FileManager.default.fileExists(atPath: expanded) {
+
+    // Direct path (absolute, relative, tilde-expanded)
+    if path.hasPrefix("/") || path.hasPrefix("./") || path.hasPrefix("../") || path.hasPrefix("~")
+       || FileManager.default.fileExists(atPath: expanded) {
       return .local(expanded, scale: scale ?? 1.0)
     }
+
+    // Library resolution: search the LoRA library root for the filename
+    let libraryRoot = ("~/Models/loras" as NSString).expandingTildeInPath
+    let fm = FileManager.default
+    if let enumerator = fm.enumerator(at: URL(fileURLWithPath: libraryRoot),
+                                       includingPropertiesForKeys: [.isRegularFileKey]) {
+      for case let fileURL as URL in enumerator {
+        if fileURL.lastPathComponent == path {
+          return .local(fileURL.path, scale: scale ?? 1.0)
+        }
+      }
+    }
+
+    // HuggingFace fallback
     return .huggingFace(path, scale: scale ?? 1.0)
   }
 }

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -459,10 +459,14 @@ public final class WarmServer {
         let shouldActivate = payload.activate ?? true
         let shouldWait = payload.wait ?? true
 
+        // Resolve CivitAI model IDs (e.g. 'cyberrealistic-v5') to file paths
+        let resolvedSpec = Self.parseModelSpec(from: payload.model)
+        let resolvedQuantization = payload.quantization ?? Self.parseQuantization(from: payload.model)
+
         if shouldWait {
           let result = try await coordinator.poolLoad(
-            modelSpec: payload.model,
-            quantization: payload.quantization,
+            modelSpec: resolvedSpec,
+            quantization: resolvedQuantization,
             activate: shouldActivate
           )
           return .json(status: 200, payload: result)
@@ -471,8 +475,8 @@ public final class WarmServer {
           Task {
             do {
               try await coordinator.poolLoad(
-                modelSpec: payload.model,
-                quantization: payload.quantization,
+                modelSpec: resolvedSpec,
+                quantization: resolvedQuantization,
                 activate: shouldActivate
               )
             } catch {

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -1966,7 +1966,7 @@ private actor WarmServerCoordinator {
     // Cancel all pending continuations with an error.
     for op in pending {
       switch op {
-      case .generate(_, let cont, _):
+      case .generate(_, let cont, _, _):
         cont.resume(throwing: ServerError.shuttingDown)
       case .controlGenerate(_, let cont):
         cont.resume(throwing: ServerError.shuttingDown)


### PR DESCRIPTION
## Summary

Fixes 4 interrelated bugs that made LoRA swap completely non-functional:

- **Deadlock fix** — `LoRAWeightLoader.load()` ran synchronous mmap I/O inside the Swift cooperative thread pool, starving the actor. Moved to `Task.detached(priority: .userInitiated)` to break the deadlock.
- **Queue hang prevention** — Added `defer` guard to all 6 continuation methods. Unresumed continuations now fail gracefully instead of hanging the queue forever.
- **Path resolution** — Bare LoRA filenames from MCP tools fell through to HuggingFace download. Now searches `~/Models/loras/` recursively before the fallback.
- **Health + metadata accuracy** — Health endpoint reports pool active model instead of startup default. `list_loras` reports actual filesystem paths. CyberRealistic V5 registered as `.base` matching its actual architecture.

## Test Results

- CyberRealistic V5 + DeeDee LoRA at 0.2 and 0.4 weight: renders successfully ✅
- CyberRealistic prompt-only (no LoRA): renders successfully ✅
- Invalid LoRA path: returns error immediately, queue stays healthy ✅
- A/B comparison (6 renders, 2 seeds × 3 configs) delivered and verified

## Files Changed (6 files, +173/-11)

| File | Change |
|------|--------|
| `LoRAWeightLoader.swift` | `Task.detached` for weight loading |
| `WarmServer.swift` | defer guards on 6 continuations, health endpoint pool awareness, LoRA path search |
| `ComfyBridgeModelRegistry.swift` | CyberRealistic variant `.turbo` → `.base` |
| `MCPToolExecutor.swift` | `list_loras` path correction |
| `MCPToolRegistry.swift` | Tool description updates |

## Specs

- PRD: `Coffee Shop/Specs/2026-06-04-comfybox-lora-swap-fix-prd.md`
- FDD: `Coffee Shop/Specs/2026-06-04-comfybox-lora-swap-fix-fdd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)