### PR TITLE
feat(telegram): Phase 1 bot surface — prompt to image

### DIFF
--- a/Sources/ComfyBox/main.swift
+++ b/Sources/ComfyBox/main.swift
@@ -234,6 +234,9 @@ struct ZImageCLI {
       case "ltx2-text-encoder-test":
         try runLTX2TextEncoderTest(args: Array(args.dropFirst()))
         return
+      case "telegram":
+        try runTelegram(args: Array(args.dropFirst()))
+        return
       default:
         logger.warning("Unknown argument: \(arg)")
       }
@@ -1320,6 +1323,13 @@ struct ZImageCLI {
         --port               WarmServer port (default: 7862)
         --host               WarmServer host (default: 127.0.0.1)
         Use 'ComfyBox mcp --help' for full options
+
+      telegram               Start Telegram bot (receives prompts, renders via WarmServer)
+        --bot-token          Telegram Bot API token
+        --config             Config file path (default: ~/.comfybox/telegram.json)
+        --port               WarmServer port (default: 7862)
+        --host               WarmServer host (default: 127.0.0.1)
+        Use 'ComfyBox telegram --help' for full options
 
     Examples:
       ComfyBox -p "a cute cat" -o cat.png
@@ -3988,6 +3998,172 @@ struct ZImageCLI {
     #endif
   }
 
+
+  // MARK: - Telegram Bot Subcommand
+
+  private static func runTelegram(args: [String]) throws {
+    var botToken: String? = nil
+    var configPath: String? = nil
+    var warmServerPort: UInt16 = 7862
+    var warmServerHost: String = "127.0.0.1"
+
+    var iterator = args.makeIterator()
+    while let arg = iterator.next() {
+      switch arg {
+      case "--bot-token":
+        botToken = nextValue(for: arg, iterator: &iterator)
+      case "--config":
+        configPath = nextValue(for: arg, iterator: &iterator)
+      case "--port":
+        let raw = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: 7862)
+        warmServerPort = UInt16(min(raw, Int(UInt16.max)))
+      case "--host":
+        warmServerHost = nextValue(for: arg, iterator: &iterator)
+      case "--help", "-h":
+        printTelegramUsage()
+        return
+      default:
+        logger.warning("Unknown telegram argument: \(arg)")
+      }
+    }
+
+    // Load config
+    let config = try loadTelegramConfig(
+      botToken: botToken,
+      configPath: configPath,
+      warmServerHost: warmServerHost,
+      warmServerPort: warmServerPort
+    )
+
+    let coordinator = ImageBotCoordinator(configuration: config, logger: logger)
+
+    // Signal handling (SIGINT/SIGTERM)
+    let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+    signalSource.setEventHandler { coordinator.shutdown() }
+    signalSource.resume()
+    signal(SIGINT, SIG_IGN)
+
+    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+    termSource.setEventHandler { coordinator.shutdown() }
+    termSource.resume()
+    signal(SIGTERM, SIG_IGN)
+
+    // Keep Mac awake while bot is running
+    let caffeinate = Process()
+    caffeinate.executableURL = URL(fileURLWithPath: "/usr/bin/caffeinate")
+    caffeinate.arguments = ["-s", "-w", "\(ProcessInfo.processInfo.processIdentifier)"]
+    try? caffeinate.run()
+
+    logger.info("ComfyBox Telegram bot starting...")
+
+    Task {
+      do {
+        try await coordinator.run()
+      } catch {
+        fputs("Telegram bot error: \(error.localizedDescription)\n", stderr)
+      }
+      Darwin.exit(0)
+    }
+
+    dispatchMain()
+  }
+
+  private static func loadTelegramConfig(
+    botToken: String?,
+    configPath: String?,
+    warmServerHost: String,
+    warmServerPort: UInt16
+  ) throws -> ImageBotCoordinator.Configuration {
+    // Resolution: CLI > env > config file > defaults
+    var token = botToken
+    var allowedUserIds: Set<Int> = [8754779862]  // Todd
+    var host = warmServerHost
+    var port = warmServerPort
+    var outputDir = ("~/Pictures/ComfyBox/Telegram" as NSString).expandingTildeInPath
+
+    // Check environment variable
+    if token == nil {
+      token = ProcessInfo.processInfo.environment["COMFYBOX_TELEGRAM_TOKEN"]
+    }
+
+    // Load config file
+    let configFilePath = configPath ?? (("~/.comfybox/telegram.json" as NSString).expandingTildeInPath)
+    if FileManager.default.fileExists(atPath: configFilePath),
+       let data = FileManager.default.contents(atPath: configFilePath),
+       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+
+      if token == nil, let fileToken = json["botToken"] as? String {
+        token = fileToken
+      }
+      if let userIds = json["allowedUserIds"] as? [Int] {
+        allowedUserIds = Set(userIds)
+      }
+      if let ws = json["warmServer"] as? [String: Any] {
+        // Only use config file values if not overridden by CLI
+        if warmServerHost == "127.0.0.1", let h = ws["host"] as? String {
+          host = h
+        }
+        if warmServerPort == 7862, let p = ws["port"] as? Int {
+          port = UInt16(min(p, Int(UInt16.max)))
+        }
+      }
+      if let dir = json["outputDirectory"] as? String {
+        outputDir = (dir as NSString).expandingTildeInPath
+      }
+    }
+
+    guard let finalToken = token, !finalToken.isEmpty else {
+      throw NSError(
+        domain: "ComfyBox.Telegram",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey:
+          "Bot token required. Use --bot-token, COMFYBOX_TELEGRAM_TOKEN env, or config file."]
+      )
+    }
+
+    let telegramConfig = TelegramBot.Configuration(
+      botToken: finalToken,
+      allowedUserIds: allowedUserIds
+    )
+
+    return ImageBotCoordinator.Configuration(
+      telegram: telegramConfig,
+      warmServerHost: host,
+      warmServerPort: port,
+      outputDirectory: outputDir
+    )
+  }
+
+  private static func printTelegramUsage() {
+    print("""
+    Start Telegram bot surface for ComfyBox.
+    Connects to a running WarmServer for image generation.
+
+    Usage: ComfyBox telegram [options]
+
+    Options:
+      --bot-token <token>     Telegram Bot API token (or COMFYBOX_TELEGRAM_TOKEN env)
+      --config <path>         Config file (default: ~/.comfybox/telegram.json)
+      --port <port>           WarmServer port (default: 7862)
+      --host <host>           WarmServer host (default: 127.0.0.1)
+      --help, -h              Show help
+
+    Config file (~/.comfybox/telegram.json):
+      {
+        "botToken": "123456:ABC...",
+        "allowedUserIds": [8754779862],
+        "warmServer": { "host": "127.0.0.1", "port": 7862 },
+        "outputDirectory": "~/Pictures/ComfyBox/Telegram"
+      }
+
+    Resolution order: CLI flags > env vars > config file > defaults
+
+    Requires a running WarmServer: ComfyBox serve --port 7862
+    """)
+  }
+
+
+
 }
 
 // MARK: - Progress Helpers
@@ -4079,6 +4255,7 @@ private final class ProgressBar {
     if m > 0 { return String(format: "%dm%02ds", m, s) }
     return String(format: "%ds", s)
   }
+
 
 
 }

--- a/Sources/ZImage/Telegram/ImageBotCoordinator.swift
+++ b/Sources/ZImage/Telegram/ImageBotCoordinator.swift
@@ -1,0 +1,293 @@
+// ImageBotCoordinator.swift — Orchestrates Telegram bot: parse -> render -> send.
+//
+// Phase 1: Handles text prompts via WarmServer, /help, and /status.
+// Connects to a running WarmServer instance via WarmServerClient.
+
+import Foundation
+import Logging
+
+public final class ImageBotCoordinator {
+  public struct Configuration: Sendable {
+    public let telegram: TelegramBot.Configuration
+    public let warmServerHost: String
+    public let warmServerPort: UInt16
+    public let outputDirectory: String
+
+    public init(
+      telegram: TelegramBot.Configuration,
+      warmServerHost: String = "127.0.0.1",
+      warmServerPort: UInt16 = 7862,
+      outputDirectory: String = ("~/Pictures/ComfyBox/Telegram" as NSString).expandingTildeInPath
+    ) {
+      self.telegram = telegram
+      self.warmServerHost = warmServerHost
+      self.warmServerPort = warmServerPort
+      self.outputDirectory = outputDirectory
+    }
+  }
+
+  private let config: Configuration
+  private let bot: TelegramBot
+  private let warmServer: WarmServerClient
+  private let logger: Logger
+  private var isRunning = false
+  private let startTime = Date()
+
+  public init(configuration: Configuration, logger: Logger = Logger(label: "comfybox.telegram.coordinator")) {
+    self.config = configuration
+    self.logger = logger
+    self.bot = TelegramBot(configuration: configuration.telegram, logger: logger)
+    self.warmServer = WarmServerClient(host: configuration.warmServerHost, port: configuration.warmServerPort)
+
+    // Ensure output directory exists
+    let fileManager = FileManager.default
+    let outputDir = configuration.outputDirectory
+    if !fileManager.fileExists(atPath: outputDir) {
+      try? fileManager.createDirectory(atPath: outputDir, withIntermediateDirectories: true)
+      logger.info("Created output directory: \(outputDir)")
+    }
+  }
+
+  /// Start the bot. Blocks until stopped.
+  public func run() async throws {
+    isRunning = true
+    logger.info("ImageBotCoordinator: starting (WarmServer at \(config.warmServerHost):\(config.warmServerPort))")
+
+    await bot.startPolling { [self] update in
+      await self.handleUpdate(update)
+    }
+  }
+
+  /// Signal graceful shutdown.
+  public func shutdown() {
+    logger.info("ImageBotCoordinator: shutdown requested")
+    isRunning = false
+    bot.stop()
+  }
+
+  // MARK: - Update Handling
+
+  private func handleUpdate(_ update: TelegramUpdate) async {
+    // Handle text messages
+    if let message = update.message, let text = message.text {
+      await handleTextMessage(message: message, text: text)
+      return
+    }
+
+    // Future: handle callback queries, photos, etc.
+  }
+
+  private func handleTextMessage(message: TelegramMessage, text: String) async {
+    let command = TelegramCommandParser.parse(text, inDiscussMode: false)
+    let chatId = message.chatId
+
+    switch command {
+    case .help:
+      await sendHelp(chatId: chatId)
+
+    case .status:
+      await sendStatus(chatId: chatId)
+
+    case .render(let prompt):
+      await handleRender(chatId: chatId, prompt: prompt, messageId: message.messageId)
+
+    default:
+      // Phase 2+ commands not yet implemented
+      let _ = try? await bot.sendMessage(
+        chatId: chatId,
+        text: "Command not yet available in Phase 1. Send a text prompt to generate an image, or /help for commands."
+      )
+    }
+  }
+
+  // MARK: - Render Flow
+
+  private func handleRender(chatId: Int, prompt: String, messageId: Int) async {
+    guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      let _ = try? await bot.sendMessage(chatId: chatId, text: "Send me a prompt and I'll generate an image.")
+      return
+    }
+
+    // Parse prompt for character detection
+    let parsed = TelegramCommandParser.parsePrompt(prompt)
+
+    // Send status message
+    let statusResult = try? await bot.sendMessage(chatId: chatId, text: "Rendering...")
+    let statusMessageId = statusResult?.messageId
+
+    // Generate via WarmServer
+    let outputFilename = "telegram-\(Int(Date().timeIntervalSince1970))-\(UInt32.random(in: 0...999999)).png"
+    let outputPath = (config.outputDirectory as NSString).appendingPathComponent(outputFilename)
+
+    do {
+      // Build generate request
+      var body: [String: Any] = [
+        "prompt": parsed.prompt,
+        "outputPath": outputPath
+      ]
+
+      // Use default dimensions for Telegram (1024x1024)
+      body["width"] = 1024
+      body["height"] = 1024
+
+      let jsonData = try JSONSerialization.data(withJSONObject: body)
+      let (status, responseData) = try await warmServer.post("/v1/generate", body: jsonData)
+
+      guard status == 200 else {
+        let errorMsg = parseErrorMessage(responseData) ?? "WarmServer returned status \(status)"
+        throw CoordinatorError.generateFailed(errorMsg)
+      }
+
+      // Parse response to get output path
+      guard let responseJSON = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+            let actualOutputPath = responseJSON["outputPath"] as? String else {
+        throw CoordinatorError.generateFailed("Invalid response from WarmServer")
+      }
+
+      let durationMs = responseJSON["durationMs"] as? Int ?? 0
+
+      // Read the generated image
+      let imageURL = URL(fileURLWithPath: actualOutputPath)
+      let imageData = try Data(contentsOf: imageURL)
+
+      // Determine if we should use sendPhoto or sendDocument (>8MB)
+      let caption = buildCaption(prompt: parsed.prompt, character: parsed.character, durationMs: durationMs)
+
+      if imageData.count > 8_000_000 {
+        // Large image — send as document to avoid Telegram's 10MB sendPhoto limit
+        let _ = try await bot.sendDocument(
+          chatId: chatId,
+          fileData: imageData,
+          filename: outputFilename,
+          mimeType: "image/png",
+          caption: caption
+        )
+      } else {
+        let _ = try await bot.sendPhoto(
+          chatId: chatId,
+          imageData: imageData,
+          filename: outputFilename,
+          caption: caption
+        )
+      }
+
+      logger.info("Render complete: \(outputFilename) (\(durationMs)ms, \(imageData.count / 1024)KB)")
+
+    } catch let error as WarmServerClientError where error.localizedDescription.contains("not running") {
+      let _ = try? await bot.sendMessage(
+        chatId: chatId,
+        text: "WarmServer not available — start <code>ComfyBox serve</code> first."
+      )
+      logger.error("Render failed: WarmServer not running")
+    } catch {
+      let _ = try? await bot.sendMessage(
+        chatId: chatId,
+        text: "Render failed: \(error.localizedDescription)"
+      )
+      logger.error("Render failed: \(error)")
+    }
+  }
+
+  // MARK: - Help & Status
+
+  private func sendHelp(chatId: Int) async {
+    let helpText = """
+    <b>ComfyBox Image Bot</b> (Phase 1)
+
+    Send any text to generate an image.
+
+    <b>Commands:</b>
+    /help — Show this help
+    /status — WarmServer status
+
+    <b>Examples:</b>
+    <i>a golden retriever on a beach at sunset</i>
+    <i>cyberpunk cityscape with neon lights</i>
+
+    <b>Tips:</b>
+    • Be descriptive — more detail = better results
+    • Character names (Kira, Bree, Todd) are detected automatically
+    """
+    let _ = try? await bot.sendMessage(chatId: chatId, text: helpText)
+  }
+
+  private func sendStatus(chatId: Int) async {
+    do {
+      let (status, data) = try await warmServer.get("/health")
+      guard status == 200,
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        let _ = try? await bot.sendMessage(chatId: chatId, text: "WarmServer returned status \(status)")
+        return
+      }
+
+      let serverStatus = json["status"] as? String ?? "unknown"
+      let model = json["model"] as? String ?? "none"
+      let uptime = json["uptimeSeconds"] as? Int ?? 0
+      let queueLength = json["queueLength"] as? Int ?? 0
+      let totalGens = json["totalGenerations"] as? Int ?? 0
+
+      let botUptime = Int(Date().timeIntervalSince(startTime))
+
+      let statusText = """
+      <b>ComfyBox Status</b>
+
+      <b>WarmServer:</b> \(serverStatus)
+      <b>Model:</b> <code>\(model)</code>
+      <b>Queue:</b> \(queueLength) pending
+      <b>Total renders:</b> \(totalGens)
+      <b>Server uptime:</b> \(formatDuration(uptime))
+
+      <b>Bot uptime:</b> \(formatDuration(botUptime))
+      <b>Output:</b> <code>\(config.outputDirectory)</code>
+      """
+      let _ = try? await bot.sendMessage(chatId: chatId, text: statusText)
+
+    } catch {
+      let _ = try? await bot.sendMessage(
+        chatId: chatId,
+        text: "WarmServer not available — start <code>ComfyBox serve</code> first."
+      )
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func buildCaption(prompt: String, character: String?, durationMs: Int) -> String {
+    var parts: [String] = []
+    if let char = character {
+      parts.append("[\(char)]")
+    }
+    let truncatedPrompt = prompt.count > 200 ? String(prompt.prefix(197)) + "..." : prompt
+    parts.append(truncatedPrompt)
+    if durationMs > 0 {
+      let seconds = Double(durationMs) / 1000.0
+      parts.append(String(format: "(%.1fs)", seconds))
+    }
+    return parts.joined(separator: " ")
+  }
+
+  private func formatDuration(_ seconds: Int) -> String {
+    if seconds < 60 { return "\(seconds)s" }
+    if seconds < 3600 { return "\(seconds / 60)m \(seconds % 60)s" }
+    let hours = seconds / 3600
+    let mins = (seconds % 3600) / 60
+    return "\(hours)h \(mins)m"
+  }
+
+  private func parseErrorMessage(_ data: Data) -> String? {
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+    return json["error"] as? String
+  }
+}
+
+// MARK: - Errors
+
+enum CoordinatorError: Error, LocalizedError {
+  case generateFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .generateFailed(let msg): return msg
+    }
+  }
+}

--- a/Sources/ZImage/Telegram/TelegramBot.swift
+++ b/Sources/ZImage/Telegram/TelegramBot.swift
@@ -1,0 +1,427 @@
+// TelegramBot.swift — Zero-dependency Telegram Bot API client
+//
+// Long-polling bot using URLSession. No external dependencies.
+// Handles getUpdates, sendMessage, sendPhoto, sendDocument.
+
+import Foundation
+import Logging
+
+// MARK: - Types
+
+public struct TelegramUpdate: Sendable {
+  public let updateId: Int
+  public let message: TelegramMessage?
+  public let callbackQuery: TelegramCallbackQuery?
+}
+
+public final class TelegramMessage: @unchecked Sendable {
+  public let messageId: Int
+  public let chatId: Int
+  public let userId: Int
+  public let firstName: String
+  public let text: String?
+  public let caption: String?
+  public let photo: [TelegramPhotoSize]?
+  public let replyToMessage: TelegramMessage?
+  public let date: Int
+
+  public init(
+    messageId: Int, chatId: Int, userId: Int, firstName: String,
+    text: String?, caption: String?, photo: [TelegramPhotoSize]?,
+    replyToMessage: TelegramMessage?, date: Int
+  ) {
+    self.messageId = messageId
+    self.chatId = chatId
+    self.userId = userId
+    self.firstName = firstName
+    self.text = text
+    self.caption = caption
+    self.photo = photo
+    self.replyToMessage = replyToMessage
+    self.date = date
+  }
+}
+
+public struct TelegramCallbackQuery: Sendable {
+  public let id: String
+  public let userId: Int
+  public let firstName: String
+  public let messageId: Int?
+  public let chatId: Int?
+  public let data: String?
+}
+
+public struct TelegramPhotoSize: Sendable {
+  public let fileId: String
+  public let width: Int
+  public let height: Int
+}
+
+public struct InlineKeyboard: Sendable {
+  public let rows: [[InlineButton]]
+
+  public func toJSON() -> [[[String: Any]]] {
+    return rows.map { row in
+      row.map { button -> [String: Any] in
+        var dict: [String: Any] = ["text": button.text]
+        dict["callback_data"] = button.callbackData
+        return dict
+      }
+    }
+  }
+}
+
+public struct InlineButton: Sendable {
+  public let text: String
+  public let callbackData: String
+}
+
+public struct SendResult: Sendable {
+  public let ok: Bool
+  public let messageId: Int?
+}
+
+// MARK: - TelegramBot
+
+public final class TelegramBot: @unchecked Sendable {
+  public struct Configuration: Sendable {
+    public let botToken: String
+    public let allowedUserIds: Set<Int>
+    public let pollTimeoutSeconds: Int
+    public let retryDelaySeconds: Int
+
+    public init(
+      botToken: String,
+      allowedUserIds: Set<Int>,
+      pollTimeoutSeconds: Int = 30,
+      retryDelaySeconds: Int = 5
+    ) {
+      self.botToken = botToken
+      self.allowedUserIds = allowedUserIds
+      self.pollTimeoutSeconds = pollTimeoutSeconds
+      self.retryDelaySeconds = retryDelaySeconds
+    }
+  }
+
+  private let config: Configuration
+  private let baseURL: String
+  private let session: URLSession
+  private let logger: Logger
+  private var offset: Int = 0
+  private var running = false
+
+  public init(configuration: Configuration, logger: Logger = Logger(label: "comfybox.telegram")) {
+    self.config = configuration
+    self.baseURL = "https://api.telegram.org/bot\(configuration.botToken)"
+    self.logger = logger
+
+    let sessionConfig = URLSessionConfiguration.ephemeral
+    // Long poll timeout + buffer for network overhead
+    sessionConfig.timeoutIntervalForRequest = TimeInterval(configuration.pollTimeoutSeconds + 10)
+    sessionConfig.timeoutIntervalForResource = TimeInterval(configuration.pollTimeoutSeconds + 30)
+    self.session = URLSession(configuration: sessionConfig)
+  }
+
+  // MARK: - Polling
+
+  /// Start long polling. Runs until stop() is called.
+  public func startPolling(handler: @escaping (TelegramUpdate) async -> Void) async {
+    running = true
+    logger.info("Telegram bot: polling started (allowed users: \(config.allowedUserIds))")
+
+    while running {
+      do {
+        let updates = try await getUpdates()
+        for update in updates {
+          offset = update.updateId + 1
+
+          // Auth check
+          let userId = update.message?.userId ?? update.callbackQuery?.userId
+          guard let uid = userId, config.allowedUserIds.contains(uid) else {
+            if let uid = userId {
+              logger.warning("Telegram bot: rejected update from unauthorized user \(uid)")
+            }
+            continue
+          }
+
+          await handler(update)
+        }
+      } catch {
+        if !running { break }
+        logger.error("Telegram bot: poll error — \(error.localizedDescription). Retrying in \(config.retryDelaySeconds)s.")
+        try? await Task.sleep(nanoseconds: UInt64(config.retryDelaySeconds) * 1_000_000_000)
+      }
+    }
+
+    logger.info("Telegram bot: polling stopped")
+  }
+
+  /// Stop polling gracefully.
+  public func stop() {
+    running = false
+  }
+
+  // MARK: - Outbound API
+
+  /// Send a text message.
+  public func sendMessage(chatId: Int, text: String, replyTo: Int? = nil) async throws -> SendResult {
+    var body: [String: Any] = [
+      "chat_id": chatId,
+      "text": text,
+      "parse_mode": "HTML"
+    ]
+    if let replyTo = replyTo {
+      body["reply_to_message_id"] = replyTo
+    }
+
+    return try await callMethod("sendMessage", body: body)
+  }
+
+  /// Send a photo via multipart/form-data upload.
+  public func sendPhoto(
+    chatId: Int,
+    imageData: Data,
+    filename: String,
+    caption: String? = nil,
+    replyMarkup: InlineKeyboard? = nil
+  ) async throws -> SendResult {
+    let boundary = "ComfyBox-\(UUID().uuidString)"
+    var body = Data()
+
+    // chat_id field
+    appendMultipartField(&body, boundary: boundary, name: "chat_id", value: "\(chatId)")
+
+    // caption field
+    if let caption = caption {
+      appendMultipartField(&body, boundary: boundary, name: "caption", value: caption)
+      appendMultipartField(&body, boundary: boundary, name: "parse_mode", value: "HTML")
+    }
+
+    // reply_markup field
+    if let markup = replyMarkup {
+      let markupJSON: [String: Any] = ["inline_keyboard": markup.toJSON()]
+      if let markupData = try? JSONSerialization.data(withJSONObject: markupJSON),
+         let markupString = String(data: markupData, encoding: .utf8) {
+        appendMultipartField(&body, boundary: boundary, name: "reply_markup", value: markupString)
+      }
+    }
+
+    // photo file
+    appendMultipartFile(&body, boundary: boundary, name: "photo", filename: filename, mimeType: "image/png", data: imageData)
+
+    // Close boundary
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+    guard let url = URL(string: "\(baseURL)/sendPhoto") else {
+      return SendResult(ok: false, messageId: nil)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let (data, _) = try await session.data(for: request)
+    return parseResult(data)
+  }
+
+  /// Send a document via multipart/form-data upload.
+  public func sendDocument(
+    chatId: Int,
+    fileData: Data,
+    filename: String,
+    mimeType: String,
+    caption: String? = nil,
+    replyMarkup: InlineKeyboard? = nil
+  ) async throws -> SendResult {
+    let boundary = "ComfyBox-\(UUID().uuidString)"
+    var body = Data()
+
+    appendMultipartField(&body, boundary: boundary, name: "chat_id", value: "\(chatId)")
+    if let caption = caption {
+      appendMultipartField(&body, boundary: boundary, name: "caption", value: caption)
+      appendMultipartField(&body, boundary: boundary, name: "parse_mode", value: "HTML")
+    }
+    if let markup = replyMarkup {
+      let markupJSON: [String: Any] = ["inline_keyboard": markup.toJSON()]
+      if let markupData = try? JSONSerialization.data(withJSONObject: markupJSON),
+         let markupString = String(data: markupData, encoding: .utf8) {
+        appendMultipartField(&body, boundary: boundary, name: "reply_markup", value: markupString)
+      }
+    }
+
+    appendMultipartFile(&body, boundary: boundary, name: "document", filename: filename, mimeType: mimeType, data: fileData)
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+    guard let url = URL(string: "\(baseURL)/sendDocument") else {
+      return SendResult(ok: false, messageId: nil)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let (data, _) = try await session.data(for: request)
+    return parseResult(data)
+  }
+
+  /// Answer a callback query (acknowledge inline button press).
+  public func answerCallbackQuery(id: String, text: String? = nil) async throws {
+    var body: [String: Any] = ["callback_query_id": id]
+    if let text = text { body["text"] = text }
+    let _ = try await callMethod("answerCallbackQuery", body: body)
+  }
+
+  /// Edit reply markup on an existing message.
+  public func editMessageReplyMarkup(chatId: Int, messageId: Int, markup: InlineKeyboard? = nil) async throws {
+    var body: [String: Any] = [
+      "chat_id": chatId,
+      "message_id": messageId
+    ]
+    if let markup = markup {
+      body["reply_markup"] = ["inline_keyboard": markup.toJSON()]
+    }
+    let _ = try await callMethod("editMessageReplyMarkup", body: body)
+  }
+
+  // MARK: - Private
+
+  private func getUpdates() async throws -> [TelegramUpdate] {
+    let body: [String: Any] = [
+      "offset": offset,
+      "timeout": config.pollTimeoutSeconds,
+      "allowed_updates": ["message", "callback_query"]
+    ]
+
+    guard let url = URL(string: "\(baseURL)/getUpdates") else { return [] }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+    let (data, _) = try await session.data(for: request)
+
+    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let ok = json["ok"] as? Bool, ok,
+          let result = json["result"] as? [[String: Any]] else {
+      return []
+    }
+
+    return result.compactMap { parseUpdate($0) }
+  }
+
+  private func callMethod(_ method: String, body: [String: Any]) async throws -> SendResult {
+    guard let url = URL(string: "\(baseURL)/\(method)") else {
+      return SendResult(ok: false, messageId: nil)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+    let (data, _) = try await session.data(for: request)
+    return parseResult(data)
+  }
+
+  private func parseResult(_ data: Data) -> SendResult {
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return SendResult(ok: false, messageId: nil)
+    }
+    let ok = json["ok"] as? Bool ?? false
+    let messageId = (json["result"] as? [String: Any])?["message_id"] as? Int
+    return SendResult(ok: ok, messageId: messageId)
+  }
+
+  private func parseUpdate(_ json: [String: Any]) -> TelegramUpdate? {
+    guard let updateId = json["update_id"] as? Int else { return nil }
+
+    var message: TelegramMessage? = nil
+    if let msgJson = json["message"] as? [String: Any] {
+      message = parseMessage(msgJson)
+    }
+
+    var callbackQuery: TelegramCallbackQuery? = nil
+    if let cbJson = json["callback_query"] as? [String: Any] {
+      callbackQuery = parseCallbackQuery(cbJson)
+    }
+
+    return TelegramUpdate(updateId: updateId, message: message, callbackQuery: callbackQuery)
+  }
+
+  private func parseMessage(_ json: [String: Any]) -> TelegramMessage? {
+    guard let messageId = json["message_id"] as? Int,
+          let chat = json["chat"] as? [String: Any],
+          let chatId = chat["id"] as? Int else { return nil }
+
+    let from = json["from"] as? [String: Any]
+    let userId = from?["id"] as? Int ?? 0
+    let firstName = from?["first_name"] as? String ?? ""
+
+    var photos: [TelegramPhotoSize]? = nil
+    if let photoArray = json["photo"] as? [[String: Any]] {
+      photos = photoArray.compactMap { p in
+        guard let fileId = p["file_id"] as? String,
+              let width = p["width"] as? Int,
+              let height = p["height"] as? Int else { return nil }
+        return TelegramPhotoSize(fileId: fileId, width: width, height: height)
+      }
+    }
+
+    var replyTo: TelegramMessage? = nil
+    if let replyJson = json["reply_to_message"] as? [String: Any] {
+      replyTo = parseMessage(replyJson)
+    }
+
+    return TelegramMessage(
+      messageId: messageId,
+      chatId: chatId,
+      userId: userId,
+      firstName: firstName,
+      text: json["text"] as? String,
+      caption: json["caption"] as? String,
+      photo: photos,
+      replyToMessage: replyTo,
+      date: json["date"] as? Int ?? 0
+    )
+  }
+
+  private func parseCallbackQuery(_ json: [String: Any]) -> TelegramCallbackQuery? {
+    guard let id = json["id"] as? String else { return nil }
+
+    let from = json["from"] as? [String: Any]
+    let userId = from?["id"] as? Int ?? 0
+    let firstName = from?["first_name"] as? String ?? ""
+
+    let msg = json["message"] as? [String: Any]
+    let messageId = msg?["message_id"] as? Int
+    let chat = msg?["chat"] as? [String: Any]
+    let chatId = chat?["id"] as? Int
+
+    return TelegramCallbackQuery(
+      id: id,
+      userId: userId,
+      firstName: firstName,
+      messageId: messageId,
+      chatId: chatId,
+      data: json["data"] as? String
+    )
+  }
+
+  // MARK: - Multipart Helpers
+
+  private func appendMultipartField(_ body: inout Data, boundary: String, name: String, value: String) {
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+    body.append("\(value)\r\n".data(using: .utf8)!)
+  }
+
+  private func appendMultipartFile(_ body: inout Data, boundary: String, name: String, filename: String, mimeType: String, data: Data) {
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+    body.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+    body.append(data)
+    body.append("\r\n".data(using: .utf8)!)
+  }
+}

--- a/Sources/ZImage/Telegram/TelegramCommandParser.swift
+++ b/Sources/ZImage/Telegram/TelegramCommandParser.swift
@@ -1,0 +1,257 @@
+// TelegramCommandParser.swift — Parse Telegram message text into bot commands.
+//
+// Phase 1: /help, /status, and bare text (render). All other commands defined
+// in the enum but parsed as render with the raw text for forward compatibility.
+
+import Foundation
+
+// MARK: - Command Enum
+
+public enum BotCommand: Sendable {
+  // -- Content modes --
+  case neutral
+  case banana
+  case avocado
+
+  // -- Toggles --
+  case enhance(on: Bool?)
+  case upscale(on: Bool?)
+  case polish(on: Bool?)
+  case verbose(on: Bool?)
+  case autoVideo(on: Bool?)
+  case resolution(target: String?)
+
+  // -- Settings --
+  case aspect(mode: String?)
+  case cfg(value: Double?)
+  case seed(value: Int?)
+  case saturation(value: Double?)
+  case colorTemp(kelvin: Int?)
+  case film(lookId: String?)
+
+  // -- Generation --
+  case render(prompt: String)
+  case batch(count: Int, prompt: String)
+  case vary(count: Int, prompt: String)
+  case sequence(count: Int, story: String)
+  case video(prompt: String)
+
+  // -- Session --
+  case chat
+  case imagine(description: String)
+  case endChat
+  case shipCue
+  case chatMessage(text: String)
+
+  // -- Admin --
+  case status
+  case help
+  case reset
+  case look
+  case queue(subcommand: String?)
+}
+
+// MARK: - Parsed Prompt
+
+public struct ParsedPrompt: Sendable {
+  public let prompt: String
+  public let character: String?
+  public let contentMode: String?
+}
+
+// MARK: - Parser
+
+public enum TelegramCommandParser {
+  // Known characters for detection
+  private static let characterNames = ["kira", "bree", "todd"]
+
+  // Ship-cue phrases
+  private static let shipCues: Set<String> = [
+    "go", "render", "render it", "ship", "ship it",
+    "do it", "let's go", "send it", "fire it"
+  ]
+
+  /// Parse raw message text into a BotCommand.
+  /// `inDiscussMode` controls whether bare text maps to .chatMessage or .render.
+  public static func parse(_ text: String, inDiscussMode: Bool = false) -> BotCommand {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return .render(prompt: trimmed)
+    }
+
+    // Ship cue detection (discuss mode)
+    if inDiscussMode && shipCues.contains(trimmed.lowercased()) {
+      return .shipCue
+    }
+
+    // Command parsing (starts with /)
+    if trimmed.hasPrefix("/") {
+      let parts = trimmed.split(separator: " ", maxSplits: 1)
+      let command = String(parts[0]).lowercased()
+      let args = parts.count > 1 ? String(parts[1]) : nil
+
+      switch command {
+      // Phase 1 commands
+      case "/help":
+        return .help
+      case "/status":
+        return .status
+
+      // Phase 2 commands (defined for forward compat)
+      case "/neutral", "/apple":
+        return .neutral
+      case "/banana":
+        return .banana
+      case "/avocado":
+        return .avocado
+      case "/enhance":
+        return .enhance(on: parseToggle(args))
+
+      // Phase 3 commands
+      case "/batch":
+        if let args = args, let (count, prompt) = parseCountAndPrompt(args, defaultCount: 3) {
+          return .batch(count: count, prompt: prompt)
+        }
+        return .help
+      case "/vary":
+        if let args = args, let (count, prompt) = parseCountAndPrompt(args, defaultCount: 3) {
+          return .vary(count: count, prompt: prompt)
+        }
+        return .help
+      case "/seq", "/sequence":
+        if let args = args, let (count, prompt) = parseCountAndPrompt(args, defaultCount: 4) {
+          return .sequence(count: count, story: prompt)
+        }
+        return .help
+      case "/video":
+        if let args = args { return .video(prompt: args) }
+        return .help
+      case "/upscale":
+        return .upscale(on: parseToggle(args))
+      case "/polish":
+        return .polish(on: parseToggle(args))
+      case "/verbose":
+        return .verbose(on: parseToggle(args))
+      case "/autovideo":
+        return .autoVideo(on: parseToggle(args))
+      case "/aspect":
+        return .aspect(mode: args)
+      case "/cfg":
+        if let args = args, let val = Double(args) { return .cfg(value: val) }
+        return .cfg(value: nil)
+      case "/seed":
+        if let args = args {
+          if args.lowercased() == "random" { return .seed(value: nil) }
+          if let val = Int(args) { return .seed(value: val) }
+        }
+        return .seed(value: nil)
+      case "/saturation":
+        if let args = args {
+          if args.lowercased() == "off" { return .saturation(value: nil) }
+          if let val = Double(args) { return .saturation(value: val) }
+        }
+        return .saturation(value: nil)
+      case "/temp":
+        if let args = args {
+          if args.lowercased() == "off" { return .colorTemp(kelvin: nil) }
+          if let val = Int(args) { return .colorTemp(kelvin: val) }
+        }
+        return .colorTemp(kelvin: nil)
+      case "/film":
+        return .film(lookId: args)
+      case "/2k":
+        return .resolution(target: parseToggle(args) == false ? nil : "2k")
+      case "/4k":
+        return .resolution(target: parseToggle(args) == false ? nil : "4k")
+      case "/reset":
+        return .reset
+      case "/look":
+        return .look
+
+      // Phase 4 commands
+      case "/chat", "/discuss":
+        return .chat
+      case "/imagine":
+        if let args = args { return .imagine(description: args) }
+        return .help
+      case "/end", "/exit":
+        return .endChat
+      case "/queue":
+        return .queue(subcommand: args)
+
+      default:
+        // Unknown command — treat as render prompt
+        return .render(prompt: trimmed)
+      }
+    }
+
+    // Bare text — depends on mode
+    if inDiscussMode {
+      return .chatMessage(text: trimmed)
+    }
+
+    return .render(prompt: trimmed)
+  }
+
+  /// Extract character name and inline mode overrides from a prompt string.
+  public static func parsePrompt(_ text: String, defaultMode: String = "neutral") -> ParsedPrompt {
+    var prompt = text
+    var mode: String? = nil
+
+    // Detect inline mode overrides: /neutral, /banana, /avocado in the prompt text
+    let modePatterns: [(String, String)] = [
+      ("/avocado", "avocado"),
+      ("/banana", "banana"),
+      ("/neutral", "neutral"),
+      ("/apple", "neutral")
+    ]
+    for (pattern, modeName) in modePatterns {
+      if let range = prompt.range(of: pattern, options: .caseInsensitive) {
+        mode = modeName
+        prompt.removeSubrange(range)
+        prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        break
+      }
+    }
+
+    // Detect character name
+    let lowered = prompt.lowercased()
+    var character: String? = nil
+    for name in characterNames {
+      if lowered.contains(name) {
+        character = name.capitalized
+        break
+      }
+    }
+
+    return ParsedPrompt(
+      prompt: prompt,
+      character: character,
+      contentMode: mode
+    )
+  }
+
+  // MARK: - Private Helpers
+
+  private static func parseToggle(_ args: String?) -> Bool? {
+    guard let args = args?.lowercased().trimmingCharacters(in: .whitespaces) else { return nil }
+    switch args {
+    case "on", "true", "yes", "1": return true
+    case "off", "false", "no", "0": return false
+    default: return nil
+    }
+  }
+
+  private static func parseCountAndPrompt(_ args: String, defaultCount: Int) -> (Int, String)? {
+    let parts = args.split(separator: " ", maxSplits: 1)
+    guard !parts.isEmpty else { return nil }
+
+    if let count = Int(parts[0]), parts.count > 1 {
+      let clampedCount = max(1, min(count, 8))
+      return (clampedCount, String(parts[1]))
+    }
+
+    // No count prefix — use default
+    return (defaultCount, args)
+  }
+}


### PR DESCRIPTION
## Summary

- Add native Telegram bot surface to ComfyBox (zero daemon dependency)
- Text prompt received via Telegram long polling, rendered via WarmServer HTTP API, photo sent back via multipart upload
- Three new Swift files under `Sources/ZImage/Telegram/`: `TelegramBot.swift`, `TelegramCommandParser.swift`, `ImageBotCoordinator.swift`
- New `telegram` subcommand in `main.swift` with config file support (`~/.comfybox/telegram.json`), signal handling, caffeinate

## What works (Phase 1)

- Send any text to the bot -> renders image via WarmServer -> sends photo back
- `/help` -- shows available commands
- `/status` -- WarmServer health check
- Auth: only allowed user IDs can interact (default: Todd)
- Large images (>8MB) sent as document instead of photo
- Config resolution: CLI flags > env vars > config file > defaults
- SIGINT/SIGTERM graceful shutdown
- `caffeinate -s` keeps Mac awake while bot runs
- Output saved to `~/Pictures/ComfyBox/Telegram/`

## What is stubbed for Phase 2+

- Full `BotCommand` enum defined (content modes, batch, vary, sequence, etc.)
- `TelegramCommandParser` parses Phase 2+ commands but coordinator returns "not yet available"
- `ParsedPrompt` detects character names (Kira, Bree, Todd) and inline mode overrides

## Build

```
swift build -c release  # Build complete! (18.92s)
ComfyBox telegram --help  # Works
```

## FDD Reference

`Coffee Shop/Specs/2026-06-08-comfybox-telegram-surface-fdd.md` -- Section 6 Phase 1 acceptance criteria.

## Test plan

- [ ] `ComfyBox telegram --help` shows usage
- [ ] Bot receives prompt, sends "Rendering..." status, delivers photo (requires running WarmServer)
- [ ] Unauthorized user gets silently rejected (warning in log)
- [ ] WarmServer down -> user-facing error message, bot keeps polling
- [ ] SIGINT -> clean shutdown
- [ ] Output images saved to `~/Pictures/ComfyBox/Telegram/`

Generated with [Claude Code](https://claude.com/claude-code)