### PR TITLE
feat(desktop): ComfyBoxDesktop SwiftUI app — Phase 1 skeleton

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
   platforms: [.macOS(.v14), .iOS(.v16)],
   products: [
     .library(name: "ZImage", targets: ["ZImage"]),
-    .executable(name: "ComfyBox", targets: ["ComfyBox"])
+    .executable(name: "ComfyBox", targets: ["ComfyBox"]),
+    .executable(name: "ComfyBoxDesktop", targets: ["ComfyBoxDesktop"])
   ],
   dependencies: [
     .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.29.1")),
@@ -34,6 +35,11 @@ let package = Package(
       name: "ComfyBox",
       dependencies: ["ZImage"],
       path: "Sources/ComfyBox"
+    ),
+    .executableTarget(
+      name: "ComfyBoxDesktop",
+      dependencies: ["ZImage"],
+      path: "Sources/ComfyBoxDesktop"
     ),
     .testTarget(
       name: "ZImageTests",

--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -1,0 +1,94 @@
+// ComfyBoxDesktopApp.swift — SwiftUI app entry point
+//
+// Main application for ComfyBox Desktop. Creates the EngineService
+// on launch and provides the primary window with a tabbed interface
+// for generation and gallery views.
+
+import SwiftUI
+
+@main
+struct ComfyBoxDesktopApp: App {
+    @State private var engine = EngineService()
+    @State private var selectedTab: AppTab = .generate
+
+    enum AppTab: String, CaseIterable {
+        case generate = "Generate"
+        case gallery = "Gallery"
+
+        var icon: String {
+            switch self {
+            case .generate: return "wand.and.stars"
+            case .gallery: return "photo.on.rectangle"
+            }
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationSplitView {
+                List(AppTab.allCases, id: \.self, selection: $selectedTab) { tab in
+                    Label(tab.rawValue, systemImage: tab.icon)
+                }
+                .navigationSplitViewColumnWidth(min: 140, ideal: 160, max: 200)
+            } detail: {
+                switch selectedTab {
+                case .generate:
+                    GenerationView(engine: engine)
+                case .gallery:
+                    GalleryView()
+                }
+            }
+            .navigationTitle("ComfyBox Desktop")
+            .frame(minWidth: 900, minHeight: 600)
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    connectionButton
+                }
+            }
+        }
+        .defaultSize(width: 1200, height: 800)
+
+        Settings {
+            SettingsView(engine: engine)
+        }
+    }
+
+    private var connectionButton: some View {
+        Button(action: {
+            if engine.connectionState.isConnected {
+                engine.disconnect()
+            } else {
+                engine.connect()
+            }
+        }) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(engine.connectionState.isConnected ? .green : .gray)
+                    .frame(width: 8, height: 8)
+                Text(engine.connectionState.isConnected ? "Connected" : "Connect")
+                    .font(.caption)
+            }
+        }
+    }
+}
+
+// MARK: - Settings View
+
+struct SettingsView: View {
+    @Bindable var engine: EngineService
+
+    var body: some View {
+        Form {
+            Section("Server Connection") {
+                TextField("Host", text: $engine.serverHost)
+                TextField("Port", value: $engine.serverPort, format: .number)
+            }
+
+            Section("Output") {
+                TextField("Output Directory", text: $engine.outputDirectory)
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 400, height: 200)
+    }
+}

--- a/Sources/ComfyBoxDesktop/DAM/DAMAsset.swift
+++ b/Sources/ComfyBoxDesktop/DAM/DAMAsset.swift
@@ -1,0 +1,80 @@
+// DAMAsset.swift — Digital Asset Management model
+//
+// Core data model for tracked image/video assets. Each generated image
+// is recorded in the DAM database with its generation parameters,
+// file metadata, and user annotations (rating, favorite, content mode).
+
+import Foundation
+
+public struct DAMAsset: Identifiable, Sendable {
+    public let id: String
+    public let kind: String  // "image" or "video"
+    public let filename: String
+    public let absolutePath: String
+    public let fileSize: Int64
+    public let sha256: String?
+    public let width: Int?
+    public let height: Int?
+    public let createdAt: Date
+    public let modifiedAt: Date
+    public let ingestedAt: Date
+    public let orphaned: Bool
+    public let prompt: String?
+    public let negativePrompt: String?
+    public let seed: Int?
+    public let steps: Int?
+    public let guidance: Double?
+    public let modelFamily: String?
+    public let rating: Int
+    public let favorite: Bool
+    public let contentMode: String?
+    public let characterName: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        kind: String = "image",
+        filename: String,
+        absolutePath: String,
+        fileSize: Int64 = 0,
+        sha256: String? = nil,
+        width: Int? = nil,
+        height: Int? = nil,
+        createdAt: Date = Date(),
+        modifiedAt: Date = Date(),
+        ingestedAt: Date = Date(),
+        orphaned: Bool = false,
+        prompt: String? = nil,
+        negativePrompt: String? = nil,
+        seed: Int? = nil,
+        steps: Int? = nil,
+        guidance: Double? = nil,
+        modelFamily: String? = nil,
+        rating: Int = 0,
+        favorite: Bool = false,
+        contentMode: String? = nil,
+        characterName: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.filename = filename
+        self.absolutePath = absolutePath
+        self.fileSize = fileSize
+        self.sha256 = sha256
+        self.width = width
+        self.height = height
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.ingestedAt = ingestedAt
+        self.orphaned = orphaned
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.seed = seed
+        self.steps = steps
+        self.guidance = guidance
+        self.modelFamily = modelFamily
+        self.rating = rating
+        self.favorite = favorite
+        self.contentMode = contentMode
+        self.characterName = characterName
+    }
+}

--- a/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
+++ b/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
@@ -1,0 +1,352 @@
+// DAMStore.swift — Digital Asset Management SQLite store
+//
+// Actor-isolated SQLite database for tracking generated assets.
+// Uses system SQLite3 framework (zero dependencies). WAL mode
+// for concurrent reads. FTS5 for full-text prompt search.
+//
+// Database location: ~/.comfybox/dam.sqlite3
+
+import Foundation
+import SQLite3
+
+public actor DAMStore {
+    private var db: OpaquePointer?
+    private let dbPath: String
+
+    private init(db: OpaquePointer, dbPath: String) {
+        self.db = db
+        self.dbPath = dbPath
+    }
+
+    /// Create and initialize a DAMStore. Opens the database, enables WAL mode,
+    /// and creates tables if they do not exist.
+    public static func open(path: String? = nil) async throws -> DAMStore {
+        let resolvedPath: String
+        if let path = path {
+            resolvedPath = path
+        } else {
+            let comfyboxDir = NSString(string: "~/.comfybox").expandingTildeInPath
+            try FileManager.default.createDirectory(
+                atPath: comfyboxDir,
+                withIntermediateDirectories: true
+            )
+            resolvedPath = (comfyboxDir as NSString).appendingPathComponent("dam.sqlite3")
+        }
+
+        var dbHandle: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let rc = sqlite3_open_v2(resolvedPath, &dbHandle, flags, nil)
+        guard rc == SQLITE_OK, let handle = dbHandle else {
+            let msg = dbHandle.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            if let h = dbHandle { sqlite3_close(h) }
+            throw DAMStoreError.openFailed(resolvedPath, msg)
+        }
+
+        let store = DAMStore(db: handle, dbPath: resolvedPath)
+        try await store.initialize()
+        return store
+    }
+
+    /// Perform post-init setup within actor isolation.
+    private func initialize() throws {
+        try execute("PRAGMA journal_mode=WAL")
+        try createTables()
+    }
+
+    deinit {
+        if let db = db {
+            sqlite3_close(db)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Insert a new asset into the database.
+    public func insertAsset(_ asset: DAMAsset) throws {
+        let sql = """
+            INSERT OR REPLACE INTO assets (
+                id, kind, filename, absolute_path, file_size, sha256,
+                width, height, created_at, modified_at, ingested_at, orphaned,
+                prompt, negative_prompt, seed, steps, guidance,
+                model_family, rating, favorite, content_mode, character_name
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6,
+                ?7, ?8, ?9, ?10, ?11, ?12,
+                ?13, ?14, ?15, ?16, ?17,
+                ?18, ?19, ?20, ?21, ?22
+            )
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, (asset.id as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 2, (asset.kind as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 3, (asset.filename as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 4, (asset.absolutePath as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(stmt, 5, sqlite3_int64(asset.fileSize))
+        bindOptionalText(stmt, 6, asset.sha256)
+        bindOptionalInt(stmt, 7, asset.width)
+        bindOptionalInt(stmt, 8, asset.height)
+        sqlite3_bind_double(stmt, 9, asset.createdAt.timeIntervalSince1970)
+        sqlite3_bind_double(stmt, 10, asset.modifiedAt.timeIntervalSince1970)
+        sqlite3_bind_double(stmt, 11, asset.ingestedAt.timeIntervalSince1970)
+        sqlite3_bind_int(stmt, 12, asset.orphaned ? 1 : 0)
+        bindOptionalText(stmt, 13, asset.prompt)
+        bindOptionalText(stmt, 14, asset.negativePrompt)
+        bindOptionalInt(stmt, 15, asset.seed)
+        bindOptionalInt(stmt, 16, asset.steps)
+        bindOptionalDouble(stmt, 17, asset.guidance)
+        bindOptionalText(stmt, 18, asset.modelFamily)
+        sqlite3_bind_int(stmt, 19, Int32(asset.rating))
+        sqlite3_bind_int(stmt, 20, asset.favorite ? 1 : 0)
+        bindOptionalText(stmt, 21, asset.contentMode)
+        bindOptionalText(stmt, 22, asset.characterName)
+
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            throw DAMStoreError.insertFailed(lastError)
+        }
+
+        // Update FTS index.
+        if let prompt = asset.prompt {
+            try insertFTS(id: asset.id, prompt: prompt, negativePrompt: asset.negativePrompt)
+        }
+    }
+
+    /// Fetch assets ordered by creation date (newest first).
+    public func fetchAssets(limit: Int = 50, offset: Int = 0) throws -> [DAMAsset] {
+        let sql = """
+            SELECT id, kind, filename, absolute_path, file_size, sha256,
+                   width, height, created_at, modified_at, ingested_at, orphaned,
+                   prompt, negative_prompt, seed, steps, guidance,
+                   model_family, rating, favorite, content_mode, character_name
+            FROM assets
+            ORDER BY created_at DESC
+            LIMIT ?1 OFFSET ?2
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_int(stmt, 1, Int32(limit))
+        sqlite3_bind_int(stmt, 2, Int32(offset))
+
+        var results: [DAMAsset] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            results.append(assetFromRow(stmt))
+        }
+        return results
+    }
+
+    /// Total number of assets in the database.
+    public func assetCount() throws -> Int {
+        let sql = "SELECT COUNT(*) FROM assets"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        guard sqlite3_step(stmt) == SQLITE_ROW else {
+            return 0
+        }
+        return Int(sqlite3_column_int64(stmt, 0))
+    }
+
+    /// Full-text search across prompts. Returns matching assets.
+    public func searchPrompts(query: String, limit: Int = 50) throws -> [DAMAsset] {
+        let sql = """
+            SELECT a.id, a.kind, a.filename, a.absolute_path, a.file_size, a.sha256,
+                   a.width, a.height, a.created_at, a.modified_at, a.ingested_at, a.orphaned,
+                   a.prompt, a.negative_prompt, a.seed, a.steps, a.guidance,
+                   a.model_family, a.rating, a.favorite, a.content_mode, a.character_name
+            FROM assets_fts fts
+            JOIN assets a ON a.id = fts.id
+            WHERE assets_fts MATCH ?1
+            ORDER BY rank
+            LIMIT ?2
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, (query as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(stmt, 2, Int32(limit))
+
+        var results: [DAMAsset] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            results.append(assetFromRow(stmt))
+        }
+        return results
+    }
+
+    // MARK: - Private
+
+    private var lastError: String {
+        db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+    }
+
+    private func execute(_ sql: String) throws {
+        var errMsg: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(db, sql, nil, nil, &errMsg)
+        if rc != SQLITE_OK {
+            let msg = errMsg.flatMap { String(cString: $0) } ?? "unknown"
+            sqlite3_free(errMsg)
+            throw DAMStoreError.execFailed(sql, msg)
+        }
+    }
+
+    private func createTables() throws {
+        try execute("""
+            CREATE TABLE IF NOT EXISTS assets (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL DEFAULT 'image',
+                filename TEXT NOT NULL,
+                absolute_path TEXT NOT NULL UNIQUE,
+                file_size INTEGER NOT NULL DEFAULT 0,
+                sha256 TEXT,
+                width INTEGER,
+                height INTEGER,
+                created_at REAL NOT NULL,
+                modified_at REAL NOT NULL,
+                ingested_at REAL NOT NULL,
+                orphaned INTEGER NOT NULL DEFAULT 0,
+                prompt TEXT,
+                negative_prompt TEXT,
+                seed INTEGER,
+                steps INTEGER,
+                guidance REAL,
+                model_family TEXT,
+                rating INTEGER NOT NULL DEFAULT 0,
+                favorite INTEGER NOT NULL DEFAULT 0,
+                content_mode TEXT,
+                character_name TEXT
+            )
+            """)
+
+        try execute("CREATE INDEX IF NOT EXISTS idx_assets_created ON assets(created_at DESC)")
+
+        // FTS5 virtual table for full-text prompt search.
+        try execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS assets_fts USING fts5(
+                id UNINDEXED,
+                prompt,
+                negative_prompt
+            )
+            """)
+    }
+
+    private func insertFTS(id: String, prompt: String, negativePrompt: String?) throws {
+        let sql = "INSERT OR REPLACE INTO assets_fts (id, prompt, negative_prompt) VALUES (?1, ?2, ?3)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            // FTS insert failure is non-fatal.
+            return
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 2, (prompt as NSString).utf8String, -1, nil)
+        bindOptionalText(stmt, 3, negativePrompt)
+        sqlite3_step(stmt)
+    }
+
+    private func assetFromRow(_ stmt: OpaquePointer?) -> DAMAsset {
+        DAMAsset(
+            id: columnText(stmt, 0) ?? "",
+            kind: columnText(stmt, 1) ?? "image",
+            filename: columnText(stmt, 2) ?? "",
+            absolutePath: columnText(stmt, 3) ?? "",
+            fileSize: sqlite3_column_int64(stmt, 4),
+            sha256: columnText(stmt, 5),
+            width: columnOptionalInt(stmt, 6),
+            height: columnOptionalInt(stmt, 7),
+            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 8)),
+            modifiedAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 9)),
+            ingestedAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 10)),
+            orphaned: sqlite3_column_int(stmt, 11) != 0,
+            prompt: columnText(stmt, 12),
+            negativePrompt: columnText(stmt, 13),
+            seed: columnOptionalInt(stmt, 14),
+            steps: columnOptionalInt(stmt, 15),
+            guidance: columnOptionalDouble(stmt, 16),
+            modelFamily: columnText(stmt, 17),
+            rating: Int(sqlite3_column_int(stmt, 18)),
+            favorite: sqlite3_column_int(stmt, 19) != 0,
+            contentMode: columnText(stmt, 20),
+            characterName: columnText(stmt, 21)
+        )
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func bindOptionalText(_ stmt: OpaquePointer?, _ index: Int32, _ value: String?) {
+        if let value = value {
+            sqlite3_bind_text(stmt, index, (value as NSString).utf8String, -1, nil)
+        } else {
+            sqlite3_bind_null(stmt, index)
+        }
+    }
+
+    private func bindOptionalInt(_ stmt: OpaquePointer?, _ index: Int32, _ value: Int?) {
+        if let value = value {
+            sqlite3_bind_int64(stmt, index, sqlite3_int64(value))
+        } else {
+            sqlite3_bind_null(stmt, index)
+        }
+    }
+
+    private func bindOptionalDouble(_ stmt: OpaquePointer?, _ index: Int32, _ value: Double?) {
+        if let value = value {
+            sqlite3_bind_double(stmt, index, value)
+        } else {
+            sqlite3_bind_null(stmt, index)
+        }
+    }
+
+    private func columnText(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
+        guard let cStr = sqlite3_column_text(stmt, index) else { return nil }
+        return String(cString: cStr)
+    }
+
+    private func columnOptionalInt(_ stmt: OpaquePointer?, _ index: Int32) -> Int? {
+        if sqlite3_column_type(stmt, index) == SQLITE_NULL { return nil }
+        return Int(sqlite3_column_int64(stmt, index))
+    }
+
+    private func columnOptionalDouble(_ stmt: OpaquePointer?, _ index: Int32) -> Double? {
+        if sqlite3_column_type(stmt, index) == SQLITE_NULL { return nil }
+        return sqlite3_column_double(stmt, index)
+    }
+}
+
+// MARK: - Errors
+
+public enum DAMStoreError: Error, LocalizedError {
+    case openFailed(String, String)
+    case prepareFailed(String)
+    case insertFailed(String)
+    case execFailed(String, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .openFailed(let path, let msg):
+            return "Failed to open database at \(path): \(msg)"
+        case .prepareFailed(let msg):
+            return "SQL prepare failed: \(msg)"
+        case .insertFailed(let msg):
+            return "Insert failed: \(msg)"
+        case .execFailed(let sql, let msg):
+            return "SQL exec failed (\(sql)): \(msg)"
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/EngineService.swift
+++ b/Sources/ComfyBoxDesktop/EngineService.swift
@@ -1,0 +1,265 @@
+// EngineService.swift — SwiftUI-reactive wrapper for WarmServer
+//
+// Observable class that communicates with the WarmServer via its HTTP API
+// using WarmServerClient from the ZImage library. The server itself runs
+// as a separate process (the ComfyBox CLI); this service connects to it
+// as an HTTP client.
+
+import Foundation
+import SwiftUI
+import ZImage
+
+/// Generation parameters submitted to the server.
+public struct GenerationRequest: Sendable {
+    public var prompt: String
+    public var width: Int
+    public var height: Int
+    public var steps: Int
+    public var guidance: Float
+    public var seed: UInt64  // 0 = random
+
+    public init(
+        prompt: String = "",
+        width: Int = 1024,
+        height: Int = 1024,
+        steps: Int = 9,
+        guidance: Float = 3.5,
+        seed: UInt64 = 0
+    ) {
+        self.prompt = prompt
+        self.width = width
+        self.height = height
+        self.steps = steps
+        self.guidance = guidance
+        self.seed = seed
+    }
+}
+
+/// Decoded generation response from the server.
+private struct ServerGenerateResponse: Decodable {
+    let success: Bool
+    let outputPath: String
+    let durationMs: Int
+}
+
+/// Decoded health response from the server.
+private struct ServerHealthResponse: Decodable {
+    let status: String
+    let model: String?
+    let queuePending: Int?
+    let queueActive: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case model
+        case queuePending = "queue_pending"
+        case queueActive = "queue_active"
+    }
+}
+
+/// Connection status to the WarmServer.
+public enum ServerConnectionState: Sendable {
+    case disconnected
+    case connecting
+    case connected
+    case error(String)
+
+    public var label: String {
+        switch self {
+        case .disconnected: return "Disconnected"
+        case .connecting: return "Connecting..."
+        case .connected: return "Connected"
+        case .error(let msg): return "Error: \(msg)"
+        }
+    }
+
+    public var isConnected: Bool {
+        if case .connected = self { return true }
+        return false
+    }
+}
+
+@Observable
+public final class EngineService {
+    // MARK: - Published State
+
+    public var connectionState: ServerConnectionState = .disconnected
+    public var currentModel: String?
+    public var queueCount: Int = 0
+    public var isGenerating: Bool = false
+    public var lastGeneratedImagePath: String?
+    public var lastError: String?
+    public var lastDurationMs: Int?
+
+    // MARK: - Configuration
+
+    public var serverHost: String = "127.0.0.1"
+    public var serverPort: UInt16 = 7862
+    public var outputDirectory: String = NSString(string: "~/Pictures/ComfyBox").expandingTildeInPath
+
+    // MARK: - Private
+
+    private var client: WarmServerClient?
+    private var healthPollTask: Task<Void, Never>?
+
+    public init() {}
+
+    deinit {
+        healthPollTask?.cancel()
+    }
+
+    // MARK: - Connection Management
+
+    /// Connect to an already-running WarmServer instance.
+    public func connect() {
+        connectionState = .connecting
+        lastError = nil
+
+        let newClient = WarmServerClient(host: serverHost, port: serverPort)
+        self.client = newClient
+
+        // Start polling health to verify connection and track state.
+        healthPollTask?.cancel()
+        healthPollTask = Task { [weak self] in
+            // Initial connection check.
+            await self?.pollHealth()
+            // Poll every 3 seconds.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(3))
+                if Task.isCancelled { break }
+                await self?.pollHealth()
+            }
+        }
+    }
+
+    /// Disconnect from the server (stops polling, does NOT shut down the server).
+    public func disconnect() {
+        healthPollTask?.cancel()
+        healthPollTask = nil
+        client = nil
+        connectionState = .disconnected
+        currentModel = nil
+        queueCount = 0
+    }
+
+    // MARK: - Generation
+
+    /// Submit a generation request to the server. Returns the output file path on success.
+    @discardableResult
+    public func generate(_ request: GenerationRequest) async throws -> String {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+        guard !request.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw EngineServiceError.emptyPrompt
+        }
+
+        isGenerating = true
+        lastError = nil
+
+        defer { isGenerating = false }
+
+        // Build the output path.
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let outputFilename = "comfybox-\(timestamp).png"
+
+        // Ensure output directory exists.
+        try FileManager.default.createDirectory(
+            atPath: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        let outputPath = (outputDirectory as NSString).appendingPathComponent(outputFilename)
+
+        // Build JSON payload matching the server API GeneratePayload.
+        var payloadDict: [String: Any] = [
+            "prompt": request.prompt,
+            "width": request.width,
+            "height": request.height,
+            "steps": request.steps,
+            "guidance": request.guidance,
+            "outputPath": outputPath
+        ]
+
+        if request.seed > 0 {
+            payloadDict["seed"] = request.seed
+        }
+
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/generate", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage: String
+            if let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+               let msg = json["error"] as? String {
+                errorMessage = msg
+            } else {
+                errorMessage = "Server returned status \(status)"
+            }
+            lastError = errorMessage
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(ServerGenerateResponse.self, from: responseData)
+
+        guard response.success else {
+            let msg = "Generation reported failure"
+            lastError = msg
+            throw EngineServiceError.generationFailed(msg)
+        }
+
+        lastGeneratedImagePath = response.outputPath
+        lastDurationMs = response.durationMs
+        return response.outputPath
+    }
+
+    // MARK: - Health Polling
+
+    private func pollHealth() async {
+        guard let client = client else {
+            connectionState = .disconnected
+            return
+        }
+
+        do {
+            let (status, data) = try await client.get("/health")
+            guard status == 200 else {
+                connectionState = .error("Server returned \(status)")
+                return
+            }
+
+            let decoder = JSONDecoder()
+            let health = try decoder.decode(ServerHealthResponse.self, from: data)
+
+            connectionState = .connected
+            currentModel = health.model
+            queueCount = (health.queuePending ?? 0) + (health.queueActive ?? 0)
+        } catch is WarmServerClientError {
+            connectionState = .disconnected
+        } catch {
+            connectionState = .error(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum EngineServiceError: Error, LocalizedError {
+    case notConnected
+    case emptyPrompt
+    case serverError(Int, String)
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            return "Not connected to WarmServer. Start ComfyBox or click Connect."
+        case .emptyPrompt:
+            return "Prompt cannot be empty"
+        case .serverError(let status, let msg):
+            return "Server error (\(status)): \(msg)"
+        case .generationFailed(let msg):
+            return "Generation failed: \(msg)"
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/GalleryView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GalleryView.swift
@@ -1,0 +1,32 @@
+// GalleryView.swift — Asset gallery placeholder
+//
+// Phase 2 will implement a full gallery view with grid layout,
+// filtering, search, and metadata display. For now, shows a
+// placeholder message.
+
+import SwiftUI
+
+struct GalleryView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 64))
+                .foregroundStyle(.tertiary)
+
+            Text("Gallery")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+
+            Text("Coming in Phase 2")
+                .font(.body)
+                .foregroundStyle(.tertiary)
+
+            Text("The gallery will display all generated assets with search, filtering, rating, and metadata.")
+                .font(.caption)
+                .foregroundStyle(.quaternary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 300)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/GenerationView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GenerationView.swift
@@ -1,0 +1,307 @@
+// GenerationView.swift — Main image generation interface
+//
+// Provides prompt entry, parameter controls, generation button,
+// and image preview. Communicates with the WarmServer through
+// EngineService.
+
+import SwiftUI
+
+/// Common resolution presets.
+struct ResolutionPreset: Identifiable, Hashable {
+    let id: String
+    let width: Int
+    let height: Int
+    var label: String { "\(width) x \(height)" }
+
+    static let presets: [ResolutionPreset] = [
+        ResolutionPreset(id: "512sq", width: 512, height: 512),
+        ResolutionPreset(id: "768p", width: 768, height: 1024),
+        ResolutionPreset(id: "1024sq", width: 1024, height: 1024),
+        ResolutionPreset(id: "1024l", width: 1024, height: 768),
+    ]
+}
+
+struct GenerationView: View {
+    @Bindable var engine: EngineService
+
+    // Generation parameters
+    @State private var prompt: String = ""
+    @State private var selectedResolution: ResolutionPreset = ResolutionPreset.presets[2]
+    @State private var steps: Double = 9
+    @State private var guidance: Double = 3.5
+    @State private var seedText: String = ""
+    @State private var displayedImage: NSImage?
+
+    var body: some View {
+        HSplitView {
+            // Left panel: Controls
+            controlPanel
+                .frame(minWidth: 320, maxWidth: 400)
+
+            // Right panel: Image preview
+            previewPanel
+                .frame(minWidth: 400)
+        }
+    }
+
+    // MARK: - Control Panel
+
+    private var controlPanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // Server status bar
+                serverStatusBar
+
+                Divider()
+
+                // Prompt
+                promptSection
+
+                Divider()
+
+                // Parameters
+                parameterSection
+
+                Divider()
+
+                // Generate button
+                generateButton
+
+                // Error display
+                if let error = engine.lastError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal)
+                }
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+
+    private var serverStatusBar: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+
+            Text(engine.connectionState.label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if let model = engine.currentModel {
+                Text(model)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            if engine.queueCount > 0 {
+                Text("Queue: \(engine.queueCount)")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var statusColor: Color {
+        switch engine.connectionState {
+        case .connected: return .green
+        case .connecting: return .yellow
+        case .disconnected: return .gray
+        case .error: return .red
+        }
+    }
+
+    private var promptSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Prompt")
+                .font(.headline)
+
+            TextEditor(text: $prompt)
+                .font(.body)
+                .frame(minHeight: 80, maxHeight: 160)
+                .scrollContentBackground(.hidden)
+                .padding(6)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+        }
+    }
+
+    private var parameterSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Parameters")
+                .font(.headline)
+
+            // Resolution picker
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Resolution")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Picker("Resolution", selection: $selectedResolution) {
+                    ForEach(ResolutionPreset.presets) { preset in
+                        Text(preset.label).tag(preset)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+
+            // Steps slider
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Steps")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(Int(steps))")
+                        .font(.subheadline)
+                        .monospacedDigit()
+                }
+
+                Slider(value: $steps, in: 1...50, step: 1)
+            }
+
+            // Guidance slider
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Guidance")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(String(format: "%.1f", guidance))
+                        .font(.subheadline)
+                        .monospacedDigit()
+                }
+
+                Slider(value: $guidance, in: 0...20, step: 0.5)
+            }
+
+            // Seed field
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Seed (empty = random)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                TextField("Random", text: $seedText)
+                    .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+
+    private var generateButton: some View {
+        Button(action: { submitGeneration() }) {
+            HStack {
+                if engine.isGenerating {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.trailing, 4)
+                    Text("Generating...")
+                } else {
+                    Image(systemName: "wand.and.stars")
+                    Text("Generate")
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!canGenerate)
+        .keyboardShortcut(.return, modifiers: .command)
+    }
+
+    private var canGenerate: Bool {
+        engine.connectionState.isConnected
+            && !engine.isGenerating
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Preview Panel
+
+    private var previewPanel: some View {
+        VStack {
+            if engine.isGenerating {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Generating image...")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let image = displayedImage {
+                VStack {
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .padding()
+
+                    if let duration = engine.lastDurationMs {
+                        Text("Rendered in \(duration)ms")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.bottom, 8)
+                    }
+                }
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.tertiary)
+                    Text("Generated images will appear here")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    // MARK: - Actions
+
+    private func submitGeneration() {
+        let seed: UInt64
+        if let parsed = UInt64(seedText), parsed > 0 {
+            seed = parsed
+        } else {
+            seed = 0
+        }
+
+        let request = GenerationRequest(
+            prompt: prompt,
+            width: selectedResolution.width,
+            height: selectedResolution.height,
+            steps: Int(steps),
+            guidance: Float(guidance),
+            seed: seed
+        )
+
+        Task {
+            do {
+                let outputPath = try await engine.generate(request)
+                // Load the generated image for display.
+                if let image = NSImage(contentsOfFile: outputPath) {
+                    await MainActor.run {
+                        displayedImage = image
+                    }
+                }
+            } catch {
+                // Error is already stored in engine.lastError
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds new `ComfyBoxDesktop` SPM executable target sharing the `ZImage` library with the existing CLI
- SwiftUI app with NavigationSplitView (Generate + Gallery tabs), connects to running WarmServer via HTTP API
- EngineService wraps `WarmServerClient` with `@Observable` for SwiftUI reactivity (health polling, generation submission)
- GenerationView provides full generation UI: multi-line prompt editor, resolution presets (512/768/1024), steps/guidance sliders, seed field, image preview with render duration
- DAMStore: actor-isolated SQLite database (`~/.comfybox/dam.sqlite3`) with WAL mode and FTS5 full-text prompt search
- DAMAsset: Sendable model for tracked assets with generation metadata
- GalleryView placeholder for Phase 2
- Settings window for server host/port/output directory configuration
- Zero external dependencies, macOS 14+, zero warnings

## Architecture

```
ComfyBoxDesktop (SwiftUI app)
    |
    +-- EngineService (@Observable)
    |       |
    |       +-- WarmServerClient (HTTP)
    |               |
    |               +-- WarmServer (separate process, ComfyBox CLI)
    |
    +-- DAMStore (actor, SQLite3)
    +-- Views/GenerationView
    +-- Views/GalleryView (placeholder)
```

## Test plan

- [ ] `swift build --target ComfyBoxDesktop` compiles with zero errors and zero warnings
- [ ] `swift build --target ComfyBox` still compiles (no regressions to existing CLI)
- [ ] App launches and shows NavigationSplitView with Generate/Gallery sidebar
- [ ] Connect button establishes connection to running WarmServer (health poll every 3s)
- [ ] Status bar shows connection state, model name, queue count
- [ ] Generate button submits prompt and displays result image
- [ ] Settings window allows changing host/port/output directory
- [ ] DAMStore creates `~/.comfybox/dam.sqlite3` with correct schema

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>