### PR TITLE
feat(desktop): Phase 3 — model management, LoRA picker, queue panel, settings

### DIFF
--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -3,7 +3,7 @@
 // Main application for ComfyBox Desktop. Creates the EngineService,
 // DAMStore, and AssetIngestor on launch. Provides a tabbed interface
 // for generation and gallery views. Generation output is automatically
-// ingested into the DAM.
+// ingested into the DAM. Settings persist via DesktopSettings.
 
 import SwiftUI
 
@@ -73,6 +73,7 @@ struct ComfyBoxDesktopApp: App {
                 }
             }
             .task {
+                applySettings()
                 await initializeDAM()
             }
         }
@@ -112,6 +113,20 @@ struct ComfyBoxDesktopApp: App {
         }
     }
 
+    // MARK: - Settings
+
+    /// Apply persisted settings to the engine on launch.
+    private func applySettings() {
+        let settings = DesktopSettings.load()
+        engine.serverHost = settings.serverHost
+        engine.serverPort = settings.serverPort
+        engine.outputDirectory = settings.outputDirectory
+
+        if settings.autoConnect {
+            engine.connect()
+        }
+    }
+
     // MARK: - Initialization
 
     private func initializeDAM() async {
@@ -143,26 +158,5 @@ struct ComfyBoxDesktopApp: App {
                 print("[ComfyBoxDesktop] Auto-ingest failed for \(path): \(error)")
             }
         }
-    }
-}
-
-// MARK: - Settings View
-
-struct SettingsView: View {
-    @Bindable var engine: EngineService
-
-    var body: some View {
-        Form {
-            Section("Server Connection") {
-                TextField("Host", text: $engine.serverHost)
-                TextField("Port", value: $engine.serverPort, format: .number)
-            }
-
-            Section("Output") {
-                TextField("Output Directory", text: $engine.outputDirectory)
-            }
-        }
-        .formStyle(.grouped)
-        .frame(width: 400, height: 200)
     }
 }

--- a/Sources/ComfyBoxDesktop/EngineService.swift
+++ b/Sources/ComfyBoxDesktop/EngineService.swift
@@ -17,6 +17,8 @@ public struct GenerationRequest: Sendable {
     public var steps: Int
     public var guidance: Float
     public var seed: UInt64  // 0 = random
+    public var modelId: String?
+    public var loras: [LoRASelection]
 
     public init(
         prompt: String = "",
@@ -24,7 +26,9 @@ public struct GenerationRequest: Sendable {
         height: Int = 1024,
         steps: Int = 9,
         guidance: Float = 3.5,
-        seed: UInt64 = 0
+        seed: UInt64 = 0,
+        modelId: String? = nil,
+        loras: [LoRASelection] = []
     ) {
         self.prompt = prompt
         self.width = width
@@ -32,6 +36,21 @@ public struct GenerationRequest: Sendable {
         self.steps = steps
         self.guidance = guidance
         self.seed = seed
+        self.modelId = modelId
+        self.loras = loras
+    }
+}
+
+/// A LoRA selected for generation with its scale.
+public struct LoRASelection: Sendable, Identifiable, Equatable {
+    public var id: String
+    public var filename: String
+    public var scale: Float
+
+    public init(id: String, filename: String, scale: Float = 1.0) {
+        self.id = id
+        self.filename = filename
+        self.scale = scale
     }
 }
 
@@ -46,15 +65,34 @@ private struct ServerGenerateResponse: Decodable {
 private struct ServerHealthResponse: Decodable {
     let status: String
     let model: String?
-    let queuePending: Int?
-    let queueActive: Int?
+    let modelFamily: String?
+    let loaded: Bool?
+    let isRendering: Bool?
+    let pendingCount: Int?
+    let renderCount: Int?
+    let uptimeSeconds: Int?
+    let lastRenderDurationMs: Int?
+    let lastError: String?
+    let loras: [ServerLoRAState]?
+    let memoryUsageMB: UInt64?
 
     enum CodingKeys: String, CodingKey {
-        case status
-        case model
-        case queuePending = "queue_pending"
-        case queueActive = "queue_active"
+        case status, model, loaded, loras
+        case modelFamily = "model_family"
+        case isRendering = "is_rendering"
+        case pendingCount = "pending_count"
+        case renderCount = "render_count"
+        case uptimeSeconds = "uptime_seconds"
+        case lastRenderDurationMs = "last_render_duration_ms"
+        case lastError = "last_error"
+        case memoryUsageMB = "memory_usage_mb"
     }
+}
+
+/// LoRA state from health endpoint.
+private struct ServerLoRAState: Decodable {
+    let source: String
+    let scale: Float
 }
 
 /// Connection status to the WarmServer.
@@ -79,17 +117,92 @@ public enum ServerConnectionState: Sendable {
     }
 }
 
+// MARK: - Model Info
+
+/// Information about a model available on the server.
+public struct ModelInfo: Sendable, Identifiable {
+    public let id: String
+    public let family: String
+    public let variant: String
+    public let quantization: String
+    public let displayName: String
+    public let description: String
+    public let parametersBillions: Float
+    public let defaultSteps: Int
+    public let defaultGuidance: Float
+    public let supportsGuidance: Bool
+    public let supportsLoRA: Bool
+    public let defaultResolution: String
+    public let estimatedVRAM_GB: Float
+    public let huggingFaceId: String
+}
+
+/// Information about a model loaded in the server's model pool.
+public struct PoolModelInfo: Sendable, Identifiable {
+    public let id: String
+    public let model: String
+    public let family: String
+    public let vramMB: Int
+    public let active: Bool
+    public let lastUsed: String
+}
+
+// MARK: - LoRA Info
+
+/// Information about a LoRA in the server's library.
+public struct LoRAInfo: Sendable, Identifiable {
+    public let id: String
+    public let filename: String
+    public let modelCompatibility: String
+    public let format: String
+    public let rank: Int
+    public let sizeBytes: Int
+    public let quarantined: Bool
+    public let tags: [String]
+    public let category: String
+    public let triggerwords: [String]
+    public let recommendedScale: Float
+    public let isActive: Bool
+}
+
+// MARK: - Queue Info
+
+/// Information about the server's render queue.
+public struct QueueInfo: Sendable {
+    public let isRendering: Bool
+    public let pendingCount: Int
+    public let renderCount: Int
+    public let uptimeSeconds: Int
+    public let lastRenderDurationMs: Int?
+    public let lastError: String?
+    public let memoryUsageMB: UInt64
+}
+
 @Observable
 public final class EngineService {
     // MARK: - Published State
 
     public var connectionState: ServerConnectionState = .disconnected
     public var currentModel: String?
+    public var currentModelFamily: String?
     public var queueCount: Int = 0
     public var isGenerating: Bool = false
     public var lastGeneratedImagePath: String?
     public var lastError: String?
     public var lastDurationMs: Int?
+
+    // Model pool state
+    public var availableModels: [ModelInfo] = []
+    public var poolModels: [PoolModelInfo] = []
+    public var isLoadingModel: Bool = false
+
+    // LoRA state
+    public var availableLoras: [LoRAInfo] = []
+    public var activeLoraIds: [String] = []
+    public var isSwappingLoras: Bool = false
+
+    // Queue state
+    public var queueInfo: QueueInfo?
 
     // MARK: - Configuration
 
@@ -123,6 +236,13 @@ public final class EngineService {
         healthPollTask = Task { [weak self] in
             // Initial connection check.
             await self?.pollHealth()
+
+            // Fetch models and LoRAs on first connect.
+            if let self = self, self.connectionState.isConnected {
+                await self.refreshModels()
+                await self.refreshLoras()
+            }
+
             // Poll every 3 seconds.
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(3))
@@ -139,7 +259,13 @@ public final class EngineService {
         client = nil
         connectionState = .disconnected
         currentModel = nil
+        currentModelFamily = nil
         queueCount = 0
+        availableModels = []
+        poolModels = []
+        availableLoras = []
+        activeLoraIds = []
+        queueInfo = nil
     }
 
     // MARK: - Generation
@@ -213,6 +339,211 @@ public final class EngineService {
         return response.outputPath
     }
 
+    // MARK: - Model Management
+
+    /// Fetch the list of all available models from the server registry.
+    public func refreshModels() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/models")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let models = json["models"] as? [[String: Any]] else { return }
+
+            availableModels = models.compactMap { dict -> ModelInfo? in
+                guard let id = dict["id"] as? String,
+                      let family = dict["family"] as? String,
+                      let variant = dict["variant"] as? String,
+                      let quantization = dict["quantization"] as? String,
+                      let displayName = dict["display_name"] as? String,
+                      let description = dict["description"] as? String else { return nil }
+
+                return ModelInfo(
+                    id: id,
+                    family: family,
+                    variant: variant,
+                    quantization: quantization,
+                    displayName: displayName,
+                    description: description,
+                    parametersBillions: (dict["parameters_b"] as? Float) ?? 0,
+                    defaultSteps: (dict["default_steps"] as? Int) ?? 9,
+                    defaultGuidance: (dict["default_guidance"] as? Float) ?? 3.5,
+                    supportsGuidance: (dict["supports_guidance"] as? Bool) ?? false,
+                    supportsLoRA: (dict["supports_lora"] as? Bool) ?? false,
+                    defaultResolution: (dict["default_resolution"] as? String) ?? "1024x1024",
+                    estimatedVRAM_GB: (dict["estimated_vram_gb"] as? Float) ?? 0,
+                    huggingFaceId: (dict["huggingface_id"] as? String) ?? ""
+                )
+            }
+
+            // Also refresh pool status.
+            await refreshPool()
+        } catch {
+            // Non-fatal — models list is informational.
+        }
+    }
+
+    /// Fetch the current model pool status.
+    public func refreshPool() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/model/pool")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let pool = json["pool"] as? [[String: Any]] else { return }
+
+            poolModels = pool.compactMap { dict -> PoolModelInfo? in
+                guard let model = dict["model"] as? String,
+                      let family = dict["family"] as? String else { return nil }
+
+                let poolKey = model.replacingOccurrences(of: "/", with: "-").lowercased()
+                return PoolModelInfo(
+                    id: poolKey,
+                    model: model,
+                    family: family,
+                    vramMB: (dict["vram_mb"] as? Int) ?? 0,
+                    active: (dict["active"] as? Bool) ?? false,
+                    lastUsed: (dict["last_used"] as? String) ?? ""
+                )
+            }
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    /// Load a model into the server's model pool.
+    public func loadModel(id: String, quantization: String? = nil, activate: Bool = true) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        isLoadingModel = true
+        defer { isLoadingModel = false }
+
+        var payloadDict: [String: Any] = [
+            "model": id,
+            "activate": activate,
+            "wait": true
+        ]
+        if let q = quantization {
+            payloadDict["quantization"] = q
+        }
+
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/load", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    /// Activate an already-loaded model in the pool.
+    public func activateModel(id: String) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        let payloadDict: [String: Any] = ["model": id]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/activate", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    /// Unload a model from the pool.
+    public func unloadModel(id: String) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        let payloadDict: [String: Any] = ["model": id]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/unload", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    // MARK: - LoRA Management
+
+    /// Fetch the list of available LoRAs from the server's library.
+    public func refreshLoras() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/loras")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let loras = json["loras"] as? [[String: Any]],
+                  let activeLoras = json["active_loras"] as? [String] else { return }
+
+            activeLoraIds = activeLoras
+
+            availableLoras = loras.compactMap { dict -> LoRAInfo? in
+                guard let id = dict["id"] as? String,
+                      let filename = dict["filename"] as? String else { return nil }
+
+                return LoRAInfo(
+                    id: id,
+                    filename: filename,
+                    modelCompatibility: (dict["model_compatibility"] as? String) ?? "unknown",
+                    format: (dict["format"] as? String) ?? "unknown",
+                    rank: (dict["rank"] as? Int) ?? 0,
+                    sizeBytes: (dict["size_bytes"] as? Int) ?? 0,
+                    quarantined: (dict["quarantined"] as? Bool) ?? false,
+                    tags: (dict["tags"] as? [String]) ?? [],
+                    category: (dict["category"] as? String) ?? "",
+                    triggerwords: (dict["triggerwords"] as? [String]) ?? [],
+                    recommendedScale: (dict["recommended_scale"] as? Float) ?? 1.0,
+                    isActive: activeLoras.contains(id)
+                )
+            }
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    /// Swap the active LoRAs on the server.
+    public func swapLoras(_ selections: [LoRASelection]) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        isSwappingLoras = true
+        defer { isSwappingLoras = false }
+
+        let loraEntries = selections.map { lora -> [String: Any] in
+            ["path": lora.id, "scale": lora.scale]
+        }
+        let payloadDict: [String: Any] = ["loras": loraEntries]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/lora/swap", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshLoras()
+    }
+
     // MARK: - Health Polling
 
     private func pollHealth() async {
@@ -233,12 +564,37 @@ public final class EngineService {
 
             connectionState = .connected
             currentModel = health.model
-            queueCount = (health.queuePending ?? 0) + (health.queueActive ?? 0)
+            currentModelFamily = health.modelFamily
+            let pending = health.pendingCount ?? 0
+            let rendering = (health.isRendering ?? false) ? 1 : 0
+            queueCount = pending + rendering
+
+            // Update queue info from health data.
+            queueInfo = QueueInfo(
+                isRendering: health.isRendering ?? false,
+                pendingCount: health.pendingCount ?? 0,
+                renderCount: health.renderCount ?? 0,
+                uptimeSeconds: health.uptimeSeconds ?? 0,
+                lastRenderDurationMs: health.lastRenderDurationMs,
+                lastError: health.lastError,
+                memoryUsageMB: health.memoryUsageMB ?? 0
+            )
         } catch is WarmServerClientError {
             connectionState = .disconnected
+            queueInfo = nil
         } catch {
             connectionState = .error(error.localizedDescription)
+            queueInfo = nil
         }
+    }
+
+    // MARK: - Helpers
+
+    private func parseErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["error"] as? String
     }
 }
 

--- a/Sources/ComfyBoxDesktop/Views/GenerationView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GenerationView.swift
@@ -1,9 +1,9 @@
 // GenerationView.swift — Main image generation interface
 //
-// Provides prompt entry, parameter controls, generation button,
-// and image preview. Communicates with the WarmServer through
-// EngineService. On successful generation, calls onGenerated
-// to trigger DAM ingestion.
+// Provides prompt entry, parameter controls, model selection,
+// LoRA picker, queue status, and image preview. Communicates
+// with the WarmServer through EngineService. On successful
+// generation, calls onGenerated to trigger DAM ingestion.
 
 import SwiftUI
 
@@ -34,11 +34,19 @@ struct GenerationView: View {
     @State private var seedText: String = ""
     @State private var displayedImage: NSImage?
 
+    // LoRA selections
+    @State private var selectedLoras: [LoRASelection] = []
+
+    // Sidebar sections
+    @State private var showModelSelector: Bool = true
+    @State private var showLoraPicker: Bool = false
+    @State private var showQueuePanel: Bool = false
+
     var body: some View {
         HSplitView {
             // Left panel: Controls
             controlPanel
-                .frame(minWidth: 320, maxWidth: 400)
+                .frame(minWidth: 340, maxWidth: 420)
 
             // Right panel: Image preview
             previewPanel
@@ -56,6 +64,17 @@ struct GenerationView: View {
 
                 Divider()
 
+                // Model selector (collapsible)
+                DisclosureGroup(isExpanded: $showModelSelector) {
+                    ModelSelector(engine: engine)
+                        .padding(.top, 4)
+                } label: {
+                    Label("Model", systemImage: "cpu")
+                        .font(.headline)
+                }
+
+                Divider()
+
                 // Prompt
                 promptSection
 
@@ -63,6 +82,49 @@ struct GenerationView: View {
 
                 // Parameters
                 parameterSection
+
+                Divider()
+
+                // LoRA picker (collapsible)
+                DisclosureGroup(isExpanded: $showLoraPicker) {
+                    LoRAPicker(engine: engine, selectedLoras: $selectedLoras)
+                        .padding(.top, 4)
+                } label: {
+                    HStack {
+                        Label("LoRA Adapters", systemImage: "slider.horizontal.3")
+                            .font(.headline)
+                        if !selectedLoras.isEmpty {
+                            Text("\(selectedLoras.count)")
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.accentColor.opacity(0.2))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
+
+                Divider()
+
+                // Queue panel (collapsible)
+                DisclosureGroup(isExpanded: $showQueuePanel) {
+                    QueuePanel(engine: engine)
+                        .padding(.top, 4)
+                } label: {
+                    HStack {
+                        Label("Queue", systemImage: "list.bullet.rectangle")
+                            .font(.headline)
+                        if engine.queueCount > 0 {
+                            Text("\(engine.queueCount)")
+                                .font(.caption2)
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.orange)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
 
                 Divider()
 
@@ -289,10 +351,21 @@ struct GenerationView: View {
             height: selectedResolution.height,
             steps: Int(steps),
             guidance: Float(guidance),
-            seed: seed
+            seed: seed,
+            loras: selectedLoras
         )
 
         Task {
+            // Swap LoRAs if any selected (before generation).
+            if !selectedLoras.isEmpty {
+                do {
+                    try await engine.swapLoras(selectedLoras)
+                } catch {
+                    // LoRA swap failure — still attempt generation with
+                    // whatever LoRAs are currently loaded.
+                }
+            }
+
             do {
                 let outputPath = try await engine.generate(request)
                 // Load the generated image for display.

--- a/Sources/ComfyBoxDesktop/Views/LoRAPicker.swift
+++ b/Sources/ComfyBoxDesktop/Views/LoRAPicker.swift
@@ -1,0 +1,280 @@
+// LoRAPicker.swift — LoRA selection and scale control
+//
+// Lists available LoRAs from the server's LoRA library. Each row shows
+// LoRA name, checkbox to enable, and scale slider. Selected LoRAs are
+// tracked as LoRASelection instances and passed to generation requests.
+// Active LoRAs (currently loaded on the server) appear at the top.
+
+import SwiftUI
+
+struct LoRAPicker: View {
+    @Bindable var engine: EngineService
+    @Binding var selectedLoras: [LoRASelection]
+
+    @State private var searchText: String = ""
+    @State private var errorMessage: String?
+
+    private var filteredLoras: [LoRAInfo] {
+        let nonQuarantined = engine.availableLoras.filter { !$0.quarantined }
+
+        guard !searchText.isEmpty else {
+            return sortedLoras(nonQuarantined)
+        }
+
+        let query = searchText.lowercased()
+        let filtered = nonQuarantined.filter { lora in
+            lora.id.lowercased().contains(query)
+                || lora.filename.lowercased().contains(query)
+                || lora.tags.contains { $0.lowercased().contains(query) }
+                || lora.category.lowercased().contains(query)
+                || lora.triggerwords.contains { $0.lowercased().contains(query) }
+        }
+        return sortedLoras(filtered)
+    }
+
+    /// Sort: selected first, then active on server, then alphabetical.
+    private func sortedLoras(_ loras: [LoRAInfo]) -> [LoRAInfo] {
+        loras.sorted { a, b in
+            let aSelected = selectedLoras.contains { $0.id == a.id }
+            let bSelected = selectedLoras.contains { $0.id == b.id }
+            if aSelected != bSelected { return aSelected }
+            if a.isActive != b.isActive { return a.isActive }
+            return a.id < b.id
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Header with refresh
+            HStack {
+                Text("LoRA Adapters")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+
+                Spacer()
+
+                if !selectedLoras.isEmpty {
+                    Text("\(selectedLoras.count) selected")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button(action: { Task { await engine.refreshLoras() } }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .help("Refresh LoRA library")
+            }
+
+            // Search
+            if engine.availableLoras.count > 5 {
+                HStack(spacing: 4) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Search LoRAs...", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .font(.caption)
+                    if !searchText.isEmpty {
+                        Button(action: { searchText = "" }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(4)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+
+            // LoRA list
+            if engine.availableLoras.isEmpty {
+                if engine.connectionState.isConnected {
+                    Text("No LoRAs available")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                } else {
+                    Text("Connect to server to load LoRAs")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            } else if filteredLoras.isEmpty {
+                Text("No LoRAs match \"\(searchText)\"")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ScrollView {
+                    VStack(spacing: 2) {
+                        ForEach(filteredLoras) { lora in
+                            loraRow(lora)
+                        }
+                    }
+                }
+                .frame(maxHeight: 240)
+            }
+
+            // Apply button if selections differ from server state
+            if !selectedLoras.isEmpty {
+                Button(action: { Task { await applyLoras() } }) {
+                    HStack(spacing: 4) {
+                        if engine.isSwappingLoras {
+                            ProgressView()
+                                .controlSize(.mini)
+                        }
+                        Text(engine.isSwappingLoras ? "Applying..." : "Apply LoRAs")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(engine.isSwappingLoras)
+            }
+
+            // Error display
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    // MARK: - LoRA Row
+
+    private func loraRow(_ lora: LoRAInfo) -> some View {
+        let isSelected = selectedLoras.contains { $0.id == lora.id }
+        let selectionIndex = selectedLoras.firstIndex { $0.id == lora.id }
+
+        return VStack(spacing: 4) {
+            HStack(spacing: 6) {
+                // Checkbox
+                Button(action: { toggleLora(lora) }) {
+                    Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+
+                // Name and info
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 4) {
+                        Text(lora.id)
+                            .font(.caption)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        if lora.isActive {
+                            Text("active")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.green)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(Color.green.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 3))
+                        }
+                    }
+
+                    HStack(spacing: 4) {
+                        Text(formattedSize(lora.sizeBytes))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+
+                        if !lora.category.isEmpty {
+                            Text(lora.category)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if !lora.triggerwords.isEmpty {
+                            Text(lora.triggerwords.joined(separator: ", "))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+
+            // Scale slider when selected
+            if isSelected, let index = selectionIndex {
+                HStack(spacing: 6) {
+                    Text("Scale")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 32, alignment: .leading)
+
+                    Slider(
+                        value: Binding(
+                            get: { selectedLoras[index].scale },
+                            set: { selectedLoras[index].scale = $0 }
+                        ),
+                        in: 0.0...2.0,
+                        step: 0.05
+                    )
+                    .controlSize(.mini)
+
+                    Text(String(format: "%.2f", selectedLoras[safe: index]?.scale ?? 1.0))
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .frame(width: 32)
+                }
+                .padding(.leading, 22)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(isSelected ? Color.accentColor.opacity(0.06) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    // MARK: - Actions
+
+    private func toggleLora(_ lora: LoRAInfo) {
+        if let index = selectedLoras.firstIndex(where: { $0.id == lora.id }) {
+            selectedLoras.remove(at: index)
+        } else {
+            selectedLoras.append(LoRASelection(
+                id: lora.id,
+                filename: lora.filename,
+                scale: lora.recommendedScale
+            ))
+        }
+    }
+
+    private func applyLoras() async {
+        errorMessage = nil
+        do {
+            try await engine.swapLoras(selectedLoras)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formattedSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.0f KB", kb) }
+        let mb = kb / 1024
+        if mb < 1024 { return String(format: "%.1f MB", mb) }
+        let gb = mb / 1024
+        return String(format: "%.1f GB", gb)
+    }
+}
+
+// MARK: - Safe Array Access
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard index >= 0 && index < count else { return nil }
+        return self[index]
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/ModelSelector.swift
+++ b/Sources/ComfyBoxDesktop/Views/ModelSelector.swift
@@ -1,0 +1,253 @@
+// ModelSelector.swift — Model pool management and selection
+//
+// Displays available models from the server registry and the active model pool.
+// Allows loading, activating, and unloading models. Shows current active model
+// prominently with pool VRAM usage.
+
+import SwiftUI
+
+struct ModelSelector: View {
+    @Bindable var engine: EngineService
+
+    @State private var selectedRegistryModel: String?
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Active model header
+            activeModelHeader
+
+            // Loaded models (pool)
+            if !engine.poolModels.isEmpty {
+                poolSection
+            }
+
+            // Available models from registry
+            if !engine.availableModels.isEmpty {
+                registrySection
+            }
+
+            // Error display
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 4)
+            }
+        }
+    }
+
+    // MARK: - Active Model
+
+    private var activeModelHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Active Model")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            if let model = engine.currentModel {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(.green)
+                        .frame(width: 8, height: 8)
+                    Text(model)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let family = engine.currentModelFamily {
+                        Text(family)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.secondary.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
+            } else {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(.gray)
+                        .frame(width: 8, height: 8)
+                    Text("No model loaded")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Pool Section
+
+    private var poolSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Model Pool")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                Button(action: { Task { await engine.refreshPool() } }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .help("Refresh pool status")
+            }
+
+            ForEach(engine.poolModels) { poolModel in
+                poolModelRow(poolModel)
+            }
+        }
+    }
+
+    private func poolModelRow(_ model: PoolModelInfo) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(model.active ? .green : .orange)
+                .frame(width: 6, height: 6)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(model.model)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                HStack(spacing: 6) {
+                    Text(model.family)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(model.vramMB) MB")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if model.active {
+                Text("Active")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            } else {
+                HStack(spacing: 4) {
+                    Button("Activate") {
+                        Task { await activatePoolModel(model.id) }
+                    }
+                    .font(.caption2)
+                    .buttonStyle(.bordered)
+                    .controlSize(.mini)
+
+                    Button(action: { Task { await unloadPoolModel(model.id) } }) {
+                        Image(systemName: "xmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Unload model")
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(model.active ? Color.green.opacity(0.05) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: - Registry Section
+
+    private var registrySection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Available Models")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            // Group by family
+            let families = Dictionary(grouping: engine.availableModels) { $0.family }
+            let sortedFamilies = families.keys.sorted()
+
+            ForEach(sortedFamilies, id: \.self) { family in
+                if let models = families[family] {
+                    DisclosureGroup(family) {
+                        ForEach(models) { model in
+                            registryModelRow(model)
+                        }
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+    }
+
+    private func registryModelRow(_ model: ModelInfo) -> some View {
+        let isLoaded = engine.poolModels.contains { $0.model == model.huggingFaceId }
+
+        return HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayName)
+                    .font(.caption)
+                HStack(spacing: 6) {
+                    Text("\(String(format: "%.1f", model.parametersBillions))B")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(model.quantization)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(String(format: "%.1f", model.estimatedVRAM_GB)) GB VRAM")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if isLoaded {
+                Text("Loaded")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            } else {
+                Button("Load") {
+                    Task { await loadRegistryModel(model) }
+                }
+                .font(.caption2)
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .disabled(engine.isLoadingModel)
+            }
+        }
+        .padding(.vertical, 2)
+        .help(model.description)
+    }
+
+    // MARK: - Actions
+
+    private func loadRegistryModel(_ model: ModelInfo) async {
+        errorMessage = nil
+        do {
+            try await engine.loadModel(
+                id: model.huggingFaceId,
+                quantization: model.quantization == "bf16" ? nil : model.quantization,
+                activate: true
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func activatePoolModel(_ id: String) async {
+        errorMessage = nil
+        do {
+            try await engine.activateModel(id: id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func unloadPoolModel(_ id: String) async {
+        errorMessage = nil
+        do {
+            try await engine.unloadModel(id: id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/QueuePanel.swift
+++ b/Sources/ComfyBoxDesktop/Views/QueuePanel.swift
@@ -1,0 +1,227 @@
+// QueuePanel.swift — Render queue status panel
+//
+// Shows the current render queue status from the WarmServer health endpoint.
+// Displays active render progress, pending queue count, completed render
+// statistics, and server resource usage. Auto-refreshes via EngineService
+// health polling (every 3 seconds).
+
+import SwiftUI
+
+struct QueuePanel: View {
+    @Bindable var engine: EngineService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Text("Render Queue")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                if engine.connectionState.isConnected {
+                    statusIndicator
+                }
+            }
+
+            if let info = engine.queueInfo {
+                queueContent(info)
+            } else if engine.connectionState.isConnected {
+                Text("Loading queue status...")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("Connect to server to view queue")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    // MARK: - Status Indicator
+
+    private var statusIndicator: some View {
+        HStack(spacing: 4) {
+            if engine.isGenerating || (engine.queueInfo?.isRendering ?? false) {
+                Circle()
+                    .fill(.orange)
+                    .frame(width: 6, height: 6)
+                Text("Rendering")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            } else {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 6, height: 6)
+                Text("Idle")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            }
+        }
+    }
+
+    // MARK: - Queue Content
+
+    private func queueContent(_ info: QueueInfo) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Active render
+            activeRenderSection(info)
+
+            Divider()
+
+            // Statistics
+            statsSection(info)
+
+            // Server resources
+            resourceSection(info)
+
+            // Last error
+            if let lastError = info.lastError, !lastError.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Last Error")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(lastError)
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                        .lineLimit(3)
+                }
+            }
+        }
+    }
+
+    private func activeRenderSection(_ info: QueueInfo) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Status")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if info.isRendering {
+                    HStack(spacing: 4) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text("Rendering...")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                } else {
+                    Text("Ready")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            }
+
+            // Pending count
+            if info.pendingCount > 0 {
+                HStack {
+                    Text("Pending")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(info.pendingCount) job\(info.pendingCount == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+
+    private func statsSection(_ info: QueueInfo) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Statistics")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Text("Completed renders")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(info.renderCount)")
+                    .font(.caption)
+                    .monospacedDigit()
+            }
+
+            if let lastMs = info.lastRenderDurationMs, lastMs > 0 {
+                HStack {
+                    Text("Last render")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(formatDuration(lastMs))
+                        .font(.caption)
+                        .monospacedDigit()
+                }
+            }
+
+            HStack {
+                Text("Server uptime")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(formatUptime(info.uptimeSeconds))
+                    .font(.caption)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    private func resourceSection(_ info: QueueInfo) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Resources")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Text("Memory usage")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(formatMemory(info.memoryUsageMB))
+                    .font(.caption)
+                    .monospacedDigit()
+            }
+
+            if !engine.poolModels.isEmpty {
+                HStack {
+                    Text("Models loaded")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(engine.poolModels.count)")
+                        .font(.caption)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formatDuration(_ ms: Int) -> String {
+        if ms < 1000 { return "\(ms) ms" }
+        let seconds = Double(ms) / 1000.0
+        if seconds < 60 { return String(format: "%.1f s", seconds) }
+        let minutes = Int(seconds) / 60
+        let remainingSeconds = Int(seconds) % 60
+        return "\(minutes)m \(remainingSeconds)s"
+    }
+
+    private func formatUptime(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3600 {
+            let m = seconds / 60
+            let s = seconds % 60
+            return "\(m)m \(s)s"
+        }
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        return "\(h)h \(m)m"
+    }
+
+    private func formatMemory(_ mb: UInt64) -> String {
+        if mb < 1024 { return "\(mb) MB" }
+        let gb = Double(mb) / 1024.0
+        return String(format: "%.1f GB", gb)
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/SettingsView.swift
+++ b/Sources/ComfyBoxDesktop/Views/SettingsView.swift
@@ -1,0 +1,297 @@
+// SettingsView.swift — Application settings with persistence
+//
+// Provides configuration for server connection, output directory,
+// default generation parameters, and gallery settings. Settings
+// persist to ~/.comfybox/desktop-config.json.
+
+import SwiftUI
+
+// MARK: - Settings Storage
+
+/// Persisted settings stored at ~/.comfybox/desktop-config.json.
+struct DesktopSettings: Codable {
+    var serverHost: String
+    var serverPort: UInt16
+    var autoConnect: Bool
+    var outputDirectory: String
+    var defaultSteps: Int
+    var defaultGuidance: Float
+    var defaultWidth: Int
+    var defaultHeight: Int
+    var thumbnailSize: Int
+    var gallerySortDefault: String
+
+    static let defaultSettings = DesktopSettings(
+        serverHost: "127.0.0.1",
+        serverPort: 7862,
+        autoConnect: true,
+        outputDirectory: NSString(string: "~/Pictures/ComfyBox").expandingTildeInPath,
+        defaultSteps: 9,
+        defaultGuidance: 3.5,
+        defaultWidth: 1024,
+        defaultHeight: 1024,
+        thumbnailSize: 180,
+        gallerySortDefault: "date"
+    )
+
+    static var configPath: String {
+        let dir = NSString(string: "~/.comfybox").expandingTildeInPath
+        return (dir as NSString).appendingPathComponent("desktop-config.json")
+    }
+
+    /// Load settings from disk, returning defaults on any failure.
+    static func load() -> DesktopSettings {
+        let path = configPath
+        guard FileManager.default.fileExists(atPath: path),
+              let data = FileManager.default.contents(atPath: path) else {
+            return defaultSettings
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(DesktopSettings.self, from: data)
+        } catch {
+            return defaultSettings
+        }
+    }
+
+    /// Save settings to disk.
+    func save() {
+        let path = Self.configPath
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true
+        )
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(self)
+            try data.write(to: URL(fileURLWithPath: path))
+        } catch {
+            // Save failure is non-fatal — settings revert to defaults on next launch.
+        }
+    }
+}
+
+// MARK: - Settings View
+
+struct SettingsView: View {
+    @Bindable var engine: EngineService
+
+    @State private var settings: DesktopSettings
+    @State private var hasUnsavedChanges: Bool = false
+    @State private var showingSaveConfirmation: Bool = false
+
+    init(engine: EngineService) {
+        self.engine = engine
+        self._settings = State(initialValue: DesktopSettings.load())
+    }
+
+    var body: some View {
+        TabView {
+            serverTab
+                .tabItem {
+                    Label("Server", systemImage: "server.rack")
+                }
+
+            generationTab
+                .tabItem {
+                    Label("Generation", systemImage: "wand.and.stars")
+                }
+
+            galleryTab
+                .tabItem {
+                    Label("Gallery", systemImage: "photo.on.rectangle")
+                }
+        }
+        .frame(width: 480, height: 340)
+        .onDisappear {
+            if hasUnsavedChanges {
+                applyAndSave()
+            }
+        }
+    }
+
+    // MARK: - Server Tab
+
+    private var serverTab: some View {
+        Form {
+            Section("Connection") {
+                TextField("Host", text: $settings.serverHost)
+                    .onChange(of: settings.serverHost) { _, _ in hasUnsavedChanges = true }
+
+                TextField("Port", value: $settings.serverPort, format: .number)
+                    .onChange(of: settings.serverPort) { _, _ in hasUnsavedChanges = true }
+
+                Toggle("Auto-connect on launch", isOn: $settings.autoConnect)
+                    .onChange(of: settings.autoConnect) { _, _ in hasUnsavedChanges = true }
+            }
+
+            Section("Status") {
+                HStack {
+                    Text("Connection")
+                    Spacer()
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(engine.connectionState.isConnected ? .green : .gray)
+                            .frame(width: 8, height: 8)
+                        Text(engine.connectionState.label)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let model = engine.currentModel {
+                    HStack {
+                        Text("Active Model")
+                        Spacer()
+                        Text(model)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Apply & Save") {
+                        applyAndSave()
+                    }
+                    .disabled(!hasUnsavedChanges)
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Reset to Defaults") {
+                        settings = .defaultSettings
+                        hasUnsavedChanges = true
+                    }
+                    Spacer()
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Generation Tab
+
+    private var generationTab: some View {
+        Form {
+            Section("Default Parameters") {
+                HStack {
+                    Text("Steps")
+                    Spacer()
+                    TextField("Steps", value: $settings.defaultSteps, format: .number)
+                        .frame(width: 60)
+                        .multilineTextAlignment(.trailing)
+                        .onChange(of: settings.defaultSteps) { _, _ in hasUnsavedChanges = true }
+                }
+
+                HStack {
+                    Text("Guidance")
+                    Spacer()
+                    TextField("Guidance", value: $settings.defaultGuidance, format: .number.precision(.fractionLength(1)))
+                        .frame(width: 60)
+                        .multilineTextAlignment(.trailing)
+                        .onChange(of: settings.defaultGuidance) { _, _ in hasUnsavedChanges = true }
+                }
+            }
+
+            Section("Default Resolution") {
+                HStack {
+                    Text("Width")
+                    Spacer()
+                    TextField("Width", value: $settings.defaultWidth, format: .number)
+                        .frame(width: 80)
+                        .multilineTextAlignment(.trailing)
+                        .onChange(of: settings.defaultWidth) { _, _ in hasUnsavedChanges = true }
+                }
+
+                HStack {
+                    Text("Height")
+                    Spacer()
+                    TextField("Height", value: $settings.defaultHeight, format: .number)
+                        .frame(width: 80)
+                        .multilineTextAlignment(.trailing)
+                        .onChange(of: settings.defaultHeight) { _, _ in hasUnsavedChanges = true }
+                }
+            }
+
+            Section("Output") {
+                TextField("Output Directory", text: $settings.outputDirectory)
+                    .onChange(of: settings.outputDirectory) { _, _ in hasUnsavedChanges = true }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Apply & Save") {
+                        applyAndSave()
+                    }
+                    .disabled(!hasUnsavedChanges)
+                    .buttonStyle(.borderedProminent)
+                    Spacer()
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Gallery Tab
+
+    private var galleryTab: some View {
+        Form {
+            Section("Display") {
+                HStack {
+                    Text("Thumbnail Size")
+                    Spacer()
+                    Picker("", selection: $settings.thumbnailSize) {
+                        Text("Small (140)").tag(140)
+                        Text("Medium (180)").tag(180)
+                        Text("Large (240)").tag(240)
+                    }
+                    .frame(width: 160)
+                    .onChange(of: settings.thumbnailSize) { _, _ in hasUnsavedChanges = true }
+                }
+
+                HStack {
+                    Text("Default Sort")
+                    Spacer()
+                    Picker("", selection: $settings.gallerySortDefault) {
+                        Text("Date").tag("date")
+                        Text("Rating").tag("rating")
+                        Text("Favorites First").tag("favorite")
+                    }
+                    .frame(width: 160)
+                    .onChange(of: settings.gallerySortDefault) { _, _ in hasUnsavedChanges = true }
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Apply & Save") {
+                        applyAndSave()
+                    }
+                    .disabled(!hasUnsavedChanges)
+                    .buttonStyle(.borderedProminent)
+                    Spacer()
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Actions
+
+    private func applyAndSave() {
+        // Apply to engine
+        engine.serverHost = settings.serverHost
+        engine.serverPort = settings.serverPort
+        engine.outputDirectory = settings.outputDirectory
+
+        // Persist to disk
+        settings.save()
+        hasUnsavedChanges = false
+    }
+}


### PR DESCRIPTION
## Summary
- **ModelSelector** — browse the full model registry by family, load/activate/unload models in the pool, see VRAM usage and active model
- **LoRAPicker** — searchable LoRA library with per-adapter enable checkboxes, scale sliders (0.0-2.0), server-side swap on apply
- **QueuePanel** — live render queue status, pending count, completed render stats, server uptime, memory usage
- **SettingsView** — tabbed settings (Server, Generation, Gallery) persisted to ~/.comfybox/desktop-config.json with auto-connect on launch
- **GenerationView** updated with all three panels as collapsible DisclosureGroups
- **EngineService** extended with model pool, LoRA library, and queue status APIs (/v1/models, /v1/model/pool, /v1/model/load, /v1/model/activate, /v1/model/unload, /v1/loras, /v1/lora/swap)
- **ComfyBoxDesktopApp** applies persisted settings on launch and auto-connects when configured

## Test plan
- [ ] Verify clean build with `swift build`
- [ ] Launch app, confirm auto-connect to running WarmServer
- [ ] Open Model section, verify registry models grouped by family
- [ ] Load a model, confirm pool updates with VRAM and active status
- [ ] Open LoRA section, search for a LoRA, toggle on, adjust scale
- [ ] Apply LoRAs, verify server swap completes
- [ ] Open Queue section during a render, verify live status updates
- [ ] Open Settings (Cmd+,), change host/port, save, verify persistence
- [ ] Restart app, confirm settings restored from desktop-config.json

Generated with [Claude Code](https://claude.com/claude-code)