### PR TITLE
docs(telegram): user guide and technical reference

### DIFF
--- a/docs/telegram-technical.md
+++ b/docs/telegram-technical.md
@@ -1,0 +1,556 @@
+# ComfyBox Telegram Bot -- Technical Documentation
+
+Developer reference for the Telegram image generation surface in `Sources/ZImage/Telegram/`.
+
+## Architecture
+
+The Telegram bot is a WarmServer client -- not a standalone image engine. It translates Telegram messages into WarmServer API calls and delivers results back to the user.
+
+```
+Telegram Cloud <--HTTPS (long poll)--> TelegramBot (URLSession)
+                                            |
+                                       TelegramCommandParser
+                                            |
+                                       ImageBotCoordinator
+                                       /    |    \       \
+                            PromptOptimizer  |  PostProcessor  SessionState
+                             (Ollama/LMS)    |   (CIFilter)
+                                        WarmServerClient
+                                             |
+                                        WarmServer (:7862)
+                                             |
+                                      Z-Image / MLX engine
+```
+
+Key design decisions:
+
+- **Zero daemon dependency.** The bot does not require the Bree daemon, event system, or any Node.js infrastructure. It is a pure Swift process that talks to the Telegram API and the WarmServer.
+- **URLSession only.** No external networking dependencies. All HTTP calls (Telegram API, Ollama, LM Studio, WarmServer) use Foundation's `URLSession`.
+- **WarmServer as render backend.** All image generation goes through `WarmServerClient` -- the bot never loads models or touches MLX directly.
+- **Per-chat state.** All render settings (aspect, seed, post-processing, etc.) are tracked per Telegram chat ID in memory. Content mode is the only global setting and is persisted to disk.
+
+## Module Map
+
+### `TelegramBot.swift`
+
+Zero-dependency Telegram Bot API client. Handles polling, outbound messaging, file downloads, and callback queries.
+
+**Public API:**
+
+| Type/Method | Purpose |
+|-------------|---------|
+| `TelegramBot.Configuration` | Bot token, allowed user IDs, poll timeout, retry delay |
+| `init(configuration:logger:)` | Create bot with config and optional logger |
+| `startPolling(handler:)` | Start long polling loop. Blocks until `stop()` called. Handler receives `TelegramUpdate` |
+| `stop()` | Set `running = false` to break the poll loop |
+| `sendMessage(chatId:text:replyTo:)` | Send HTML-formatted text message |
+| `sendPhoto(chatId:imageData:filename:caption:replyMarkup:)` | Upload photo via multipart/form-data |
+| `sendDocument(chatId:fileData:filename:mimeType:caption:replyMarkup:)` | Upload document via multipart/form-data |
+| `answerCallbackQuery(id:text:)` | Acknowledge inline keyboard button press |
+| `editMessageReplyMarkup(chatId:messageId:markup:)` | Add/remove inline keyboard on existing message |
+| `downloadFile(fileId:)` | Download file from Telegram (getFile + fetch file_path) |
+
+**Types:**
+
+| Type | Fields |
+|------|--------|
+| `TelegramUpdate` | `updateId`, `message?`, `callbackQuery?` |
+| `TelegramMessage` | `messageId`, `chatId`, `userId`, `firstName`, `text?`, `caption?`, `photo?`, `replyToMessage?`, `date` |
+| `TelegramCallbackQuery` | `id`, `userId`, `firstName`, `messageId?`, `chatId?`, `data?` |
+| `TelegramPhotoSize` | `fileId`, `width`, `height` |
+| `InlineKeyboard` | `rows: [[InlineButton]]` with `toJSON()` |
+| `InlineButton` | `text`, `callbackData` |
+| `SendResult` | `ok`, `messageId?` |
+
+**Concurrency:** `TelegramBot` is `@unchecked Sendable`. The polling loop runs in the caller's async context. `running` is a simple bool (no lock) -- single-writer (stop/start), single-reader (poll loop).
+
+**Auth:** Updates from user IDs not in `allowedUserIds` are silently dropped with a log warning.
+
+**Dependencies:** Foundation, Logging.
+
+---
+
+### `TelegramCommandParser.swift`
+
+Stateless command parser. Maps raw message text to a `BotCommand` enum.
+
+**Public API:**
+
+| Method | Purpose |
+|--------|---------|
+| `parse(_:inDiscussMode:)` | Parse message text into `BotCommand`. `inDiscussMode` controls whether bare text maps to `.chatMessage` or `.render` |
+| `parseReplyIntent(_:)` | Classify reply-to-image text into `ReplyIntent` |
+| `parsePrompt(_:defaultMode:)` | Extract character name and inline mode override from prompt text |
+
+**`BotCommand` enum (36 cases):**
+
+Content modes: `.neutral`, `.banana`, `.avocado`
+
+Toggles: `.enhance(on:)`, `.upscale(on:)`, `.polish(on:)`, `.verbose(on:)`, `.autoVideo(on:)`, `.resolution(target:)`
+
+Settings: `.aspect(mode:)`, `.cfg(value:)`, `.seed(value:)`, `.saturation(value:)`, `.colorTemp(kelvin:)`, `.film(lookId:)`
+
+Generation: `.render(prompt:)`, `.batch(count:prompt:)`, `.vary(count:prompt:)`, `.sequence(count:story:)`, `.video(prompt:)`
+
+Session: `.chat`, `.imagine(description:)`, `.endChat`, `.shipCue`, `.chatMessage(text:)`
+
+Admin: `.status`, `.help`, `.reset`, `.look(id:)`, `.queue(subcommand:)`
+
+**`ReplyIntent` enum (5 cases):**
+
+`.rerender`, `.hq`, `.upscaleReply`, `.video(motion:)`, `.newPrompt(text:)`
+
+**`ParsedPrompt`:** `prompt` (cleaned), `character?` (detected name), `contentMode?` (inline override).
+
+**Ship-cue detection:** In discuss mode, bare text matching "go", "render", "render it", "ship", "ship it", "do it", "let's go", "send it", "fire it" returns `.shipCue` instead of `.chatMessage`.
+
+**Character detection:** Case-insensitive scan of the prompt for "kira", "bree", "todd". First match wins. Returns capitalized name.
+
+**Count parsing for batch/vary/sequence:** If the first word is a number, it is used as count (clamped 1-8). Otherwise, the entire arg string is the prompt and a default count is used (3 for batch/vary, 4 for sequence).
+
+**Dependencies:** Foundation only.
+
+---
+
+### `ContentModeManager.swift`
+
+Thread-safe content mode state with JSON disk persistence.
+
+**Public API:**
+
+| Method/Property | Purpose |
+|-----------------|---------|
+| `init(configPath:)` | Load mode from `~/.comfybox/content-mode.json` or default to `.neutral` |
+| `current: Mode` | Thread-safe read of current mode |
+| `set(_:)` | Set mode and persist via atomic temp-file + rename |
+| `displayName(for:)` | Human-readable name: "Neutral (SFW)", "Banana (suggestive)", "Avocado (explicit)" |
+| `emoji(for:)` | Mode emoji: red apple, banana, avocado |
+
+**`Mode` enum:** `.neutral`, `.banana`, `.avocado`. RawValue is the string used in JSON.
+
+**Thread safety:** NSLock around `_current`. Disk writes are fire-and-forget after the lock is released.
+
+**Persistence:** `{"mode": "neutral"}` written to `~/.comfybox/content-mode.json` via temp file UUID + rename.
+
+**Dependencies:** Foundation only.
+
+---
+
+### `CharacterLoader.swift`
+
+Loads tiered character descriptions from a JSON file and resolves them by content mode.
+
+**Public API:**
+
+| Method | Purpose |
+|--------|---------|
+| `init(configPath:)` | Load from `~/.comfybox/characters.json`. Graceful degradation if missing |
+| `description(for:mode:)` | Get mode-gated description string. Returns nil if character not found |
+| `allNames()` | All character names (sorted, lowercase) |
+| `has(_:)` | Check if a character exists (case-insensitive) |
+
+**JSON format:**
+
+```json
+{
+  "kira": {
+    "base": "physical description always included",
+    "banana": "appended in banana and avocado modes",
+    "avocado": "appended only in avocado mode"
+  }
+}
+```
+
+**Tier resolution:**
+
+| Mode | Composition |
+|------|-------------|
+| neutral | `base` |
+| banana | `base` + `banana` (if present) |
+| avocado | `base` + `banana` (if present) + `avocado` (if present) |
+
+This mirrors the server-side `characters.ts` logic. Strings are space-joined.
+
+**Dependencies:** Foundation only.
+
+---
+
+### `PromptOptimizer.swift`
+
+Local LLM client for rewriting user prompts into Z-Image Turbo native format.
+
+**Public API:**
+
+| Method | Purpose |
+|--------|---------|
+| `init(configuration:logger:)` | Create optimizer with endpoint config |
+| `optimize(prompt:character:characterDescription:contentMode:)` | Async prompt optimization. Returns `OptimizeResult` |
+
+**`OptimizeResult`:** `prompt` (rewritten), `enhanced` (bool), `note?` (fallback info).
+
+**`Configuration`:** `ollamaBaseURL`, `lmStudioBaseURL?`, `model` (default: `"qwen3:8b"`), `timeoutSeconds` (default: 15), `enabled`.
+
+**Fallback chain:**
+
+1. Ollama at `ollamaBaseURL/v1/chat/completions`
+2. LM Studio at `lmStudioBaseURL/v1/chat/completions`
+3. Rule-based `wrapInQwen3Format()` -- wraps prompt in YOUR CONTEXT / YOUR PHOTO with mode-appropriate defaults
+
+If `enabled` is false, step 3 is used directly.
+
+**System prompts (3 variants):**
+
+Each mode has a dedicated system prompt embedding the Z-Image Turbo rendering rules:
+
+- **Neutral:** SFW, fully clothed, focus on character presence and environment
+- **Banana:** Suggestive, lingerie, partial nudity, tension and implication
+- **Avocado:** Explicit, graphic anatomical language, nude default, amateur aesthetic
+
+All three share the `zImageRules` constant: YOUR CONTEXT / YOUR PHOTO format spec, facial detail scaling, hard rules (no keywords, no negatives, no camera brands, narrative prose only).
+
+**User message construction:**
+
+1. Scene type hint (inferred from keywords: POV, portrait, macro, full body, wide, cinematic)
+2. Character context injection (if character detected)
+3. Raw input prompt
+4. Mode-specific instruction suffix
+
+**Temperature:** 0.4 for neutral/banana, 0.9 for avocado (pushes past model safety defaults).
+
+**Output cleaning (`cleanLLMOutput`):**
+
+- Strips `<think>...</think>` blocks (Qwen3 chain-of-thought)
+- Strips stop tokens: `<|im_end|>`, `<|endoftext|>`, `<|eot_id|>`
+- Detects refusal patterns ("I'm sorry", "I cannot", "content policy", etc.) and returns empty string
+
+**Static helpers (used by coordinator):**
+
+| Method | Purpose |
+|--------|---------|
+| `selectSystemPrompt(contentMode:)` | Return the system prompt for a mode |
+| `buildUserMessage(...)` | Build the user message with scene hints and character context |
+| `cleanLLMOutput(_:)` | Strip think tags, stop tokens, detect refusals |
+| `wrapInQwen3Format(prompt:contentMode:)` | Rule-based YOUR CONTEXT / YOUR PHOTO wrapping |
+
+**Dependencies:** Foundation, Logging.
+
+---
+
+### `ImageBotCoordinator.swift`
+
+Central orchestrator. Owns all other components, handles the full message-to-image pipeline, and manages the bot lifecycle.
+
+**Public API:**
+
+| Method | Purpose |
+|--------|---------|
+| `init(configuration:logger:)` | Create coordinator, initialize all subsystems |
+| `run()` | Start the bot. Blocks until shutdown. Calls `bot.startPolling()` |
+| `shutdown()` | Signal graceful stop |
+
+**`Configuration`:** `telegram` (bot config), `warmServerHost`, `warmServerPort`, `outputDirectory`, `galleryDirectory?`, `optimizer` (config), `characterConfigPath?`, `contentModeConfigPath?`.
+
+**Owned components:**
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `bot` | `TelegramBot` | Telegram API client |
+| `warmServer` | `WarmServerClient` | WarmServer HTTP client |
+| `contentModeManager` | `ContentModeManager` | Mode state |
+| `characterLoader` | `CharacterLoader` | Character descriptions |
+| `promptOptimizer` | `PromptOptimizer` | LLM prompt rewriting |
+| `sessions` | `SessionState` | Per-chat state storage |
+
+**Update routing:**
+
+```
+handleUpdate()
+  |-- callbackQuery? --> handleCallbackQuery()
+  |-- reply-to-image? --> handleReplyToImage()
+  |-- text message --> handleTextMessage()
+                         |-- TelegramCommandParser.parse()
+                         |-- switch on BotCommand (36 cases)
+```
+
+**Render pipeline (single image):**
+
+```
+handleRender(prompt)
+  1. parseAndResolve(prompt)
+       -> TelegramCommandParser.parsePrompt() -- extract character, inline mode
+       -> CharacterLoader.description() -- load tiered description
+       -> Return ParsedContext
+  2. Send status message
+  3. generateImage(prompt, character, characterDescription, mode, state, seed)
+       -> If enhance: PromptOptimizer.optimize()
+       -> Else: prepend character description
+       -> generateImageDirect(finalPrompt, state, seed)
+            -> WarmServerClient.post("/v1/generate")
+            -> If polish: WarmServerClient.post("/v1/generate", strength=0.35, steps=30)
+            -> If upscale: WarmServerClient.post("/v1/upscale")
+            -> If 4K: second upscale pass
+  4. applyPostProcessing(imageData, state, wasUpscaled)
+       -> PostProcessor.applyPipeline()
+  5. buildCaption()
+  6. sendImageWithKeyboard()
+       -> bot.sendPhoto() then bot.editMessageReplyMarkup() to attach keyboard
+       -> If >8MB: bot.sendDocument() (no keyboard)
+  7. Store RenderContext for the sent message ID
+  8. copyToGallery()
+```
+
+**Callback query handling (inline keyboard):**
+
+Callback data format: `"action:chatId:messageId"`
+
+| Action | Handler | Behavior |
+|--------|---------|----------|
+| `rerender` | `handleCallbackRerender` | Same prompt, new random seed |
+| `hq` | `handleCallbackHQ` | Same prompt + seed, force polish on |
+| `video` | inline | Message directing to @BaristaBree_Bot |
+
+**Reply-to-image handling:**
+
+| `ReplyIntent` | Handler | Behavior |
+|---------------|---------|----------|
+| `.rerender` | `handleCallbackRerender` | Same prompt, new seed |
+| `.hq` | `handleCallbackHQ` | Same prompt + seed, polish on |
+| `.upscaleReply` | `handleReplyUpscale` | Upscale + sharpen + post-process |
+| `.video(motion:)` | inline | Message directing to @BaristaBree_Bot |
+| `.newPrompt(text:)` | `handleImg2Img` | img2img at 50% strength with new prompt |
+
+**Discuss mode flow:**
+
+```
+/chat -> enterDiscussMode() -> isInDiscussMode = true
+  |
+  user text -> .chatMessage -> handleDiscussMessage()
+       -> callDiscussLLM(messages) via Ollama/LM Studio
+       -> extractPromptFromDiscussion() -> store discussCurrentPrompt
+       -> Send response to user
+  |
+  ship cue -> .shipCue -> handleShipCue()
+       -> Use discussCurrentPrompt (or last user message)
+       -> exitDiscussMode()
+       -> handleRender()
+  |
+  /end -> exitDiscussMode()
+```
+
+**Multi-image commands:**
+
+- **Batch:** Sequential loop, same prompt, different seeds. Progress updates per image.
+- **Vary:** Each iteration passes a variation instruction to the optimizer. Progress updates per image.
+- **Sequence:** First pass: optimizer breaks story into numbered scenes. Second pass: each scene is optimized and rendered independently. Fallback: split by sentence boundaries.
+
+**Error types:**
+
+```swift
+enum RenderError {
+  case warmServerDown(String)
+  case generateFailed(String)
+  case upscaleFailed(String)
+}
+```
+
+**Dependencies:** Foundation, Logging, WarmServerClient.
+
+---
+
+### `PostProcessor.swift`
+
+Post-processing effects pipeline using Core Image filters (macOS) with ImageMagick CLI fallback (Linux).
+
+**Public API:**
+
+| Method | Purpose |
+|--------|---------|
+| `sharpen(imageData:radius:intensity:)` | CIUnsharpMask (default radius 2.5, intensity 0.5) |
+| `adjustSaturation(imageData:factor:)` | CIColorControls saturation (0=grayscale, 1=original, 2=double) |
+| `adjustColorTemperature(imageData:kelvin:)` | CITemperatureAndTint (2000-10000K, 6500=neutral) |
+| `applyFilmLook(imageData:look:)` | CIColorMatrix + CIColorControls chain |
+| `applyPipeline(imageData:saturation:colorTemp:filmLookId:sharpenAfterUpscale:)` | Full pipeline: sharpen -> saturation -> temp -> film look |
+| `availableLooks()` | List all film look `(id, name)` tuples |
+| `findLook(_:)` | Case-insensitive lookup by ID |
+
+**Film look presets (5 built-in):**
+
+| ID | Name | Character |
+|----|------|-----------|
+| `kodak-portra` | Kodak Portra 400 | Warm reds, lifted blacks, slightly desaturated (0.9x), reduced contrast (0.95x) |
+| `fuji-velvia` | Fuji Velvia 50 | Boosted RGB, high saturation (1.3x), increased contrast (1.1x) |
+| `ilford-hp5` | Ilford HP5 Plus | Equal RGB channels (black and white), zero saturation, high contrast (1.15x) |
+| `cinestill-800t` | CineStill 800T | Reduced greens, boosted blues with green crossover, slight desaturation (0.95x) |
+| `kodak-ektar` | Kodak Ektar 100 | Boosted reds and greens, high saturation (1.2x), punchy contrast (1.08x) |
+
+Each preset is a `FilmLook` struct with SIMD4 color matrix vectors (`redVector`, `greenVector`, `blueVector`, `biasVector`) plus `saturationAdjust` and `contrastAdjust` floats.
+
+**CIFilter pipeline order:**
+
+1. CIUnsharpMask (only if `sharpenAfterUpscale` -- counteracts upscaler softness)
+2. CIColorControls (saturation)
+3. CITemperatureAndTint (color temperature)
+4. CIColorMatrix + CIColorControls (film look -- applied last as the "film stock envelope")
+
+**Rendering:** `CIContext.createCGImage()` -> `CGImageDestinationCreateWithData()` -> PNG output. Software renderer disabled (uses GPU).
+
+**ImageMagick fallback (non-macOS):** Uses `/opt/homebrew/bin/convert` with temp files. Saturation via `-modulate`, temperature via `-colorize` approximation, film looks via modulate brightness/saturation.
+
+**Dependencies:** Foundation, CoreImage, CoreGraphics, AppKit (macOS). No external dependencies.
+
+---
+
+### `SessionState.swift`
+
+Per-chat render settings and context storage.
+
+**Public types:**
+
+**`ChatState` (value type):**
+
+| Property | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `enhanceEnabled` | Bool | config-dependent | Prompt optimization on/off |
+| `upscaleEnabled` | Bool | false | SeedVR 2x upscale |
+| `polishEnabled` | Bool | false | Two-pass refinement |
+| `autoVideoEnabled` | Bool | false | Auto-video after render |
+| `verboseEnabled` | Bool | false | Verbose captions |
+| `aspectMode` | String | "portrait" | Aspect ratio mode |
+| `cfgOverride` | Double? | nil | CFG guidance override |
+| `seedLock` | Int? | nil | Locked seed value |
+| `resolutionTarget` | String? | nil | "2k" or "4k" |
+| `saturation` | Double? | nil | Saturation factor |
+| `colorTemp` | Int? | nil | Color temperature (Kelvin) |
+| `filmLook` | String? | nil | Film look preset ID |
+| `lastPrompt` | String? | nil | Last rendered prompt |
+| `lastImagePath` | String? | nil | Last rendered image path |
+| `lastSeed` | Int? | nil | Last render seed |
+| `renderContexts` | [Int: RenderContext] | [:] | messageId -> render context map |
+| `isInDiscussMode` | Bool | false | In discuss mode |
+| `discussHistory` | [DiscussEntry] | [] | Discuss conversation history |
+| `discussCurrentPrompt` | String? | nil | Current refined prompt in discuss mode |
+
+**`RenderContext` (value type):** `prompt`, `imagePath`, `seed?`, `character?`, `contentMode`, `enhanceEnabled`. Stored per bot-sent message ID for inline keyboard and reply-to-image.
+
+**`DiscussEntry`:** `role` ("user" or "assistant"), `content`.
+
+**Eviction policies:**
+
+- Render contexts: max 50 per chat. Oldest messageIds evicted first.
+- Discuss history: max 20 entries. Oldest entries dropped.
+
+**Aspect dimensions:**
+
+| Mode | Width | Height |
+|------|-------|--------|
+| square | 1024 | 1024 |
+| portrait | 768 | 1024 |
+| landscape | 1024 | 768 |
+| wide | 1024 | 576 |
+| tall | 576 | 1024 |
+
+**`SessionState` (reference type, thread-safe):**
+
+| Method | Purpose |
+|--------|---------|
+| `init(defaultEnhance:)` | Create with default enhance setting |
+| `getState(chatId:)` | Get or create ChatState for a chat |
+| `updateState(chatId:update:)` | Mutate state via closure |
+
+Thread safety: NSLock around the `states` dictionary. State is copied out on get, replaced on update.
+
+**Dependencies:** Foundation only.
+
+---
+
+### Entry Point (`Sources/ComfyBox/main.swift`)
+
+The `telegram` subcommand is parsed in `runTelegram(args:)`.
+
+**CLI argument parsing:**
+
+```
+ComfyBox telegram [--bot-token <token>] [--config <path>]
+                  [--port <port>] [--host <host>]
+                  [--enhance [on|off]] [--no-enhance]
+                  [--help]
+```
+
+**Config loading (`loadTelegramConfig`):**
+
+Resolution order for each field: CLI flag > environment variable > config file > default.
+
+The bot token is required. Resolution: `--bot-token` > `COMFYBOX_TELEGRAM_TOKEN` env > `botToken` in config file. Throws if none found.
+
+**Signal handling:** SIGINT and SIGTERM trigger `coordinator.shutdown()` via `DispatchSource`.
+
+**Caffeinate:** Spawns `/usr/bin/caffeinate -s -w <PID>` to prevent macOS sleep while the bot runs.
+
+**Run loop:** `Task { coordinator.run() }` + `dispatchMain()`.
+
+---
+
+## Extension Points
+
+### Adding a New Command
+
+1. Add a case to `BotCommand` in `TelegramCommandParser.swift`
+2. Add the parser match in `parse(_:inDiscussMode:)` (the `/` command switch)
+3. Add the handler case in `ImageBotCoordinator.handleTextMessage()`
+4. Implement the handler method on `ImageBotCoordinator`
+5. Add to the help text in `sendHelp(chatId:)`
+
+### Adding a Film Look Preset
+
+Add a `FilmLook` entry to the `filmLooks` array in `PostProcessor.swift`:
+
+```swift
+FilmLook(
+  id: "my-look",
+  name: "My Custom Look",
+  redVector: SIMD4<Float>(1.0, 0.0, 0.0, 0.0),
+  greenVector: SIMD4<Float>(0.0, 1.0, 0.0, 0.0),
+  blueVector: SIMD4<Float>(0.0, 0.0, 1.0, 0.0),
+  biasVector: SIMD4<Float>(0.0, 0.0, 0.0, 0.0),
+  saturationAdjust: 1.0,
+  contrastAdjust: 1.0
+)
+```
+
+The color matrix vectors are RGBA and map to CIColorMatrix's `inputRVector`, `inputGVector`, `inputBVector`, `inputBiasVector`. Identity matrix = no change.
+
+### Adding a Character
+
+Add an entry to `~/.comfybox/characters.json`:
+
+```json
+{
+  "newchar": {
+    "base": "A person with specific physical traits...",
+    "banana": "suggestive additions...",
+    "avocado": "explicit additions..."
+  }
+}
+```
+
+Then add the name to `characterNames` in `TelegramCommandParser.swift` for auto-detection:
+
+```swift
+private static let characterNames = ["kira", "bree", "todd", "newchar"]
+```
+
+### Adding a New Post-Processing Effect
+
+1. Add a `CIFilter`-based static method to `PostProcessor` (with ImageMagick fallback)
+2. Add the corresponding setting to `ChatState` in `SessionState.swift`
+3. Add a command to `BotCommand` and parser
+4. Add a handler to the coordinator
+5. Include the new effect in `applyPipeline()` at the appropriate stage
+
+### Adding a New LLM Backend
+
+The optimizer talks to any OpenAI-compatible `/v1/chat/completions` endpoint. To add a new provider:
+
+1. Add a URL field to `PromptOptimizer.Configuration`
+2. Add it to the fallback chain in `optimize()` (after Ollama, before rule-based)
+3. Add the corresponding config field to `loadTelegramConfig()` in `main.swift`

--- a/docs/telegram-user-guide.md
+++ b/docs/telegram-user-guide.md
@@ -1,0 +1,582 @@
+# ComfyBox Telegram Bot User Guide
+
+@CoffeeImageBot -- generate images from Telegram using your Mac's GPU.
+
+## Getting Started
+
+### Prerequisites
+
+1. **WarmServer running.** Start it before the bot:
+
+   ```
+   ComfyBox serve --port 7862
+   ```
+
+2. **Bot token.** Create one via [@BotFather](https://t.me/BotFather) on Telegram, or use the one already provisioned for @CoffeeImageBot.
+
+3. **Ollama (optional but recommended).** Prompt enhancement requires a local LLM. Install Ollama and pull the model:
+
+   ```
+   ollama pull qwen3:8b
+   ```
+
+### Starting the Bot
+
+Minimal launch:
+
+```
+ComfyBox telegram --bot-token YOUR_TOKEN
+```
+
+Or use environment variable:
+
+```
+export COMFYBOX_TELEGRAM_TOKEN=YOUR_TOKEN
+ComfyBox telegram
+```
+
+Or use the config file (recommended for persistent setups):
+
+```
+ComfyBox telegram --config ~/.comfybox/telegram.json
+```
+
+All CLI options:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--bot-token <token>` | none | Telegram Bot API token |
+| `--config <path>` | `~/.comfybox/telegram.json` | Config file path |
+| `--port <port>` | 7862 | WarmServer port |
+| `--host <host>` | 127.0.0.1 | WarmServer host |
+| `--enhance [on\|off]` | on | Enable/disable prompt optimization |
+| `--no-enhance` | -- | Disable prompt optimization |
+
+Resolution order: CLI flags > environment variables > config file > defaults.
+
+The bot keeps the Mac awake via `caffeinate` while running. SIGINT or SIGTERM shuts down gracefully.
+
+### Configuration File
+
+Create `~/.comfybox/telegram.json`:
+
+```json
+{
+  "botToken": "123456:ABC-DEF...",
+  "allowedUserIds": [8754779862],
+  "warmServer": {
+    "host": "127.0.0.1",
+    "port": 7862
+  },
+  "optimizer": {
+    "enabled": true,
+    "ollamaBaseURL": "http://localhost:11434",
+    "lmStudioBaseURL": "http://localhost:1234",
+    "model": "qwen3:8b",
+    "timeoutSeconds": 15
+  },
+  "characterConfigPath": "~/.comfybox/characters.json",
+  "outputDirectory": "~/Pictures/ComfyBox/Telegram",
+  "galleryDirectory": "~/Pictures/ComfyBox/Gallery"
+}
+```
+
+**`allowedUserIds`** -- only these Telegram user IDs can interact with the bot. Find your ID by messaging [@userinfobot](https://t.me/userinfobot).
+
+**`galleryDirectory`** -- optional. If set, every generated image is copied here in addition to `outputDirectory`.
+
+---
+
+## Basic Usage
+
+Send any text message and the bot renders an image.
+
+```
+A black cat sitting on a windowsill in the rain
+```
+
+The bot will:
+1. Parse the prompt for character names and inline mode overrides
+2. Optimize the prompt via Ollama (if enhance is on)
+3. Send it to WarmServer for rendering
+4. Deliver the image with a caption showing mode, seed, and timing
+5. Attach inline keyboard buttons (Rerender, HQ, Video)
+
+### Character Names
+
+The bot detects character names -- **Kira**, **Bree**, and **Todd** -- anywhere in your prompt. When detected, the character's physical description is loaded from `~/.comfybox/characters.json` and injected into the prompt automatically.
+
+```
+Kira sitting in a coffee shop reading a book
+```
+
+This loads Kira's full description (skin tone, build, hair, eyes, etc.) and weaves it into the optimized prompt. The description changes based on the active content mode (see below).
+
+---
+
+## Content Modes
+
+Three content modes control the style of character descriptions and prompt optimization.
+
+| Command | Mode | Effect |
+|---------|------|--------|
+| `/neutral` or `/apple` | Neutral (SFW) | Fully clothed subjects, no suggestive content |
+| `/banana` | Banana (suggestive) | Lingerie, partial nudity, intimate framing |
+| `/avocado` | Avocado (explicit) | Full nudity, graphic anatomical descriptions |
+
+Mode is global and persistent -- it survives bot restarts (saved to `~/.comfybox/content-mode.json`).
+
+### Inline Mode Override
+
+Override the mode for a single prompt by including the mode command in your text:
+
+```
+Kira at the beach /avocado
+```
+
+This uses avocado mode for this render only without changing the global setting.
+
+---
+
+## Prompt Enhancement
+
+By default, every prompt is rewritten by a local LLM (Ollama with Qwen3-8B) into the Z-Image Turbo native format:
+
+```
+YOUR CONTEXT:
+[lens, lighting, aesthetic, skin texture approach]
+
+YOUR PHOTO:
+[subject, action, composition, environment, atmosphere]
+```
+
+This format matches Z-Image's Qwen3-4B text encoder, producing significantly better results than raw prompts.
+
+### Toggle Enhancement
+
+```
+/enhance off     -- disable, send raw prompts
+/enhance on      -- re-enable
+/enhance         -- toggle current state
+```
+
+When enhancement is off and a character name is detected, the character description is prepended to the prompt as-is.
+
+### Fallback Chain
+
+1. **Ollama** (primary) -- `http://localhost:11434`
+2. **LM Studio** (fallback) -- `http://localhost:1234`
+3. **Rule-based wrapping** (final fallback) -- wraps in YOUR CONTEXT / YOUR PHOTO format with mode-appropriate defaults
+
+If both LLMs are down, you still get well-formatted prompts.
+
+---
+
+## Batch and Variations
+
+### Batch
+
+Generate multiple images from the same prompt (different random seeds each time):
+
+```
+/batch 5 Kira in a sundress on a rooftop at sunset
+```
+
+Generates 5 images, each with a unique seed. Count range: 1-8.
+
+If you omit the count, it defaults to 3:
+
+```
+/batch Kira in a sundress on a rooftop at sunset
+```
+
+### Vary
+
+Generate multiple prompt variations -- the optimizer rewrites the prompt differently each time, varying angle, lighting, or composition:
+
+```
+/vary 4 Kira in a coffee shop
+```
+
+Produces 4 distinct interpretations of the same scene concept. Default count: 3.
+
+### Sequence
+
+Break a story into sequential frames:
+
+```
+/seq 4 Kira walks through a garden gate, discovers a hidden fountain, sits on the edge, dips her feet in the water
+```
+
+When enhancement is on, the LLM breaks the story into separate scene descriptions. When off, the story is split by sentence/period boundaries.
+
+Default count: 4. Range: 1-8.
+
+---
+
+## Image Controls
+
+### Aspect Ratio
+
+```
+/aspect portrait    -- 768x1024 (default)
+/aspect landscape   -- 1024x768
+/aspect square      -- 1024x1024
+/aspect wide        -- 1024x576
+/aspect tall        -- 576x1024
+/aspect             -- show current setting
+```
+
+### CFG (Guidance Scale)
+
+Override the model's default guidance:
+
+```
+/cfg 3.5     -- set CFG to 3.5
+/cfg         -- reset to model default
+```
+
+Range: 0-20. Z-Image Turbo is CFG-distilled (trained at CFG 1.0), so overriding this is rarely needed.
+
+### Seed
+
+Lock the seed for reproducible results:
+
+```
+/seed 42       -- lock seed to 42
+/seed random   -- back to random seeds
+/seed          -- back to random seeds
+```
+
+### Upscale
+
+Enable SeedVR 2x upscaling on every render:
+
+```
+/upscale on    -- enable
+/upscale off   -- disable
+/upscale       -- toggle
+```
+
+### Polish
+
+Two-pass refinement: renders the image, then re-renders at 35% strength with 30 steps for added detail:
+
+```
+/polish on     -- enable
+/polish off    -- disable
+/polish        -- toggle
+```
+
+### Resolution Targets
+
+Shorthand commands that enable upscale and set the target:
+
+```
+/2k            -- enable upscale to 2K resolution
+/4k            -- double upscale to 4K resolution
+/2k off        -- disable
+/4k off        -- disable
+```
+
+4K runs two upscale passes back-to-back.
+
+---
+
+## Post-Processing
+
+Post-processing effects are applied to every rendered image using Core Image filters. They stack and persist until reset.
+
+### Saturation
+
+```
+/saturation 1.3   -- boost saturation (1.0 = unchanged)
+/saturation 0.5   -- reduce saturation
+/saturation 0     -- grayscale
+/saturation off   -- disable
+```
+
+Range: 0-2.
+
+### Color Temperature
+
+```
+/temp 4500     -- warm (lower Kelvin = warmer)
+/temp 8000     -- cool (higher Kelvin = cooler)
+/temp off      -- disable
+```
+
+Range: 2000-10000K. 6500K is neutral daylight.
+
+### Film Look Presets
+
+Apply a film stock color grade:
+
+```
+/film kodak-portra     -- warm skin tones, slightly desaturated
+/film fuji-velvia      -- vibrant colors, high contrast
+/film ilford-hp5       -- black and white with boosted contrast
+/film cinestill-800t   -- tungsten-balanced, blue shadows
+/film kodak-ektar      -- vivid colors, punchy contrast
+/film off              -- disable
+```
+
+### Browse Film Looks
+
+```
+/look              -- list all available looks with active indicator
+/look kodak-portra -- apply a look (alias for /film)
+```
+
+### Reset Post-Processing
+
+Clear all post-processing settings at once:
+
+```
+/reset
+```
+
+Clears saturation, color temperature, and film look. Does not affect other settings like aspect or seed.
+
+---
+
+## Inline Keyboards
+
+Every delivered image has three buttons:
+
+| Button | Action |
+|--------|--------|
+| **Rerender** | Re-render the same prompt with a new random seed |
+| **HQ** | Re-render with polish (two-pass refinement) enabled, same seed |
+| **Video** | Directs to @BaristaBree_Bot for video generation |
+
+Buttons reference the original render context (prompt, character, mode, seed). Context is stored per message and evicts after 50 entries per chat.
+
+---
+
+## Reply Actions
+
+Reply to any bot-sent image with text to trigger an action:
+
+| Reply text | Action |
+|------------|--------|
+| `rerender` or `again` or `redo` | Re-render with new random seed |
+| `hq` | Re-render with polish, same seed |
+| `upscale` | Upscale the image via SeedVR 2x (with sharpen) |
+| `video` | Redirect to @BaristaBree_Bot |
+| `video <description>` | Redirect with motion description |
+| *anything else* | **img2img** -- re-render using the original image as input with your new prompt |
+
+img2img sends your new text through the optimizer and generates at 50% strength using the original image as the starting point. This is great for iterating on a composition.
+
+---
+
+## Discuss Mode
+
+Discuss mode is a back-and-forth conversation with the local LLM to collaboratively design a prompt before rendering.
+
+### Enter Discuss Mode
+
+```
+/chat
+```
+
+Or equivalently:
+
+```
+/discuss
+```
+
+### How It Works
+
+1. Describe what you want in plain language
+2. The LLM proposes a prompt in YOUR CONTEXT / YOUR PHOTO format and explains its choices
+3. Reply with refinements ("make it warmer", "change to landscape", "add rain")
+4. When satisfied, say **go**, **ship it**, **render it**, **send it**, **fire it**, or **do it**
+5. The bot exits discuss mode and renders the refined prompt
+
+### Example Session
+
+```
+You: /chat
+Bot: Discuss mode -- let's design a prompt together...
+
+You: Kira in a moody jazz club
+Bot: [proposes prompt with smoky atmosphere, stage lighting...]
+
+You: Make it a closer shot, more intimate
+Bot: [revises with tighter framing, shallow depth of field...]
+
+You: ship it
+Bot: Rendering...
+[delivers image]
+```
+
+### Exit Without Rendering
+
+```
+/end
+```
+
+Or equivalently:
+
+```
+/exit
+```
+
+### One-Shot Imagine
+
+Skip the conversation and let the LLM design a prompt from a brief description:
+
+```
+/imagine Kira in a cyberpunk alley
+```
+
+The LLM designs a complete prompt and renders it immediately, then includes a brief creative report explaining its choices in the caption.
+
+---
+
+## Queue Management
+
+Check and control the WarmServer render queue:
+
+```
+/queue           -- show queue status (server state, pending jobs, completed count)
+/queue list      -- list pending jobs (up to 10, with truncated prompts)
+/queue cancel    -- clear all pending jobs from the queue
+```
+
+---
+
+## Configuration Reference
+
+### `~/.comfybox/telegram.json`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `botToken` | string | required | Telegram Bot API token |
+| `allowedUserIds` | int[] | `[8754779862]` | Authorized Telegram user IDs |
+| `warmServer.host` | string | `"127.0.0.1"` | WarmServer hostname |
+| `warmServer.port` | int | `7862` | WarmServer port |
+| `optimizer.enabled` | bool | `true` | Enable prompt enhancement |
+| `optimizer.ollamaBaseURL` | string | `"http://localhost:11434"` | Ollama endpoint |
+| `optimizer.lmStudioBaseURL` | string | `"http://localhost:1234"` | LM Studio fallback endpoint |
+| `optimizer.model` | string | `"qwen3:8b"` | LLM model name |
+| `optimizer.timeoutSeconds` | int | `15` | LLM request timeout |
+| `characterConfigPath` | string | `"~/.comfybox/characters.json"` | Path to character descriptions |
+| `contentModeConfigPath` | string | `"~/.comfybox/content-mode.json"` | Path to mode persistence file |
+| `outputDirectory` | string | `"~/Pictures/ComfyBox/Telegram"` | Where rendered images are saved |
+| `galleryDirectory` | string | none | Optional gallery copy directory |
+
+### `~/.comfybox/characters.json`
+
+```json
+{
+  "kira": {
+    "base": "A 23-year-old Filipina woman, petite 4'11\" build, warm brown skin...",
+    "banana": "wearing a lace camisole...",
+    "avocado": "nude, athletic build visible..."
+  },
+  "bree": {
+    "base": "A 5'8\" Korean-Filipino woman...",
+    "banana": "...",
+    "avocado": "..."
+  }
+}
+```
+
+The `base` description is always included. `banana` is appended in banana and avocado modes. `avocado` is appended only in avocado mode. Tiered composition mirrors the server-side `characters.ts` logic.
+
+### `~/.comfybox/content-mode.json`
+
+Auto-managed. Contains the current mode:
+
+```json
+{
+  "mode": "neutral"
+}
+```
+
+---
+
+## Full Command Reference
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| `/help` | -- | Show help text with current settings |
+| `/status` | -- | WarmServer status, model, queue, bot uptime |
+| `/neutral` or `/apple` | -- | Set content mode to neutral (SFW) |
+| `/banana` | -- | Set content mode to banana (suggestive) |
+| `/avocado` | -- | Set content mode to avocado (explicit) |
+| `/enhance` | `[on\|off]` | Toggle or set prompt enhancement |
+| `/batch` | `[N] <prompt>` | Generate N images (default 3, max 8) |
+| `/vary` | `[N] <prompt>` | N prompt variations (default 3, max 8) |
+| `/seq` or `/sequence` | `[N] <story>` | N sequential story frames (default 4, max 8) |
+| `/imagine` | `<description>` | One-shot: LLM designs and renders |
+| `/chat` or `/discuss` | -- | Enter discuss mode |
+| `/end` or `/exit` | -- | Exit discuss mode |
+| `/queue` | `[status\|list\|cancel]` | Queue management |
+| `/aspect` | `<mode>` | Set aspect ratio |
+| `/cfg` | `<value>` or none | Set or clear CFG override |
+| `/seed` | `<N\|random>` | Lock or randomize seed |
+| `/upscale` | `[on\|off]` | Toggle SeedVR 2x upscale |
+| `/polish` | `[on\|off]` | Toggle two-pass polish |
+| `/2k` | `[on\|off]` | Enable/disable 2K resolution |
+| `/4k` | `[on\|off]` | Enable/disable 4K resolution |
+| `/verbose` | `[on\|off]` | Toggle verbose mode |
+| `/autovideo` | `[on\|off]` | Toggle auto-video |
+| `/saturation` | `<0-2\|off>` | Adjust saturation |
+| `/temp` | `<2000-10000\|off>` | Adjust color temperature |
+| `/film` | `<look-id\|off>` | Apply or clear film look |
+| `/look` | `[look-id]` | List or apply film looks |
+| `/reset` | -- | Clear all post-processing settings |
+| `/video` | `<prompt>` | Redirects to @BaristaBree_Bot |
+
+Bare text (no `/` prefix) outside of discuss mode is treated as a render prompt.
+
+---
+
+## Troubleshooting
+
+### WarmServer Not Running
+
+**Symptom:** Every prompt returns "WarmServer not available -- start `ComfyBox serve` first."
+
+**Fix:** Start the WarmServer in another terminal:
+
+```
+ComfyBox serve --port 7862
+```
+
+The bot connects on-demand per request. No restart needed once the server is up.
+
+### Ollama Not Running
+
+**Symptom:** Prompts still render but captions do not show the enhance indicator. Log shows "Optimizer unavailable -- using rule-based format wrapping."
+
+**Fix:** Start Ollama:
+
+```
+ollama serve
+```
+
+The bot tries Ollama on every request. No restart needed once Ollama is up.
+
+### Bot Not Responding
+
+1. **Check the bot is running.** Look for the process: `ps aux | grep ComfyBox`.
+2. **Check allowed users.** Your Telegram user ID must be in the `allowedUserIds` list. Unauthorized users are silently rejected (check the bot log for "rejected update from unauthorized user").
+3. **Check Telegram API.** Ensure the Mac can reach `api.telegram.org`. The bot uses long polling (outbound HTTPS only -- no inbound ports needed).
+4. **Check the log output.** The bot logs to stderr. Poll errors retry automatically after 5 seconds.
+
+### Images Not Delivering
+
+**Symptom:** Bot says "Rendering..." but no image arrives.
+
+1. Check WarmServer health: send `/status` to the bot.
+2. Check `~/Pictures/ComfyBox/Telegram/` for output files -- the image may have been generated but failed to upload.
+3. Telegram has a 10MB photo limit. Images over 8MB are sent as documents instead. If upscale + 4K produces very large files, this is expected.
+
+### Post-Processing Not Applied
+
+Post-processing uses Core Image (macOS native). If running on Linux, it falls back to ImageMagick CLI (`/opt/homebrew/bin/convert`). Ensure ImageMagick is installed if not on macOS.


### PR DESCRIPTION
## Summary

- **telegram-user-guide.md** -- end-user documentation covering all commands, content modes, prompt enhancement, batch/vary/sequence, post-processing, inline keyboards, reply actions, discuss mode, queue management, config file schema, and troubleshooting
- **telegram-technical.md** -- developer reference covering architecture, module map with public APIs, render pipeline flow, callback/reply routing, discuss mode internals, post-processor CIFilter chain, session state eviction, entry point config resolution, and extension points for adding commands/looks/characters/effects

Both docs written from the Phase 1-4 source in Sources/ZImage/Telegram/.

## Test plan

- [ ] Verify all /commands listed in user guide match TelegramCommandParser.swift cases
- [ ] Verify config JSON schema matches loadTelegramConfig() in main.swift
- [ ] Spot-check film look IDs against PostProcessor.filmLooks array

Generated with [Claude Code](https://claude.com/claude-code)