### PR TITLE
feat(telegram): Phase 3 -- full command set

### DIFF
--- a/Sources/ZImage/Telegram/ImageBotCoordinator.swift
+++ b/Sources/ZImage/Telegram/ImageBotCoordinator.swift
@@ -2,6 +2,8 @@
 //
 // Phase 1: Handles text prompts via WarmServer, /help, and /status.
 // Phase 2: Content modes, character injection, prompt optimization.
+// Phase 3: Full command set — batch, vary, sequence, upscale, aspect, cfg,
+//          seed, polish, post-processing (saturation, temp, film), reset.
 // Connects to a running WarmServer instance via WarmServerClient.
 
 import Foundation
@@ -39,24 +41,16 @@ public final class ImageBotCoordinator {
     }
   }
 
-  // MARK: - Session State
-
-  private struct SessionState {
-    var enhanceEnabled: Bool = true
-    var lastPrompt: String? = nil
-    var lastImagePath: String? = nil
-  }
-
   private let config: Configuration
   private let bot: TelegramBot
   private let warmServer: WarmServerClient
   private let contentModeManager: ContentModeManager
   private let characterLoader: CharacterLoader
   private let promptOptimizer: PromptOptimizer
+  private let sessions: SessionState
   private let logger: Logger
   private var isRunning = false
   private let startTime = Date()
-  private var sessions: [Int: SessionState] = [:]  // chatId -> state
 
   public init(configuration: Configuration, logger: Logger = Logger(label: "comfybox.telegram.coordinator")) {
     self.config = configuration
@@ -66,6 +60,7 @@ public final class ImageBotCoordinator {
     self.contentModeManager = ContentModeManager(configPath: configuration.contentModeConfigPath)
     self.characterLoader = CharacterLoader(configPath: configuration.characterConfigPath)
     self.promptOptimizer = PromptOptimizer(configuration: configuration.optimizer, logger: logger)
+    self.sessions = SessionState(defaultEnhance: configuration.optimizer.enabled)
 
     // Ensure output directory exists
     let fileManager = FileManager.default
@@ -98,27 +93,13 @@ public final class ImageBotCoordinator {
     bot.stop()
   }
 
-  // MARK: - Session Helpers
-
-  private func getSession(chatId: Int) -> SessionState {
-    return sessions[chatId] ?? SessionState(enhanceEnabled: config.optimizer.enabled)
-  }
-
-  private func updateSession(chatId: Int, _ block: (inout SessionState) -> Void) {
-    var state = getSession(chatId: chatId)
-    block(&state)
-    sessions[chatId] = state
-  }
-
   // MARK: - Update Handling
 
   private func handleUpdate(_ update: TelegramUpdate) async {
-    // Handle text messages
     if let message = update.message, let text = message.text {
       await handleTextMessage(message: message, text: text)
       return
     }
-
     // Future: handle callback queries, photos, etc.
   }
 
@@ -127,12 +108,17 @@ public final class ImageBotCoordinator {
     let chatId = message.chatId
 
     switch command {
+    // -- Phase 1 --
     case .help:
       await sendHelp(chatId: chatId)
 
     case .status:
       await sendStatus(chatId: chatId)
 
+    case .render(let prompt):
+      await handleRender(chatId: chatId, prompt: prompt, messageId: message.messageId)
+
+    // -- Phase 2 --
     case .neutral:
       contentModeManager.set(.neutral)
       let emoji = ContentModeManager.emoji(for: .neutral)
@@ -152,24 +138,71 @@ public final class ImageBotCoordinator {
       let _ = try? await bot.sendMessage(chatId: chatId, text: "\(emoji) Mode set to <b>\(name)</b>")
 
     case .enhance(let on):
-      let session = getSession(chatId: chatId)
-      let newValue: Bool
-      if let on = on {
-        newValue = on
-      } else {
-        // Toggle
-        newValue = !session.enhanceEnabled
-      }
-      updateSession(chatId: chatId) { $0.enhanceEnabled = newValue }
+      let state = sessions.getState(chatId: chatId)
+      let newValue = on ?? !state.enhanceEnabled
+      sessions.updateState(chatId: chatId) { $0.enhanceEnabled = newValue }
       let stateText = newValue ? "ON" : "OFF"
-      let emoji = newValue ? "\u{2728}" : "\u{1F6D1}"  // sparkles or stop
+      let emoji = newValue ? "\u{2728}" : "\u{1F6D1}"
       let _ = try? await bot.sendMessage(chatId: chatId, text: "\(emoji) Prompt enhancement: <b>\(stateText)</b>")
 
-    case .render(let prompt):
-      await handleRender(chatId: chatId, prompt: prompt, messageId: message.messageId)
+    // -- Phase 3: Generation --
+    case .batch(let count, let prompt):
+      await handleBatch(chatId: chatId, count: count, prompt: prompt)
+
+    case .vary(let count, let prompt):
+      await handleVary(chatId: chatId, count: count, prompt: prompt)
+
+    case .sequence(let count, let story):
+      await handleSequence(chatId: chatId, count: count, story: story)
+
+    // -- Phase 3: Toggles --
+    case .upscale(let on):
+      await handleToggle(chatId: chatId, name: "Upscale (SeedVR 2x)", keyPath: \.upscaleEnabled, value: on)
+
+    case .polish(let on):
+      await handleToggle(chatId: chatId, name: "Polish (two-pass)", keyPath: \.polishEnabled, value: on)
+
+    case .verbose(let on):
+      await handleToggle(chatId: chatId, name: "Verbose", keyPath: \.verboseEnabled, value: on)
+
+    case .autoVideo(let on):
+      await handleToggle(chatId: chatId, name: "Auto-video", keyPath: \.autoVideoEnabled, value: on)
+
+    case .resolution(let target):
+      await handleResolution(chatId: chatId, target: target)
+
+    // -- Phase 3: Settings --
+    case .aspect(let mode):
+      await handleAspect(chatId: chatId, mode: mode)
+
+    case .cfg(let value):
+      await handleCfg(chatId: chatId, value: value)
+
+    case .seed(let value):
+      await handleSeed(chatId: chatId, value: value)
+
+    // -- Phase 3: Post-processing --
+    case .saturation(let value):
+      await handleSaturation(chatId: chatId, value: value)
+
+    case .colorTemp(let kelvin):
+      await handleColorTemp(chatId: chatId, kelvin: kelvin)
+
+    case .film(let lookId):
+      await handleFilm(chatId: chatId, lookId: lookId)
+
+    case .reset:
+      await handleReset(chatId: chatId)
+
+    case .look:
+      await sendLookList(chatId: chatId)
+
+    // -- Deferred --
+    case .video:
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "Video generation routes through the daemon. Use Bree's <code>/video</code> command on the server.")
 
     default:
-      // Phase 3+ commands not yet implemented
       let _ = try? await bot.sendMessage(
         chatId: chatId,
         text: "Command not yet available. Send a text prompt to generate an image, or /help for commands."
@@ -177,7 +210,167 @@ public final class ImageBotCoordinator {
     }
   }
 
-  // MARK: - Render Flow
+  // MARK: - Toggle Handler
+
+  private func handleToggle(chatId: Int, name: String, keyPath: WritableKeyPath<ChatState, Bool>, value: Bool?) async {
+    let state = sessions.getState(chatId: chatId)
+    let current = state[keyPath: keyPath]
+    let newValue = value ?? !current
+    sessions.updateState(chatId: chatId) { $0[keyPath: keyPath] = newValue }
+    let stateText = newValue ? "ON" : "OFF"
+    let emoji = newValue ? "\u{2705}" : "\u{274C}"
+    let _ = try? await bot.sendMessage(chatId: chatId, text: "\(emoji) \(name): <b>\(stateText)</b>")
+  }
+
+  // MARK: - Resolution
+
+  private func handleResolution(chatId: Int, target: String?) async {
+    if let target = target {
+      sessions.updateState(chatId: chatId) { $0.resolutionTarget = target }
+      // Also enable upscale since resolution targets require it
+      sessions.updateState(chatId: chatId) { $0.upscaleEnabled = true }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F4D0} Resolution target: <b>\(target.uppercased())</b> (upscale enabled)")
+    } else {
+      sessions.updateState(chatId: chatId) {
+        $0.resolutionTarget = nil
+        $0.upscaleEnabled = false
+      }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F4D0} Resolution target: <b>OFF</b> (upscale disabled)")
+    }
+  }
+
+  // MARK: - Aspect
+
+  private func handleAspect(chatId: Int, mode: String?) async {
+    guard let mode = mode?.lowercased().trimmingCharacters(in: .whitespaces) else {
+      let state = sessions.getState(chatId: chatId)
+      let dims = state.aspectDimensions()
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F4D0} Current aspect: <b>\(state.aspectMode)</b> (\(dims.width)x\(dims.height))\n\nOptions: square, portrait, landscape, wide, tall")
+      return
+    }
+    let validModes = ["square", "portrait", "landscape", "wide", "tall"]
+    guard validModes.contains(mode) else {
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "Invalid aspect mode. Options: <code>square</code>, <code>portrait</code>, <code>landscape</code>, <code>wide</code>, <code>tall</code>")
+      return
+    }
+    sessions.updateState(chatId: chatId) { $0.aspectMode = mode }
+    let dims = ChatState.dimensionsForAspect(mode)
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{1F4D0} Aspect: <b>\(mode)</b> (\(dims.width)x\(dims.height))")
+  }
+
+  // MARK: - CFG
+
+  private func handleCfg(chatId: Int, value: Double?) async {
+    if let value = value {
+      guard value >= 0 && value <= 20 else {
+        let _ = try? await bot.sendMessage(chatId: chatId, text: "CFG value must be between 0 and 20.")
+        return
+      }
+      sessions.updateState(chatId: chatId) { $0.cfgOverride = value }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{2699}\u{FE0F} CFG override: <b>\(String(format: "%.1f", value))</b>")
+    } else {
+      sessions.updateState(chatId: chatId) { $0.cfgOverride = nil }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{2699}\u{FE0F} CFG override: <b>OFF</b> (using model default)")
+    }
+  }
+
+  // MARK: - Seed
+
+  private func handleSeed(chatId: Int, value: Int?) async {
+    sessions.updateState(chatId: chatId) { $0.seedLock = value }
+    if let value = value {
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3B2} Seed locked: <b>\(value)</b>")
+    } else {
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3B2} Seed: <b>random</b>")
+    }
+  }
+
+  // MARK: - Post-Processing Settings
+
+  private func handleSaturation(chatId: Int, value: Double?) async {
+    if let value = value {
+      guard value >= 0 && value <= 2 else {
+        let _ = try? await bot.sendMessage(chatId: chatId, text: "Saturation must be between 0 and 2.")
+        return
+      }
+      sessions.updateState(chatId: chatId) { $0.saturation = value }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3A8} Saturation: <b>\(String(format: "%.1f", value))</b>")
+    } else {
+      sessions.updateState(chatId: chatId) { $0.saturation = nil }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3A8} Saturation: <b>OFF</b>")
+    }
+  }
+
+  private func handleColorTemp(chatId: Int, kelvin: Int?) async {
+    if let kelvin = kelvin {
+      guard kelvin >= 2000 && kelvin <= 10000 else {
+        let _ = try? await bot.sendMessage(chatId: chatId, text: "Color temperature must be between 2000 and 10000K.")
+        return
+      }
+      sessions.updateState(chatId: chatId) { $0.colorTemp = kelvin }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F321}\u{FE0F} Color temperature: <b>\(kelvin)K</b>")
+    } else {
+      sessions.updateState(chatId: chatId) { $0.colorTemp = nil }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F321}\u{FE0F} Color temperature: <b>OFF</b>")
+    }
+  }
+
+  private func handleFilm(chatId: Int, lookId: String?) async {
+    guard let lookId = lookId else {
+      // No argument — show current + available looks
+      await sendLookList(chatId: chatId)
+      return
+    }
+    if lookId.lowercased() == "off" {
+      sessions.updateState(chatId: chatId) { $0.filmLook = nil }
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3AC} Film look: <b>OFF</b>")
+      return
+    }
+    guard PostProcessor.findLook(lookId) != nil else {
+      let available = PostProcessor.availableLooks().map { "<code>\($0.id)</code>" }.joined(separator: ", ")
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "Unknown film look '<code>\(lookId)</code>'.\n\nAvailable: \(available)")
+      return
+    }
+    sessions.updateState(chatId: chatId) { $0.filmLook = lookId }
+    let name = PostProcessor.findLook(lookId)?.name ?? lookId
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{1F3AC} Film look: <b>\(name)</b>")
+  }
+
+  private func handleReset(chatId: Int) async {
+    sessions.updateState(chatId: chatId) { $0.resetPostProcessing() }
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{1F504} Post-processing settings cleared (saturation, color temp, film look).")
+  }
+
+  private func sendLookList(chatId: Int) async {
+    let looks = PostProcessor.availableLooks()
+    let state = sessions.getState(chatId: chatId)
+    var lines: [String] = ["<b>Available Film Looks:</b>\n"]
+    for look in looks {
+      let active = state.filmLook?.lowercased() == look.id.lowercased() ? " \u{2705}" : ""
+      lines.append("\u{2022} <code>\(look.id)</code> \u{2014} \(look.name)\(active)")
+    }
+    lines.append("\nUsage: <code>/film kodak-portra</code> or <code>/film off</code>")
+    let _ = try? await bot.sendMessage(chatId: chatId, text: lines.joined(separator: "\n"))
+  }
+
+  // MARK: - Single Render
 
   private func handleRender(chatId: Int, prompt: String, messageId: Int) async {
     guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -185,146 +378,607 @@ public final class ImageBotCoordinator {
       return
     }
 
-    // Parse prompt for character detection and inline mode overrides
+    let state = sessions.getState(chatId: chatId)
+    let parsed = parseAndResolve(prompt: prompt)
+
+    // Send status
+    let statusText = buildStatusText(parsed: parsed, state: state, index: nil, total: nil)
+    let statusResult = try? await bot.sendMessage(chatId: chatId, text: statusText)
+
+    // Generate
+    let result = await generateImage(
+      prompt: parsed.prompt,
+      character: parsed.character,
+      characterDescription: parsed.characterDescription,
+      effectiveMode: parsed.effectiveMode,
+      state: state,
+      seed: state.seedLock
+    )
+
+    switch result {
+    case .success(let render):
+      // Post-process
+      let finalData = applyPostProcessing(imageData: render.imageData, state: state, wasUpscaled: render.wasUpscaled)
+
+      // Build caption
+      let caption = buildCaption(
+        prompt: parsed.rawPrompt,
+        character: parsed.character,
+        mode: parsed.effectiveMode,
+        durationMs: render.durationMs,
+        enhanced: state.enhanceEnabled,
+        seed: render.seed,
+        state: state
+      )
+
+      // Send
+      await sendImage(chatId: chatId, imageData: finalData, filename: render.filename, caption: caption)
+
+      // Update session
+      sessions.updateState(chatId: chatId) {
+        $0.lastPrompt = parsed.rawPrompt
+        $0.lastImagePath = render.outputPath
+        $0.lastSeed = render.seed
+      }
+
+      // Copy to gallery
+      copyToGallery(outputPath: render.outputPath, filename: render.filename)
+
+      logger.info("Render complete: \(render.filename) (\(render.durationMs)ms)")
+
+    case .failure(let error):
+      await sendError(chatId: chatId, error: error)
+    }
+  }
+
+  // MARK: - Batch
+
+  private func handleBatch(chatId: Int, count: Int, prompt: String) async {
+    let state = sessions.getState(chatId: chatId)
+    let parsed = parseAndResolve(prompt: prompt)
+
+    let statusText = "\u{1F4E6} Batch: rendering \(count) images..."
+    let statusResult = try? await bot.sendMessage(chatId: chatId, text: statusText)
+    let statusMsgId = statusResult?.messageId
+
+    for i in 0..<count {
+      // Update progress
+      if let msgId = statusMsgId {
+        let _ = try? await bot.sendMessage(chatId: chatId,
+          text: "\u{1F4E6} Rendering \(i + 1)/\(count)...")
+      }
+
+      let result = await generateImage(
+        prompt: parsed.prompt,
+        character: parsed.character,
+        characterDescription: parsed.characterDescription,
+        effectiveMode: parsed.effectiveMode,
+        state: state,
+        seed: nil  // Different seed each time
+      )
+
+      switch result {
+      case .success(let render):
+        let finalData = applyPostProcessing(imageData: render.imageData, state: state, wasUpscaled: render.wasUpscaled)
+        let caption = "\(i + 1)/\(count) \u{2014} seed:\(render.seed ?? 0)"
+        await sendImage(chatId: chatId, imageData: finalData, filename: render.filename, caption: caption)
+        copyToGallery(outputPath: render.outputPath, filename: render.filename)
+
+      case .failure(let error):
+        await sendError(chatId: chatId, error: error)
+        return  // Abort batch on error
+      }
+    }
+
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{2705} Batch complete: \(count) images delivered.")
+  }
+
+  // MARK: - Vary
+
+  private func handleVary(chatId: Int, count: Int, prompt: String) async {
+    let state = sessions.getState(chatId: chatId)
+    let parsed = parseAndResolve(prompt: prompt)
+
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{1F500} Vary: generating \(count) prompt variations...")
+
+    for i in 0..<count {
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F500} Variation \(i + 1)/\(count)...")
+
+      // Call optimizer with variation instruction for each
+      let variedPrompt: String
+      if state.enhanceEnabled {
+        let variationInstruction = "Create variation #\(i + 1) of this scene. Change the angle, lighting, or composition while keeping the same subject and mood."
+        let result = await promptOptimizer.optimize(
+          prompt: "\(parsed.prompt) [\(variationInstruction)]",
+          character: parsed.character,
+          characterDescription: parsed.characterDescription,
+          contentMode: parsed.effectiveMode.rawValue
+        )
+        variedPrompt = result.prompt
+      } else {
+        variedPrompt = parsed.prompt
+      }
+
+      let renderResult = await generateImageDirect(
+        finalPrompt: variedPrompt,
+        state: state,
+        seed: nil
+      )
+
+      switch renderResult {
+      case .success(let render):
+        let finalData = applyPostProcessing(imageData: render.imageData, state: state, wasUpscaled: render.wasUpscaled)
+        let caption = "Variation \(i + 1)/\(count)"
+        await sendImage(chatId: chatId, imageData: finalData, filename: render.filename, caption: caption)
+        copyToGallery(outputPath: render.outputPath, filename: render.filename)
+
+      case .failure(let error):
+        await sendError(chatId: chatId, error: error)
+        return
+      }
+    }
+
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{2705} Variations complete: \(count) images delivered.")
+  }
+
+  // MARK: - Sequence
+
+  private func handleSequence(chatId: Int, count: Int, story: String) async {
+    let state = sessions.getState(chatId: chatId)
+    let parsed = parseAndResolve(prompt: story)
+
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{1F3AC} Sequence: breaking story into \(count) frames...")
+
+    // Use optimizer to break story into N sequential frame prompts
+    let framePrompts: [String]
+    if state.enhanceEnabled {
+      let breakdownInstruction = """
+      Break this story into exactly \(count) sequential scene descriptions for image generation.
+      Each scene should be a complete, self-contained image prompt.
+      Number each scene. Output ONLY the numbered scenes, nothing else.
+      Story: \(parsed.prompt)
+      """
+
+      let breakdownResult = await promptOptimizer.optimize(
+        prompt: breakdownInstruction,
+        character: parsed.character,
+        characterDescription: parsed.characterDescription,
+        contentMode: parsed.effectiveMode.rawValue
+      )
+
+      // Parse the numbered output into individual prompts
+      framePrompts = parseNumberedScenes(breakdownResult.prompt, expectedCount: count)
+    } else {
+      // No optimizer — split by sentence or use the same prompt for each frame
+      framePrompts = splitStoryIntoFrames(story, count: count)
+    }
+
+    let actualCount = min(framePrompts.count, count)
+
+    for i in 0..<actualCount {
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "\u{1F3AC} Frame \(i + 1)/\(actualCount)...")
+
+      // Optimize each frame prompt individually
+      let framePrompt: String
+      if state.enhanceEnabled {
+        let result = await promptOptimizer.optimize(
+          prompt: framePrompts[i],
+          character: parsed.character,
+          characterDescription: parsed.characterDescription,
+          contentMode: parsed.effectiveMode.rawValue
+        )
+        framePrompt = result.prompt
+      } else {
+        if let desc = parsed.characterDescription {
+          framePrompt = "\(desc)\n\n\(framePrompts[i])"
+        } else {
+          framePrompt = framePrompts[i]
+        }
+      }
+
+      let renderResult = await generateImageDirect(
+        finalPrompt: framePrompt,
+        state: state,
+        seed: nil
+      )
+
+      switch renderResult {
+      case .success(let render):
+        let finalData = applyPostProcessing(imageData: render.imageData, state: state, wasUpscaled: render.wasUpscaled)
+        let truncatedScene = framePrompts[i].count > 100
+          ? String(framePrompts[i].prefix(97)) + "..."
+          : framePrompts[i]
+        let caption = "Frame \(i + 1)/\(actualCount) \u{2014} \(truncatedScene)"
+        await sendImage(chatId: chatId, imageData: finalData, filename: render.filename, caption: caption)
+        copyToGallery(outputPath: render.outputPath, filename: render.filename)
+
+      case .failure(let error):
+        await sendError(chatId: chatId, error: error)
+        return
+      }
+    }
+
+    let _ = try? await bot.sendMessage(chatId: chatId,
+      text: "\u{2705} Sequence complete: \(actualCount) frames delivered.")
+  }
+
+  // MARK: - Render Pipeline
+
+  private struct ParsedContext {
+    let rawPrompt: String
+    let prompt: String
+    let character: String?
+    let characterDescription: String?
+    let effectiveMode: ContentModeManager.Mode
+  }
+
+  private func parseAndResolve(prompt: String) -> ParsedContext {
     let currentMode = contentModeManager.current
     let parsed = TelegramCommandParser.parsePrompt(prompt, defaultMode: currentMode.rawValue)
-
-    // Resolve effective content mode (inline override > session mode)
     let effectiveMode: ContentModeManager.Mode
     if let overrideMode = parsed.contentMode, let mode = ContentModeManager.Mode(rawValue: overrideMode) {
       effectiveMode = mode
     } else {
       effectiveMode = currentMode
     }
-
-    // Look up character description
     var characterDescription: String? = nil
     if let charName = parsed.character {
       characterDescription = characterLoader.description(for: charName, mode: effectiveMode)
     }
+    return ParsedContext(
+      rawPrompt: prompt,
+      prompt: parsed.prompt,
+      character: parsed.character,
+      characterDescription: characterDescription,
+      effectiveMode: effectiveMode
+    )
+  }
 
-    // Send status message
-    let session = getSession(chatId: chatId)
-    let modeEmoji = ContentModeManager.emoji(for: effectiveMode)
-    let enhanceEmoji = session.enhanceEnabled ? "\u{2728}" : ""
-    let charTag = parsed.character != nil ? " [\(parsed.character!)]" : ""
-    let statusText = "\(modeEmoji)\(enhanceEmoji) Rendering\(charTag)..."
-    let statusResult = try? await bot.sendMessage(chatId: chatId, text: statusText)
+  private struct RenderResult {
+    let imageData: Data
+    let outputPath: String
+    let filename: String
+    let durationMs: Int
+    let seed: Int?
+    let wasUpscaled: Bool
+  }
 
-    // Optimize prompt if enhancement is enabled
+  /// Full render pipeline: optimize prompt -> generate -> optional upscale -> optional polish.
+  private func generateImage(
+    prompt: String,
+    character: String?,
+    characterDescription: String?,
+    effectiveMode: ContentModeManager.Mode,
+    state: ChatState,
+    seed: Int?
+  ) async -> Result<RenderResult, RenderError> {
+    // Optimize prompt
     let finalPrompt: String
-    var optimizeNote: String? = nil
-    if session.enhanceEnabled {
+    if state.enhanceEnabled {
       let result = await promptOptimizer.optimize(
-        prompt: parsed.prompt,
-        character: parsed.character,
+        prompt: prompt,
+        character: character,
         characterDescription: characterDescription,
         contentMode: effectiveMode.rawValue
       )
       finalPrompt = result.prompt
-      optimizeNote = result.note
-      if result.enhanced {
-        logger.info("Prompt enhanced: \(result.prompt.prefix(100))...")
-      }
     } else {
-      // Enhancement off — inject character description manually but use raw prompt
       if let desc = characterDescription {
-        finalPrompt = "\(desc)\n\n\(parsed.prompt)"
+        finalPrompt = "\(desc)\n\n\(prompt)"
       } else {
-        finalPrompt = parsed.prompt
+        finalPrompt = prompt
       }
     }
 
-    // Generate via WarmServer
+    return await generateImageDirect(finalPrompt: finalPrompt, state: state, seed: seed)
+  }
+
+  /// Generate image with an already-resolved prompt. Handles upscale and polish.
+  private func generateImageDirect(
+    finalPrompt: String,
+    state: ChatState,
+    seed: Int?
+  ) async -> Result<RenderResult, RenderError> {
     let outputFilename = "telegram-\(Int(Date().timeIntervalSince1970))-\(UInt32.random(in: 0...999999)).png"
     let outputPath = (config.outputDirectory as NSString).appendingPathComponent(outputFilename)
 
     do {
-      // Build generate request
+      let dims = state.aspectDimensions()
       var body: [String: Any] = [
         "prompt": finalPrompt,
-        "outputPath": outputPath
+        "outputPath": outputPath,
+        "width": dims.width,
+        "height": dims.height
       ]
 
-      // Use default dimensions for Telegram (1024x1024)
-      body["width"] = 1024
-      body["height"] = 1024
+      if let cfg = state.cfgOverride {
+        body["guidance"] = cfg
+      }
+      if let seedVal = seed ?? state.seedLock {
+        body["seed"] = seedVal
+      }
 
       let jsonData = try JSONSerialization.data(withJSONObject: body)
       let (status, responseData) = try await warmServer.post("/v1/generate", body: jsonData)
 
       guard status == 200 else {
         let errorMsg = parseErrorMessage(responseData) ?? "WarmServer returned status \(status)"
-        throw CoordinatorError.generateFailed(errorMsg)
+        return .failure(.generateFailed(errorMsg))
       }
 
-      // Parse response to get output path
       guard let responseJSON = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
             let actualOutputPath = responseJSON["outputPath"] as? String else {
-        throw CoordinatorError.generateFailed("Invalid response from WarmServer")
+        return .failure(.generateFailed("Invalid response from WarmServer"))
       }
 
       let durationMs = responseJSON["durationMs"] as? Int ?? 0
+      let responseSeed = responseJSON["seed"] as? Int
 
-      // Read the generated image
+      // Read generated image
       let imageURL = URL(fileURLWithPath: actualOutputPath)
-      let imageData = try Data(contentsOf: imageURL)
+      var imageData = try Data(contentsOf: imageURL)
+      var wasUpscaled = false
+      var finalOutputPath = actualOutputPath
+      var totalDuration = durationMs
 
-      // Build caption
-      let caption = buildCaption(
-        prompt: parsed.prompt,
-        character: parsed.character,
-        mode: effectiveMode,
-        durationMs: durationMs,
-        enhanced: session.enhanceEnabled,
-        optimizeNote: optimizeNote
-      )
-
-      if imageData.count > 8_000_000 {
-        // Large image — send as document to avoid Telegram's 10MB sendPhoto limit
-        let _ = try await bot.sendDocument(
-          chatId: chatId,
-          fileData: imageData,
-          filename: outputFilename,
-          mimeType: "image/png",
-          caption: caption
-        )
-      } else {
-        let _ = try await bot.sendPhoto(
-          chatId: chatId,
-          imageData: imageData,
-          filename: outputFilename,
-          caption: caption
-        )
+      // Polish pass (two-pass: re-render with higher steps at lower strength)
+      if state.polishEnabled {
+        let polishResult = await polishImage(imagePath: actualOutputPath, prompt: finalPrompt, state: state)
+        if case .success(let polished) = polishResult {
+          imageData = polished.data
+          totalDuration += polished.durationMs
+          finalOutputPath = polished.outputPath
+        }
       }
 
-      // Update session state
-      updateSession(chatId: chatId) {
-        $0.lastPrompt = parsed.prompt
-        $0.lastImagePath = actualOutputPath
+      // Upscale pass
+      if state.upscaleEnabled {
+        let upscaleResult = await upscaleImage(imagePath: finalOutputPath, state: state)
+        if case .success(let upscaled) = upscaleResult {
+          imageData = upscaled.data
+          totalDuration += upscaled.durationMs
+          finalOutputPath = upscaled.outputPath
+          wasUpscaled = true
+        }
       }
 
-      // Copy to gallery if configured
-      if let galleryDir = config.galleryDirectory {
-        let galleryPath = (galleryDir as NSString).appendingPathComponent(outputFilename)
-        try? FileManager.default.copyItem(atPath: actualOutputPath, toPath: galleryPath)
+      // Double upscale for 4K (render -> 2K -> 4K)
+      if state.resolutionTarget == "4k" && wasUpscaled {
+        let secondUpscaleResult = await upscaleImage(imagePath: finalOutputPath, state: state)
+        if case .success(let upscaled) = secondUpscaleResult {
+          imageData = upscaled.data
+          totalDuration += upscaled.durationMs
+          finalOutputPath = upscaled.outputPath
+        }
       }
 
-      logger.info("Render complete: \(outputFilename) (\(durationMs)ms, \(imageData.count / 1024)KB, mode: \(effectiveMode.rawValue))")
+      return .success(RenderResult(
+        imageData: imageData,
+        outputPath: finalOutputPath,
+        filename: outputFilename,
+        durationMs: totalDuration,
+        seed: responseSeed,
+        wasUpscaled: wasUpscaled
+      ))
 
-    } catch let error as WarmServerClientError where error.localizedDescription.contains("not running") {
-      let _ = try? await bot.sendMessage(
-        chatId: chatId,
-        text: "WarmServer not available \u{2014} start <code>ComfyBox serve</code> first."
-      )
-      logger.error("Render failed: WarmServer not running")
+    } catch let error as WarmServerClientError {
+      return .failure(.warmServerDown(error.localizedDescription))
     } catch {
-      let _ = try? await bot.sendMessage(
-        chatId: chatId,
-        text: "Render failed: \(error.localizedDescription)"
-      )
-      logger.error("Render failed: \(error)")
+      return .failure(.generateFailed(error.localizedDescription))
     }
+  }
+
+  // MARK: - Upscale
+
+  private struct UpscaleOutput {
+    let data: Data
+    let outputPath: String
+    let durationMs: Int
+  }
+
+  private func upscaleImage(imagePath: String, state: ChatState) async -> Result<UpscaleOutput, RenderError> {
+    let upscaledPath = imagePath.replacingOccurrences(of: ".png", with: "-upscaled.png")
+
+    do {
+      let body: [String: Any] = [
+        "image_path": imagePath,
+        "output_path": upscaledPath,
+        "target_resolution": 1024  // Safe default
+      ]
+      let jsonData = try JSONSerialization.data(withJSONObject: body)
+      let (status, responseData) = try await warmServer.post("/v1/upscale", body: jsonData)
+
+      guard status == 200 else {
+        let errorMsg = parseErrorMessage(responseData) ?? "Upscale returned status \(status)"
+        return .failure(.upscaleFailed(errorMsg))
+      }
+
+      guard let responseJSON = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+            let outputPath = responseJSON["outputPath"] as? String ?? responseJSON["output_path"] as? String else {
+        return .failure(.upscaleFailed("Invalid upscale response"))
+      }
+
+      let durationMs = responseJSON["durationMs"] as? Int ?? responseJSON["duration_ms"] as? Int ?? 0
+      let data = try Data(contentsOf: URL(fileURLWithPath: outputPath))
+
+      return .success(UpscaleOutput(data: data, outputPath: outputPath, durationMs: durationMs))
+    } catch {
+      return .failure(.upscaleFailed(error.localizedDescription))
+    }
+  }
+
+  // MARK: - Polish (Two-Pass)
+
+  private struct PolishOutput {
+    let data: Data
+    let outputPath: String
+    let durationMs: Int
+  }
+
+  private func polishImage(imagePath: String, prompt: String, state: ChatState) async -> Result<PolishOutput, RenderError> {
+    let polishedPath = imagePath.replacingOccurrences(of: ".png", with: "-polished.png")
+
+    do {
+      let dims = state.aspectDimensions()
+      var body: [String: Any] = [
+        "prompt": prompt,
+        "outputPath": polishedPath,
+        "width": dims.width,
+        "height": dims.height,
+        "image_path": imagePath,
+        "strength": 0.35,
+        "steps": 30
+      ]
+      if let cfg = state.cfgOverride {
+        body["guidance"] = cfg
+      }
+
+      let jsonData = try JSONSerialization.data(withJSONObject: body)
+      let (status, responseData) = try await warmServer.post("/v1/generate", body: jsonData)
+
+      guard status == 200 else {
+        let errorMsg = parseErrorMessage(responseData) ?? "Polish returned status \(status)"
+        return .failure(.generateFailed(errorMsg))
+      }
+
+      guard let responseJSON = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+            let outputPath = responseJSON["outputPath"] as? String else {
+        return .failure(.generateFailed("Invalid polish response"))
+      }
+
+      let durationMs = responseJSON["durationMs"] as? Int ?? 0
+      let data = try Data(contentsOf: URL(fileURLWithPath: outputPath))
+
+      return .success(PolishOutput(data: data, outputPath: outputPath, durationMs: durationMs))
+    } catch {
+      return .failure(.generateFailed(error.localizedDescription))
+    }
+  }
+
+  // MARK: - Post-Processing
+
+  private func applyPostProcessing(imageData: Data, state: ChatState, wasUpscaled: Bool) -> Data {
+    guard state.hasPostProcessing || wasUpscaled else { return imageData }
+
+    return PostProcessor.applyPipeline(
+      imageData: imageData,
+      saturation: state.saturation,
+      colorTemp: state.colorTemp,
+      filmLookId: state.filmLook,
+      sharpenAfterUpscale: wasUpscaled
+    )
+  }
+
+  // MARK: - Send Helpers
+
+  private func sendImage(chatId: Int, imageData: Data, filename: String, caption: String) async {
+    if imageData.count > 8_000_000 {
+      let _ = try? await bot.sendDocument(
+        chatId: chatId,
+        fileData: imageData,
+        filename: filename,
+        mimeType: "image/png",
+        caption: caption
+      )
+    } else {
+      let _ = try? await bot.sendPhoto(
+        chatId: chatId,
+        imageData: imageData,
+        filename: filename,
+        caption: caption
+      )
+    }
+  }
+
+  private func sendError(chatId: Int, error: RenderError) async {
+    switch error {
+    case .warmServerDown:
+      let _ = try? await bot.sendMessage(chatId: chatId,
+        text: "WarmServer not available \u{2014} start <code>ComfyBox serve</code> first.")
+    case .generateFailed(let msg):
+      let _ = try? await bot.sendMessage(chatId: chatId, text: "Render failed: \(msg)")
+    case .upscaleFailed(let msg):
+      let _ = try? await bot.sendMessage(chatId: chatId, text: "Upscale failed: \(msg)")
+    }
+    logger.error("Render error: \(error)")
+  }
+
+  private func copyToGallery(outputPath: String, filename: String) {
+    if let galleryDir = config.galleryDirectory {
+      let galleryPath = (galleryDir as NSString).appendingPathComponent(filename)
+      try? FileManager.default.copyItem(atPath: outputPath, toPath: galleryPath)
+    }
+  }
+
+  // MARK: - Status Text Builder
+
+  private func buildStatusText(parsed: ParsedContext, state: ChatState, index: Int?, total: Int?) -> String {
+    let modeEmoji = ContentModeManager.emoji(for: parsed.effectiveMode)
+    let enhanceEmoji = state.enhanceEnabled ? "\u{2728}" : ""
+    let charTag = parsed.character != nil ? " [\(parsed.character!)]" : ""
+    var extras: [String] = []
+    if state.upscaleEnabled { extras.append("upscale") }
+    if state.polishEnabled { extras.append("polish") }
+    if let look = state.filmLook { extras.append(look) }
+    let extrasStr = extras.isEmpty ? "" : " [\(extras.joined(separator: ", "))]"
+    let countStr: String
+    if let i = index, let t = total {
+      countStr = " \(i)/\(t)"
+    } else {
+      countStr = ""
+    }
+    return "\(modeEmoji)\(enhanceEmoji) Rendering\(charTag)\(extrasStr)\(countStr)..."
+  }
+
+  // MARK: - Caption Builder
+
+  private func buildCaption(
+    prompt: String,
+    character: String?,
+    mode: ContentModeManager.Mode,
+    durationMs: Int,
+    enhanced: Bool,
+    seed: Int?,
+    state: ChatState
+  ) -> String {
+    var parts: [String] = []
+
+    let modeEmoji = ContentModeManager.emoji(for: mode)
+    if let char = character {
+      parts.append("\(modeEmoji) [\(char)]")
+    } else {
+      parts.append(modeEmoji)
+    }
+
+    let truncatedPrompt = prompt.count > 180 ? String(prompt.prefix(177)) + "..." : prompt
+    parts.append(truncatedPrompt)
+
+    if durationMs > 0 {
+      let seconds = Double(durationMs) / 1000.0
+      parts.append(String(format: "(%.1fs)", seconds))
+    }
+
+    if enhanced { parts.append("\u{2728}") }
+    if let s = seed { parts.append("seed:\(s)") }
+
+    // Active settings indicators
+    var indicators: [String] = []
+    if state.upscaleEnabled { indicators.append("up") }
+    if state.polishEnabled { indicators.append("pol") }
+    if state.saturation != nil { indicators.append("sat") }
+    if state.colorTemp != nil { indicators.append("temp") }
+    if state.filmLook != nil { indicators.append("film") }
+    if !indicators.isEmpty {
+      parts.append("[\(indicators.joined(separator: "+"))]")
+    }
+
+    return parts.joined(separator: " ")
   }
 
   // MARK: - Help & Status
@@ -333,9 +987,10 @@ public final class ImageBotCoordinator {
     let mode = contentModeManager.current
     let modeEmoji = ContentModeManager.emoji(for: mode)
     let modeName = ContentModeManager.displayName(for: mode)
-    let session = getSession(chatId: chatId)
-    let enhanceState = session.enhanceEnabled ? "ON" : "OFF"
+    let state = sessions.getState(chatId: chatId)
+    let enhanceState = state.enhanceEnabled ? "ON" : "OFF"
     let charList = characterLoader.allNames().map { $0.capitalized }.joined(separator: ", ")
+    let dims = state.aspectDimensions()
 
     let helpText = """
     <b>ComfyBox Image Bot</b>
@@ -347,8 +1002,27 @@ public final class ImageBotCoordinator {
     /banana \u{2014} Suggestive mode
     /avocado \u{2014} Explicit mode
 
+    <b>Generation:</b>
+    /batch &lt;N&gt; &lt;prompt&gt; \u{2014} Generate N images (2-8)
+    /vary [N] &lt;prompt&gt; \u{2014} N prompt variations (default 3)
+    /seq &lt;N&gt; &lt;story&gt; \u{2014} N sequential story frames
+
     <b>Settings:</b>
-    /enhance [on|off] \u{2014} Toggle prompt optimization
+    /enhance [on|off] \u{2014} Prompt optimization
+    /aspect &lt;mode&gt; \u{2014} square/portrait/landscape/wide/tall
+    /cfg &lt;value|off&gt; \u{2014} Guidance scale override
+    /seed &lt;N|random&gt; \u{2014} Lock or randomize seed
+    /upscale [on|off] \u{2014} SeedVR 2x upscale
+    /polish [on|off] \u{2014} Two-pass refinement
+    /2k [on|off] \u{2014} Upscale to 2K
+    /4k [on|off] \u{2014} Double upscale to 4K
+
+    <b>Post-Processing:</b>
+    /saturation &lt;0-2|off&gt; \u{2014} Saturation adjust
+    /temp &lt;2000-10000|off&gt; \u{2014} Color temperature
+    /film &lt;look|off&gt; \u{2014} Film look preset
+    /look \u{2014} List available film looks
+    /reset \u{2014} Clear all post-process settings
 
     <b>Info:</b>
     /help \u{2014} Show this help
@@ -357,11 +1031,13 @@ public final class ImageBotCoordinator {
     <b>Current Settings:</b>
     \(modeEmoji) Mode: <b>\(modeName)</b>
     \u{2728} Enhance: <b>\(enhanceState)</b>
+    \u{1F4D0} Aspect: <b>\(state.aspectMode)</b> (\(dims.width)x\(dims.height))
     \u{1F464} Characters: \(charList.isEmpty ? "none loaded" : charList)
+    \(state.settingsSummary().isEmpty ? "" : "\u{2699}\u{FE0F} \(state.settingsSummary())")
 
     <b>Tips:</b>
     \u{2022} Character names (\(charList)) are detected automatically
-    \u{2022} Inline mode override: include /avocado in your prompt for one render
+    \u{2022} Inline mode override: include /avocado in your prompt
     \u{2022} Be descriptive \u{2014} more detail = better results
     """
     let _ = try? await bot.sendMessage(chatId: chatId, text: helpText)
@@ -370,7 +1046,7 @@ public final class ImageBotCoordinator {
   private func sendStatus(chatId: Int) async {
     let mode = contentModeManager.current
     let modeEmoji = ContentModeManager.emoji(for: mode)
-    let session = getSession(chatId: chatId)
+    let state = sessions.getState(chatId: chatId)
 
     do {
       let (status, data) = try await warmServer.get("/health")
@@ -388,7 +1064,8 @@ public final class ImageBotCoordinator {
 
       let botUptime = Int(Date().timeIntervalSince(startTime))
       let charCount = characterLoader.allNames().count
-      let enhanceState = session.enhanceEnabled ? "ON" : "OFF"
+      let enhanceState = state.enhanceEnabled ? "ON" : "OFF"
+      let dims = state.aspectDimensions()
 
       let statusText = """
       <b>ComfyBox Status</b>
@@ -401,7 +1078,9 @@ public final class ImageBotCoordinator {
 
       \(modeEmoji) <b>Mode:</b> \(ContentModeManager.displayName(for: mode))
       \u{2728} <b>Enhance:</b> \(enhanceState)
+      \u{1F4D0} <b>Aspect:</b> \(state.aspectMode) (\(dims.width)x\(dims.height))
       \u{1F464} <b>Characters:</b> \(charCount) loaded
+      \(state.hasPostProcessing ? "\u{1F3A8} <b>Post-process:</b> \(state.settingsSummary())" : "")
 
       <b>Bot uptime:</b> \(formatDuration(botUptime))
       <b>Output:</b> <code>\(config.outputDirectory)</code>
@@ -416,43 +1095,74 @@ public final class ImageBotCoordinator {
     }
   }
 
-  // MARK: - Helpers
+  // MARK: - Sequence Helpers
 
-  private func buildCaption(
-    prompt: String,
-    character: String?,
-    mode: ContentModeManager.Mode,
-    durationMs: Int,
-    enhanced: Bool,
-    optimizeNote: String?
-  ) -> String {
-    var parts: [String] = []
+  /// Parse numbered scenes from LLM output (e.g., "1. scene one\n2. scene two")
+  private func parseNumberedScenes(_ text: String, expectedCount: Int) -> [String] {
+    let lines = text.components(separatedBy: .newlines)
+    var scenes: [String] = []
 
-    // Mode and character tags
-    let modeEmoji = ContentModeManager.emoji(for: mode)
-    if let char = character {
-      parts.append("\(modeEmoji) [\(char)]")
-    } else {
-      parts.append(modeEmoji)
+    var currentScene = ""
+    for line in lines {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      // Detect numbered lines: "1.", "1)", "Scene 1:", etc.
+      if let _ = trimmed.range(of: #"^\d+[\.\)\:]"#, options: .regularExpression) {
+        if !currentScene.isEmpty {
+          scenes.append(currentScene.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        // Strip the number prefix
+        let stripped = trimmed.replacingOccurrences(of: #"^\d+[\.\)\:]\s*"#, with: "", options: .regularExpression)
+        currentScene = stripped
+      } else if !trimmed.isEmpty {
+        currentScene += " " + trimmed
+      }
+    }
+    if !currentScene.isEmpty {
+      scenes.append(currentScene.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
-    // Truncated prompt
-    let truncatedPrompt = prompt.count > 180 ? String(prompt.prefix(177)) + "..." : prompt
-    parts.append(truncatedPrompt)
-
-    // Duration
-    if durationMs > 0 {
-      let seconds = Double(durationMs) / 1000.0
-      parts.append(String(format: "(%.1fs)", seconds))
+    // If parsing yielded wrong count, fall back to sentence splitting
+    if scenes.isEmpty || scenes.count < 2 {
+      return splitStoryIntoFrames(text, count: expectedCount)
     }
 
-    // Enhancement indicator
-    if enhanced {
-      parts.append("\u{2728}")
-    }
-
-    return parts.joined(separator: " ")
+    return scenes
   }
+
+  /// Fallback: split story text into N roughly equal frames by sentences.
+  private func splitStoryIntoFrames(_ story: String, count: Int) -> [String] {
+    // Split on common delimiters: periods, semicolons, em dashes, " -- "
+    let delimiters = CharacterSet(charactersIn: ".;")
+    var sentences = story.components(separatedBy: delimiters)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+
+    // Also split on " -- " for story-style separators
+    if sentences.count < count {
+      sentences = story.components(separatedBy: " -- ")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+    }
+
+    if sentences.count >= count {
+      // Group sentences into N buckets
+      var frames: [String] = []
+      let perFrame = max(1, sentences.count / count)
+      for i in 0..<count {
+        let start = i * perFrame
+        let end = (i == count - 1) ? sentences.count : min(start + perFrame, sentences.count)
+        if start < sentences.count {
+          frames.append(sentences[start..<end].joined(separator: ". "))
+        }
+      }
+      return frames
+    }
+
+    // Not enough sentences — duplicate the story for each frame with a frame number
+    return (0..<count).map { "Frame \($0 + 1) of \(count): \(story)" }
+  }
+
+  // MARK: - Helpers
 
   private func formatDuration(_ seconds: Int) -> String {
     if seconds < 60 { return "\(seconds)s" }
@@ -470,12 +1180,16 @@ public final class ImageBotCoordinator {
 
 // MARK: - Errors
 
-enum CoordinatorError: Error, LocalizedError {
+enum RenderError: Error, LocalizedError {
+  case warmServerDown(String)
   case generateFailed(String)
+  case upscaleFailed(String)
 
   var errorDescription: String? {
     switch self {
+    case .warmServerDown(let msg): return msg
     case .generateFailed(let msg): return msg
+    case .upscaleFailed(let msg): return msg
     }
   }
 }

--- a/Sources/ZImage/Telegram/PostProcessor.swift
+++ b/Sources/ZImage/Telegram/PostProcessor.swift
@@ -1,0 +1,342 @@
+// PostProcessor.swift — Post-processing effects via Core Image.
+//
+// Phase 3: sharpen, saturation, color temperature, and film look presets.
+// Uses CIFilter where available. All operations take Data in and return Data out.
+
+import Foundation
+
+#if canImport(CoreImage)
+import CoreImage
+import CoreGraphics
+#if canImport(AppKit)
+import AppKit
+#endif
+#endif
+
+// MARK: - Film Look Presets
+
+public struct FilmLook: Sendable {
+  public let id: String
+  public let name: String
+  /// RGBA multiplier adjustments (applied via CIColorMatrix).
+  public let redVector: SIMD4<Float>
+  public let greenVector: SIMD4<Float>
+  public let blueVector: SIMD4<Float>
+  public let biasVector: SIMD4<Float>
+  /// Additional saturation adjustment (1.0 = no change).
+  public let saturationAdjust: Float
+  /// Additional contrast adjustment (1.0 = no change).
+  public let contrastAdjust: Float
+}
+
+// MARK: - PostProcessor
+
+public enum PostProcessor {
+
+  /// Available film look presets.
+  public static let filmLooks: [FilmLook] = [
+    FilmLook(
+      id: "kodak-portra",
+      name: "Kodak Portra 400",
+      redVector: SIMD4<Float>(1.05, 0.0, 0.0, 0.0),
+      greenVector: SIMD4<Float>(0.0, 1.0, 0.0, 0.0),
+      blueVector: SIMD4<Float>(0.0, 0.0, 0.92, 0.0),
+      biasVector: SIMD4<Float>(0.01, 0.005, 0.02, 0.0),
+      saturationAdjust: 0.9,
+      contrastAdjust: 0.95
+    ),
+    FilmLook(
+      id: "fuji-velvia",
+      name: "Fuji Velvia 50",
+      redVector: SIMD4<Float>(1.15, 0.0, 0.0, 0.0),
+      greenVector: SIMD4<Float>(0.0, 1.1, 0.0, 0.0),
+      blueVector: SIMD4<Float>(0.0, 0.0, 1.08, 0.0),
+      biasVector: SIMD4<Float>(0.0, 0.0, 0.0, 0.0),
+      saturationAdjust: 1.3,
+      contrastAdjust: 1.1
+    ),
+    FilmLook(
+      id: "ilford-hp5",
+      name: "Ilford HP5 Plus",
+      redVector: SIMD4<Float>(0.33, 0.33, 0.33, 0.0),
+      greenVector: SIMD4<Float>(0.33, 0.33, 0.33, 0.0),
+      blueVector: SIMD4<Float>(0.33, 0.33, 0.33, 0.0),
+      biasVector: SIMD4<Float>(0.02, 0.02, 0.02, 0.0),
+      saturationAdjust: 0.0,
+      contrastAdjust: 1.15
+    ),
+    FilmLook(
+      id: "cinestill-800t",
+      name: "CineStill 800T",
+      redVector: SIMD4<Float>(1.0, 0.0, 0.0, 0.0),
+      greenVector: SIMD4<Float>(0.0, 0.95, 0.0, 0.0),
+      blueVector: SIMD4<Float>(0.0, 0.05, 1.12, 0.0),
+      biasVector: SIMD4<Float>(0.0, 0.0, 0.03, 0.0),
+      saturationAdjust: 0.95,
+      contrastAdjust: 1.05
+    ),
+    FilmLook(
+      id: "kodak-ektar",
+      name: "Kodak Ektar 100",
+      redVector: SIMD4<Float>(1.1, 0.0, 0.0, 0.0),
+      greenVector: SIMD4<Float>(0.0, 1.05, 0.0, 0.0),
+      blueVector: SIMD4<Float>(0.0, 0.0, 1.0, 0.0),
+      biasVector: SIMD4<Float>(0.0, 0.0, 0.0, 0.0),
+      saturationAdjust: 1.2,
+      contrastAdjust: 1.08
+    ),
+  ]
+
+  /// List available film looks as (id, name) tuples.
+  public static func availableLooks() -> [(id: String, name: String)] {
+    return filmLooks.map { ($0.id, $0.name) }
+  }
+
+  /// Find a film look by ID. Case-insensitive.
+  public static func findLook(_ id: String) -> FilmLook? {
+    return filmLooks.first { $0.id.lowercased() == id.lowercased() }
+  }
+
+  // MARK: - Core Image Processing
+
+  #if canImport(CoreImage)
+
+  /// Apply unsharp mask sharpening.
+  /// - Parameters:
+  ///   - imageData: Input PNG/JPEG data.
+  ///   - radius: Sharpening radius (default 2.5).
+  ///   - intensity: Sharpening intensity (default 0.5).
+  /// - Returns: Processed PNG data.
+  public static func sharpen(imageData: Data, radius: Double = 2.5, intensity: Double = 0.5) -> Data? {
+    guard let ciImage = CIImage(data: imageData) else { return nil }
+    let filter = CIFilter(name: "CIUnsharpMask")!
+    filter.setValue(ciImage, forKey: kCIInputImageKey)
+    filter.setValue(radius, forKey: "inputRadius")
+    filter.setValue(intensity, forKey: "inputIntensity")
+    guard let output = filter.outputImage else { return nil }
+    return renderToPNG(output)
+  }
+
+  /// Adjust saturation.
+  /// - Parameters:
+  ///   - imageData: Input PNG/JPEG data.
+  ///   - factor: Saturation factor (0 = grayscale, 1 = original, 2 = double).
+  /// - Returns: Processed PNG data.
+  public static func adjustSaturation(imageData: Data, factor: Double) -> Data? {
+    guard let ciImage = CIImage(data: imageData) else { return nil }
+    let filter = CIFilter(name: "CIColorControls")!
+    filter.setValue(ciImage, forKey: kCIInputImageKey)
+    filter.setValue(factor, forKey: "inputSaturation")
+    guard let output = filter.outputImage else { return nil }
+    return renderToPNG(output)
+  }
+
+  /// Adjust color temperature.
+  /// - Parameters:
+  ///   - imageData: Input PNG/JPEG data.
+  ///   - kelvin: Color temperature in Kelvin (2000-10000). 6500 = neutral daylight.
+  /// - Returns: Processed PNG data.
+  public static func adjustColorTemperature(imageData: Data, kelvin: Int) -> Data? {
+    guard let ciImage = CIImage(data: imageData) else { return nil }
+    let filter = CIFilter(name: "CITemperatureAndTint")!
+    filter.setValue(ciImage, forKey: kCIInputImageKey)
+    // CITemperatureAndTint uses a neutral of 6500K.
+    // Positive targetNeutral shifts warm, negative shifts cool.
+    let neutral = CIVector(x: CGFloat(kelvin), y: 0)
+    filter.setValue(neutral, forKey: "inputNeutral")
+    let target = CIVector(x: 6500, y: 0)
+    filter.setValue(target, forKey: "inputTargetNeutral")
+    guard let output = filter.outputImage else { return nil }
+    return renderToPNG(output)
+  }
+
+  /// Apply a film look preset.
+  /// - Parameters:
+  ///   - imageData: Input PNG/JPEG data.
+  ///   - look: The film look preset to apply.
+  /// - Returns: Processed PNG data.
+  public static func applyFilmLook(imageData: Data, look: FilmLook) -> Data? {
+    guard var ciImage = CIImage(data: imageData) else { return nil }
+
+    // Apply color matrix transformation
+    let matrixFilter = CIFilter(name: "CIColorMatrix")!
+    matrixFilter.setValue(ciImage, forKey: kCIInputImageKey)
+    matrixFilter.setValue(CIVector(x: CGFloat(look.redVector.x), y: CGFloat(look.redVector.y),
+                                   z: CGFloat(look.redVector.z), w: CGFloat(look.redVector.w)),
+                          forKey: "inputRVector")
+    matrixFilter.setValue(CIVector(x: CGFloat(look.greenVector.x), y: CGFloat(look.greenVector.y),
+                                   z: CGFloat(look.greenVector.z), w: CGFloat(look.greenVector.w)),
+                          forKey: "inputGVector")
+    matrixFilter.setValue(CIVector(x: CGFloat(look.blueVector.x), y: CGFloat(look.blueVector.y),
+                                   z: CGFloat(look.blueVector.z), w: CGFloat(look.blueVector.w)),
+                          forKey: "inputBVector")
+    matrixFilter.setValue(CIVector(x: CGFloat(look.biasVector.x), y: CGFloat(look.biasVector.y),
+                                   z: CGFloat(look.biasVector.z), w: CGFloat(look.biasVector.w)),
+                          forKey: "inputBiasVector")
+    guard let matrixOutput = matrixFilter.outputImage else { return nil }
+    ciImage = matrixOutput
+
+    // Apply saturation adjustment
+    if look.saturationAdjust != 1.0 {
+      let satFilter = CIFilter(name: "CIColorControls")!
+      satFilter.setValue(ciImage, forKey: kCIInputImageKey)
+      satFilter.setValue(Double(look.saturationAdjust), forKey: "inputSaturation")
+      if look.contrastAdjust != 1.0 {
+        satFilter.setValue(Double(look.contrastAdjust), forKey: "inputContrast")
+      }
+      guard let satOutput = satFilter.outputImage else { return nil }
+      ciImage = satOutput
+    } else if look.contrastAdjust != 1.0 {
+      let conFilter = CIFilter(name: "CIColorControls")!
+      conFilter.setValue(ciImage, forKey: kCIInputImageKey)
+      conFilter.setValue(Double(look.contrastAdjust), forKey: "inputContrast")
+      guard let conOutput = conFilter.outputImage else { return nil }
+      ciImage = conOutput
+    }
+
+    return renderToPNG(ciImage)
+  }
+
+  /// Apply the full post-processing pipeline to image data.
+  /// - Returns: Processed PNG data, or the original data if nothing was applied.
+  public static func applyPipeline(
+    imageData: Data,
+    saturation: Double?,
+    colorTemp: Int?,
+    filmLookId: String?,
+    sharpenAfterUpscale: Bool = false
+  ) -> Data {
+    var data = imageData
+    var applied = false
+
+    // 1. Sharpen (only after upscale to counteract softness)
+    if sharpenAfterUpscale {
+      if let result = sharpen(imageData: data) {
+        data = result
+        applied = true
+      }
+    }
+
+    // 2. Saturation adjustment
+    if let sat = saturation {
+      if let result = adjustSaturation(imageData: data, factor: sat) {
+        data = result
+        applied = true
+      }
+    }
+
+    // 3. Color temperature
+    if let kelvin = colorTemp {
+      if let result = adjustColorTemperature(imageData: data, kelvin: kelvin) {
+        data = result
+        applied = true
+      }
+    }
+
+    // 4. Film look (applied last — it's the "film stock" envelope)
+    if let lookId = filmLookId, let look = findLook(lookId) {
+      if let result = applyFilmLook(imageData: data, look: look) {
+        data = result
+        applied = true
+      }
+    }
+
+    _ = applied  // suppress unused warning
+    return data
+  }
+
+  // MARK: - Rendering
+
+  private static let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+  private static func renderToPNG(_ image: CIImage) -> Data? {
+    guard let cgImage = ciContext.createCGImage(image, from: image.extent) else { return nil }
+    let mutableData = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else { return nil }
+    CGImageDestinationAddImage(destination, cgImage, nil)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+    return mutableData as Data
+  }
+
+  #else
+
+  // MARK: - Fallback (non-macOS) — ImageMagick CLI
+
+  public static func sharpen(imageData: Data, radius: Double = 2.5, intensity: Double = 0.5) -> Data? {
+    return processViaImageMagick(imageData: imageData, args: ["-sharpen", "0x\(radius)"])
+  }
+
+  public static func adjustSaturation(imageData: Data, factor: Double) -> Data? {
+    let percent = Int(factor * 100)
+    return processViaImageMagick(imageData: imageData, args: ["-modulate", "100,\(percent),100"])
+  }
+
+  public static func adjustColorTemperature(imageData: Data, kelvin: Int) -> Data? {
+    // Approximate warm/cool shift via ImageMagick level adjustments
+    if kelvin < 6500 {
+      let warmth = Int(Double(6500 - kelvin) / 45.0)
+      return processViaImageMagick(imageData: imageData, args: [
+        "-fill", "rgb(\(warmth),\(warmth / 2),0)", "-colorize", "10%"
+      ])
+    } else if kelvin > 6500 {
+      let coolness = Int(Double(kelvin - 6500) / 45.0)
+      return processViaImageMagick(imageData: imageData, args: [
+        "-fill", "rgb(0,\(coolness / 2),\(coolness))", "-colorize", "10%"
+      ])
+    }
+    return imageData
+  }
+
+  public static func applyFilmLook(imageData: Data, look: FilmLook) -> Data? {
+    // For non-CI platforms, apply basic saturation + contrast via ImageMagick
+    let sat = Int(look.saturationAdjust * 100)
+    let brightness = look.contrastAdjust > 1.0 ? 105 : (look.contrastAdjust < 1.0 ? 95 : 100)
+    return processViaImageMagick(imageData: imageData, args: ["-modulate", "\(brightness),\(sat),100"])
+  }
+
+  public static func applyPipeline(
+    imageData: Data,
+    saturation: Double?,
+    colorTemp: Int?,
+    filmLookId: String?,
+    sharpenAfterUpscale: Bool = false
+  ) -> Data {
+    var data = imageData
+    if sharpenAfterUpscale, let result = sharpen(imageData: data) { data = result }
+    if let sat = saturation, let result = adjustSaturation(imageData: data, factor: sat) { data = result }
+    if let kelvin = colorTemp, let result = adjustColorTemperature(imageData: data, kelvin: kelvin) { data = result }
+    if let lookId = filmLookId, let look = findLook(lookId), let result = applyFilmLook(imageData: data, look: look) { data = result }
+    return data
+  }
+
+  private static func processViaImageMagick(imageData: Data, args: [String]) -> Data? {
+    let tmpIn = NSTemporaryDirectory() + "comfybox-pp-in-\(UUID().uuidString).png"
+    let tmpOut = NSTemporaryDirectory() + "comfybox-pp-out-\(UUID().uuidString).png"
+    defer {
+      try? FileManager.default.removeItem(atPath: tmpIn)
+      try? FileManager.default.removeItem(atPath: tmpOut)
+    }
+    guard FileManager.default.createFile(atPath: tmpIn, contents: imageData) else { return nil }
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/convert")
+    process.arguments = [tmpIn] + args + [tmpOut]
+    do {
+      try process.run()
+      process.waitUntilExit()
+      guard process.terminationStatus == 0 else { return nil }
+      return FileManager.default.contents(atPath: tmpOut)
+    } catch {
+      return nil
+    }
+  }
+
+  public static func availableLooks() -> [(id: String, name: String)] {
+    return filmLooks.map { ($0.id, $0.name) }
+  }
+
+  public static func findLook(_ id: String) -> FilmLook? {
+    return filmLooks.first { $0.id.lowercased() == id.lowercased() }
+  }
+
+  #endif
+}

--- a/Sources/ZImage/Telegram/SessionState.swift
+++ b/Sources/ZImage/Telegram/SessionState.swift
@@ -1,0 +1,129 @@
+// SessionState.swift — Per-chat session state tracking for Telegram bot.
+//
+// Phase 3: Tracks all render settings per chatId — aspect, cfg, seed,
+// post-processing, upscale, polish, and last render context.
+// Thread-safe via NSLock.
+
+import Foundation
+
+// MARK: - ChatState
+
+/// All per-chat render settings and last-render context.
+public struct ChatState: Sendable {
+  // -- Toggles --
+  public var enhanceEnabled: Bool = true
+  public var upscaleEnabled: Bool = false
+  public var polishEnabled: Bool = false
+  public var autoVideoEnabled: Bool = false
+  public var verboseEnabled: Bool = false
+
+  // -- Render settings --
+  public var aspectMode: String = "portrait"
+  public var cfgOverride: Double? = nil
+  public var seedLock: Int? = nil
+  public var resolutionTarget: String? = nil  // "2k", "4k", nil
+
+  // -- Post-processing --
+  public var saturation: Double? = nil
+  public var colorTemp: Int? = nil
+  public var filmLook: String? = nil
+
+  // -- Last render context (for re-render, vary, etc.) --
+  public var lastPrompt: String? = nil
+  public var lastImagePath: String? = nil
+  public var lastSeed: Int? = nil
+
+  public init() {}
+
+  /// Convenience initializer with custom enhance default.
+  public init(enhanceEnabled: Bool) {
+    self.enhanceEnabled = enhanceEnabled
+  }
+
+  // MARK: - Aspect Dimensions
+
+  /// Resolve aspect mode to (width, height) dimensions.
+  public func aspectDimensions() -> (width: Int, height: Int) {
+    return ChatState.dimensionsForAspect(aspectMode)
+  }
+
+  /// Static lookup for aspect mode dimensions.
+  public static func dimensionsForAspect(_ mode: String) -> (width: Int, height: Int) {
+    switch mode.lowercased() {
+    case "square":
+      return (1024, 1024)
+    case "portrait":
+      return (768, 1024)
+    case "landscape":
+      return (1024, 768)
+    case "wide":
+      return (1024, 576)
+    case "tall":
+      return (576, 1024)
+    default:
+      return (768, 1024)  // default to portrait
+    }
+  }
+
+  /// Reset all post-processing settings to defaults.
+  public mutating func resetPostProcessing() {
+    saturation = nil
+    colorTemp = nil
+    filmLook = nil
+  }
+
+  /// Whether any post-processing settings are active.
+  public var hasPostProcessing: Bool {
+    return saturation != nil || colorTemp != nil || filmLook != nil
+  }
+
+  /// Human-readable summary of active settings.
+  public func settingsSummary() -> String {
+    var parts: [String] = []
+    parts.append("aspect: \(aspectMode)")
+    if let cfg = cfgOverride { parts.append("cfg: \(cfg)") }
+    if let seed = seedLock { parts.append("seed: \(seed)") }
+    if upscaleEnabled { parts.append("upscale: on") }
+    if polishEnabled { parts.append("polish: on") }
+    if let target = resolutionTarget { parts.append("res: \(target)") }
+    if let sat = saturation { parts.append("sat: \(String(format: "%.1f", sat))") }
+    if let temp = colorTemp { parts.append("temp: \(temp)K") }
+    if let look = filmLook { parts.append("film: \(look)") }
+    return parts.joined(separator: ", ")
+  }
+}
+
+// MARK: - SessionState Manager
+
+/// Thread-safe per-chat session state storage.
+public final class SessionState: @unchecked Sendable {
+  private var states: [Int: ChatState] = [:]
+  private let lock = NSLock()
+  private let defaultEnhance: Bool
+
+  /// Initialize with a default enhance setting (from optimizer config).
+  public init(defaultEnhance: Bool = true) {
+    self.defaultEnhance = defaultEnhance
+  }
+
+  /// Get the current state for a chat. Creates a default if none exists.
+  public func getState(chatId: Int) -> ChatState {
+    lock.lock()
+    defer { lock.unlock() }
+    if let state = states[chatId] {
+      return state
+    }
+    let newState = ChatState(enhanceEnabled: defaultEnhance)
+    states[chatId] = newState
+    return newState
+  }
+
+  /// Update the state for a chat using a mutation closure.
+  public func updateState(chatId: Int, update: (inout ChatState) -> Void) {
+    lock.lock()
+    defer { lock.unlock() }
+    var state = states[chatId] ?? ChatState(enhanceEnabled: defaultEnhance)
+    update(&state)
+    states[chatId] = state
+  }
+}


### PR DESCRIPTION
## Summary

- **PostProcessor.swift** (new): Core Image post-processing pipeline -- sharpen, saturation, color temperature, and 5 film look presets (kodak-portra, fuji-velvia, ilford-hp5, cinestill-800t, kodak-ektar). ImageMagick CLI fallback for non-macOS.
- **SessionState.swift** (new): Thread-safe per-chat state tracking -- aspect mode, CFG override, seed lock, upscale/polish toggles, post-processing settings, last render context.
- **ImageBotCoordinator.swift** (expanded): Full Phase 3 command handlers -- batch, vary, sequence, upscale, polish, 2K/4K, aspect, cfg, seed, saturation, temp, film, reset, look. Refactored render pipeline with Result-based error handling.

## New Commands

| Command | Description |
|---------|-------------|
| `/batch N <prompt>` | Generate N images (2-8), different seeds |
| `/vary [N] <prompt>` | N prompt variations via optimizer |
| `/seq N <story>` | LLM breaks story into N sequential frames |
| `/upscale [on\|off]` | SeedVR 2x upscale toggle |
| `/polish [on\|off]` | Two-pass refinement (img2img at 0.35 strength) |
| `/4k [on\|off]` | Double upscale (render -> 2K -> 4K) |
| `/2k [on\|off]` | Single upscale to 2K |
| `/aspect <mode>` | square/portrait/landscape/wide/tall |
| `/cfg <value\|off>` | Guidance scale override (0-20) |
| `/seed <N\|random>` | Lock or randomize seed |
| `/saturation <0-2\|off>` | Post-process saturation |
| `/temp <2000-10000\|off>` | Color temperature |
| `/film <look\|off>` | Film simulation preset |
| `/look` | List available film looks |
| `/reset` | Clear all post-process settings |

## Build

`swift build -c release` passes. No changes to Package.swift or main.swift.

## Test plan

- [ ] `/batch 3 a sunset` delivers 3 photos with different seeds
- [ ] `/vary 3 Kira at a cafe` delivers 3 varied prompt renders
- [ ] `/seq 4 Kira makes coffee` delivers 4 sequential frames
- [ ] `/upscale on` then render produces 2x upscaled output
- [ ] `/saturation 1.3` then render produces saturated image
- [ ] `/film kodak-portra` then render applies film look
- [ ] `/reset` clears all post-process settings
- [ ] `/aspect wide` sets 1024x576 dimensions
- [ ] `/cfg 7.5` overrides guidance scale
- [ ] `/seed 42` locks seed across renders

Generated with [Claude Code](https://claude.com/claude-code)