### PR TITLE
feat(desktop): Gallery View + Asset Ingestion (Phase 2)

### DIFF
--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -1,15 +1,19 @@
 // ComfyBoxDesktopApp.swift — SwiftUI app entry point
 //
-// Main application for ComfyBox Desktop. Creates the EngineService
-// on launch and provides the primary window with a tabbed interface
-// for generation and gallery views.
+// Main application for ComfyBox Desktop. Creates the EngineService,
+// DAMStore, and AssetIngestor on launch. Provides a tabbed interface
+// for generation and gallery views. Generation output is automatically
+// ingested into the DAM.
 
 import SwiftUI
 
 @main
 struct ComfyBoxDesktopApp: App {
     @State private var engine = EngineService()
+    @State private var store: DAMStore?
+    @State private var ingestor: AssetIngestor?
     @State private var selectedTab: AppTab = .generate
+    @State private var initError: String?
 
     enum AppTab: String, CaseIterable {
         case generate = "Generate"
@@ -33,9 +37,26 @@ struct ComfyBoxDesktopApp: App {
             } detail: {
                 switch selectedTab {
                 case .generate:
-                    GenerationView(engine: engine)
+                    GenerationView(engine: engine, onGenerated: handleGenerated)
                 case .gallery:
-                    GalleryView()
+                    if let store = store, let ingestor = ingestor {
+                        GalleryView(store: store, ingestor: ingestor)
+                    } else if let error = initError {
+                        VStack(spacing: 12) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.system(size: 48))
+                                .foregroundStyle(.orange)
+                            Text("Database Error")
+                                .font(.title2)
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        ProgressView("Initializing database...")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
             }
             .navigationTitle("ComfyBox Desktop")
@@ -44,6 +65,15 @@ struct ComfyBoxDesktopApp: App {
                 ToolbarItem(placement: .automatic) {
                     connectionButton
                 }
+
+                if let ingestor = ingestor {
+                    ToolbarItem(placement: .automatic) {
+                        ingestorStatus(ingestor)
+                    }
+                }
+            }
+            .task {
+                await initializeDAM()
             }
         }
         .defaultSize(width: 1200, height: 800)
@@ -67,6 +97,50 @@ struct ComfyBoxDesktopApp: App {
                     .frame(width: 8, height: 8)
                 Text(engine.connectionState.isConnected ? "Connected" : "Connect")
                     .font(.caption)
+            }
+        }
+    }
+
+    private func ingestorStatus(_ ingestor: AssetIngestor) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(ingestor.isWatching ? .blue : .gray)
+                .frame(width: 6, height: 6)
+            Text("\(ingestor.ingestedCount) ingested")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Initialization
+
+    private func initializeDAM() async {
+        do {
+            let damStore = try await DAMStore.open()
+            let assetIngestor = AssetIngestor(
+                store: damStore,
+                watchDirectory: engine.outputDirectory
+            )
+            store = damStore
+            ingestor = assetIngestor
+            await assetIngestor.startWatching()
+        } catch {
+            initError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Generation → Ingestion Bridge
+
+    /// Called when GenerationView successfully generates an image.
+    /// Ingests the output into DAMStore so it appears in the gallery.
+    private func handleGenerated(_ path: String, _ request: GenerationRequest) {
+        guard let ingestor = ingestor else { return }
+        Task {
+            do {
+                try await ingestor.ingestFile(at: path)
+            } catch {
+                // Ingestion failure is non-fatal; the file is still on disk.
+                print("[ComfyBoxDesktop] Auto-ingest failed for \(path): \(error)")
             }
         }
     }

--- a/Sources/ComfyBoxDesktop/DAM/AssetIngestor.swift
+++ b/Sources/ComfyBoxDesktop/DAM/AssetIngestor.swift
@@ -1,0 +1,276 @@
+// AssetIngestor.swift — Watches output directory for new images
+//
+// Polls the ComfyBox output directory for new image files. When a
+// new .png/.jpg appears, reads its JSON sidecar metadata, creates
+// a DAMAsset, generates a 256px thumbnail, and inserts into DAMStore.
+//
+// Uses a simple polling approach (every 5 seconds) rather than
+// complex DispatchSource file watching.
+
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Watches an output directory and ingests new images into DAMStore.
+@Observable
+public final class AssetIngestor {
+    // MARK: - Published State
+
+    public var isWatching: Bool = false
+    public var lastIngestedFile: String?
+    public var ingestedCount: Int = 0
+    public var lastError: String?
+
+    // MARK: - Configuration
+
+    public var watchDirectory: String
+    public var thumbnailDirectory: String
+
+    // MARK: - Private
+
+    private var pollTask: Task<Void, Never>?
+    private var knownPaths: Set<String> = []
+    private let store: DAMStore
+    private let pollInterval: TimeInterval = 5.0
+    private let thumbnailMaxDimension: CGFloat = 256
+    private let thumbnailJPEGQuality: CGFloat = 0.8
+
+    public init(store: DAMStore, watchDirectory: String? = nil, thumbnailDirectory: String? = nil) {
+        self.store = store
+        let comfyboxDir = NSString(string: "~/.comfybox").expandingTildeInPath
+        self.watchDirectory = watchDirectory ?? (comfyboxDir as NSString).appendingPathComponent("output")
+        self.thumbnailDirectory = thumbnailDirectory ?? (comfyboxDir as NSString).appendingPathComponent("thumbnails")
+    }
+
+    // MARK: - Start / Stop
+
+    /// Begin watching the output directory for new images.
+    public func startWatching() async {
+        guard !isWatching else { return }
+
+        // Ensure directories exist.
+        let fm = FileManager.default
+        try? fm.createDirectory(atPath: watchDirectory, withIntermediateDirectories: true)
+        try? fm.createDirectory(atPath: thumbnailDirectory, withIntermediateDirectories: true)
+
+        // Seed known paths from DAMStore so we don't re-ingest existing assets.
+        do {
+            let existing = try await store.allAssetPaths()
+            knownPaths = Set(existing)
+        } catch {
+            // If we fail to read existing paths, start fresh — may re-ingest some.
+            knownPaths = []
+        }
+
+        // Also add any files already in the directory to avoid initial flood.
+        if let contents = try? fm.contentsOfDirectory(atPath: watchDirectory) {
+            for filename in contents where isImageFile(filename) {
+                let path = (watchDirectory as NSString).appendingPathComponent(filename)
+                knownPaths.insert(path)
+            }
+        }
+
+        isWatching = true
+        lastError = nil
+
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.scanForNewFiles()
+                try? await Task.sleep(for: .seconds(self?.pollInterval ?? 5))
+            }
+        }
+    }
+
+    /// Stop watching.
+    public func stopWatching() {
+        pollTask?.cancel()
+        pollTask = nil
+        isWatching = false
+    }
+
+    /// Manually ingest a single file at the given path. Returns the created asset.
+    @discardableResult
+    public func ingestFile(at path: String) async throws -> DAMAsset {
+        let asset = try buildAsset(from: path)
+        try await store.insertAsset(asset)
+        generateThumbnail(for: path, assetId: asset.id)
+        knownPaths.insert(path)
+        ingestedCount += 1
+        lastIngestedFile = asset.filename
+        return asset
+    }
+
+    // MARK: - Polling
+
+    private func scanForNewFiles() async {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: watchDirectory) else {
+            return
+        }
+
+        let imageFiles = contents.filter { isImageFile($0) }
+
+        for filename in imageFiles {
+            let path = (watchDirectory as NSString).appendingPathComponent(filename)
+
+            guard !knownPaths.contains(path) else { continue }
+
+            // Check file is fully written (size stable).
+            guard isFileStable(at: path) else { continue }
+
+            do {
+                try await ingestFile(at: path)
+            } catch {
+                lastError = "Failed to ingest \(filename): \(error.localizedDescription)"
+            }
+        }
+    }
+
+    // MARK: - Asset Building
+
+    private func buildAsset(from path: String) throws -> DAMAsset {
+        let fm = FileManager.default
+        let filename = (path as NSString).lastPathComponent
+
+        // File attributes.
+        let attrs = try fm.attributesOfItem(atPath: path)
+        let fileSize = (attrs[.size] as? Int64) ?? 0
+        let createdAt = (attrs[.creationDate] as? Date) ?? Date()
+        let modifiedAt = (attrs[.modificationDate] as? Date) ?? Date()
+
+        // Image dimensions via ImageIO (no full decode).
+        var width: Int?
+        var height: Int?
+        if let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: path) as CFURL, nil) {
+            if let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] {
+                width = props[kCGImagePropertyPixelWidth as String] as? Int
+                height = props[kCGImagePropertyPixelHeight as String] as? Int
+            }
+        }
+
+        // Read JSON sidecar metadata if present.
+        let sidecar = readSidecar(for: path)
+
+        return DAMAsset(
+            kind: "image",
+            filename: filename,
+            absolutePath: path,
+            fileSize: fileSize,
+            width: width,
+            height: height,
+            createdAt: createdAt,
+            modifiedAt: modifiedAt,
+            ingestedAt: Date(),
+            prompt: sidecar?.prompt,
+            negativePrompt: sidecar?.negativePrompt,
+            seed: sidecar?.seed,
+            steps: sidecar?.steps,
+            guidance: sidecar?.guidance,
+            modelFamily: sidecar?.modelFamily,
+            contentMode: sidecar?.contentMode,
+            characterName: sidecar?.characterName
+        )
+    }
+
+    // MARK: - Sidecar Metadata
+
+    private struct SidecarMetadata {
+        let prompt: String?
+        let negativePrompt: String?
+        let seed: Int?
+        let steps: Int?
+        let guidance: Double?
+        let modelFamily: String?
+        let contentMode: String?
+        let characterName: String?
+    }
+
+    private func readSidecar(for imagePath: String) -> SidecarMetadata? {
+        // ComfyBox writes {filename}.json next to each output image.
+        let basePath = (imagePath as NSString).deletingPathExtension
+        let jsonPath = basePath + ".json"
+
+        guard FileManager.default.fileExists(atPath: jsonPath),
+              let data = FileManager.default.contents(atPath: jsonPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return SidecarMetadata(
+            prompt: json["prompt"] as? String,
+            negativePrompt: json["negative_prompt"] as? String
+                ?? json["negativePrompt"] as? String,
+            seed: json["seed"] as? Int,
+            steps: json["steps"] as? Int,
+            guidance: json["guidance"] as? Double
+                ?? (json["guidance"] as? Int).map(Double.init),
+            modelFamily: json["model"] as? String
+                ?? json["modelFamily"] as? String
+                ?? json["model_family"] as? String,
+            contentMode: json["contentMode"] as? String
+                ?? json["content_mode"] as? String,
+            characterName: json["characterName"] as? String
+                ?? json["character_name"] as? String
+                ?? json["character"] as? String
+        )
+    }
+
+    // MARK: - Thumbnail Generation
+
+    private func generateThumbnail(for imagePath: String, assetId: String) {
+        let thumbPath = thumbnailPath(for: assetId)
+
+        // Skip if thumbnail already exists.
+        guard !FileManager.default.fileExists(atPath: thumbPath) else { return }
+
+        guard let source = CGImageSourceCreateWithURL(
+            URL(fileURLWithPath: imagePath) as CFURL, nil
+        ) else { return }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(thumbnailMaxDimension),
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, options as CFDictionary
+        ) else { return }
+
+        // Write as JPEG.
+        guard let dest = CGImageDestinationCreateWithURL(
+            URL(fileURLWithPath: thumbPath) as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1, nil
+        ) else { return }
+
+        let destOptions: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: thumbnailJPEGQuality,
+        ]
+        CGImageDestinationAddImage(dest, thumbnail, destOptions as CFDictionary)
+        CGImageDestinationFinalize(dest)
+    }
+
+    /// Returns the thumbnail file path for a given asset ID.
+    public func thumbnailPath(for assetId: String) -> String {
+        (thumbnailDirectory as NSString).appendingPathComponent("\(assetId).jpg")
+    }
+
+    // MARK: - Helpers
+
+    private func isImageFile(_ filename: String) -> Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        return ext == "png" || ext == "jpg" || ext == "jpeg"
+    }
+
+    private func isFileStable(at path: String) -> Bool {
+        // Simple check: file must be at least 1 second old (modification time).
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modified = attrs[.modificationDate] as? Date
+        else {
+            return false
+        }
+        return Date().timeIntervalSince(modified) > 1.0
+    }
+}

--- a/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
+++ b/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
@@ -144,6 +144,25 @@ public actor DAMStore {
         return results
     }
 
+    /// Return all known absolute_path values from the database.
+    /// Used by AssetIngestor to avoid re-ingesting existing assets.
+    public func allAssetPaths() throws -> [String] {
+        let sql = "SELECT absolute_path FROM assets"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var paths: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let path = columnText(stmt, 0) {
+                paths.append(path)
+            }
+        }
+        return paths
+    }
+
     /// Total number of assets in the database.
     public func assetCount() throws -> Int {
         let sql = "SELECT COUNT(*) FROM assets"

--- a/Sources/ComfyBoxDesktop/Views/AssetDetailView.swift
+++ b/Sources/ComfyBoxDesktop/Views/AssetDetailView.swift
@@ -1,0 +1,313 @@
+// AssetDetailView.swift — Full asset detail and metadata editing
+//
+// Displays a full-size image preview with all generation metadata.
+// Provides editable fields for rating (0-5 stars), favorite toggle,
+// and notes. Changes are saved back to DAMStore.
+
+import SwiftUI
+
+struct AssetDetailView: View {
+    let asset: DAMAsset
+    let thumbnailPath: String?
+    let onUpdate: (DAMAsset) -> Void
+
+    @State private var rating: Int
+    @State private var isFavorite: Bool
+    @State private var notes: String
+    @State private var fullImage: NSImage?
+    @State private var isLoadingImage: Bool = false
+    @Environment(\.dismiss) private var dismiss
+
+    init(asset: DAMAsset, thumbnailPath: String?, onUpdate: @escaping (DAMAsset) -> Void) {
+        self.asset = asset
+        self.thumbnailPath = thumbnailPath
+        self.onUpdate = onUpdate
+        self._rating = State(initialValue: asset.rating)
+        self._isFavorite = State(initialValue: asset.favorite)
+        self._notes = State(initialValue: "")
+    }
+
+    var body: some View {
+        HSplitView {
+            // Left: Full-size image
+            imagePanel
+                .frame(minWidth: 400)
+
+            // Right: Metadata and controls
+            metadataPanel
+                .frame(minWidth: 280, maxWidth: 360)
+        }
+        .frame(minWidth: 800, minHeight: 500)
+        .task {
+            await loadFullImage()
+        }
+    }
+
+    // MARK: - Image Panel
+
+    private var imagePanel: some View {
+        ZStack {
+            Color(nsColor: .controlBackgroundColor)
+
+            if let image = fullImage {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(16)
+            } else if isLoadingImage {
+                VStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Loading image...")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.tertiary)
+                    Text("Image not available")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Metadata Panel
+
+    private var metadataPanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // File info header
+                fileInfoSection
+
+                Divider()
+
+                // Rating and favorite
+                annotationSection
+
+                Divider()
+
+                // Generation parameters
+                generationSection
+
+                Divider()
+
+                // Prompt
+                promptSection
+
+                Spacer()
+
+                // Save button
+                saveButton
+            }
+            .padding()
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var fileInfoSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(asset.filename)
+                .font(.headline)
+                .lineLimit(2)
+                .truncationMode(.middle)
+
+            HStack(spacing: 12) {
+                if let w = asset.width, let h = asset.height {
+                    Label("\(w) x \(h)", systemImage: "aspectratio")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Label(formattedFileSize, systemImage: "doc")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(formattedDate(asset.createdAt))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var annotationSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Annotation")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            // Star rating
+            HStack(spacing: 4) {
+                Text("Rating")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                starRatingPicker
+            }
+
+            // Favorite toggle
+            Toggle(isOn: $isFavorite) {
+                Label("Favorite", systemImage: isFavorite ? "heart.fill" : "heart")
+            }
+            .toggleStyle(.switch)
+        }
+    }
+
+    private var starRatingPicker: some View {
+        HStack(spacing: 2) {
+            ForEach(1...5, id: \.self) { star in
+                Image(systemName: star <= rating ? "star.fill" : "star")
+                    .foregroundStyle(star <= rating ? .yellow : .gray)
+                    .font(.body)
+                    .onTapGesture {
+                        rating = star == rating ? 0 : star
+                    }
+            }
+        }
+    }
+
+    private var generationSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Generation")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            metadataRow("Model", value: asset.modelFamily)
+            metadataRow("Steps", value: asset.steps.map(String.init))
+            metadataRow("Guidance", value: asset.guidance.map { String(format: "%.1f", $0) })
+            metadataRow("Seed", value: asset.seed.map(String.init))
+            metadataRow("Content Mode", value: asset.contentMode)
+            metadataRow("Character", value: asset.characterName)
+        }
+    }
+
+    private var promptSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Prompt")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            if let prompt = asset.prompt {
+                Text(prompt)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else {
+                Text("No prompt recorded")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if let negPrompt = asset.negativePrompt {
+                Text("Negative Prompt")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+                Text(negPrompt)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+        }
+    }
+
+    private var saveButton: some View {
+        Button(action: saveChanges) {
+            HStack {
+                Image(systemName: "checkmark.circle")
+                Text("Save Changes")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!hasChanges)
+    }
+
+    // MARK: - Helpers
+
+    private var hasChanges: Bool {
+        rating != asset.rating || isFavorite != asset.favorite
+    }
+
+    private var formattedFileSize: String {
+        let bytes = asset.fileSize
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.0f KB", kb) }
+        let mb = kb / 1024
+        return String(format: "%.1f MB", mb)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateStyle = .medium
+        fmt.timeStyle = .short
+        return fmt.string(from: date)
+    }
+
+    @ViewBuilder
+    private func metadataRow(_ label: String, value: String?) -> some View {
+        if let value = value {
+            HStack {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 90, alignment: .leading)
+                Text(value)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                Spacer()
+            }
+        }
+    }
+
+    private func loadFullImage() async {
+        isLoadingImage = true
+        let path = asset.absolutePath
+        let image = await Task.detached {
+            NSImage(contentsOfFile: path)
+        }.value
+        await MainActor.run {
+            fullImage = image
+            isLoadingImage = false
+        }
+    }
+
+    private func saveChanges() {
+        let updated = DAMAsset(
+            id: asset.id,
+            kind: asset.kind,
+            filename: asset.filename,
+            absolutePath: asset.absolutePath,
+            fileSize: asset.fileSize,
+            sha256: asset.sha256,
+            width: asset.width,
+            height: asset.height,
+            createdAt: asset.createdAt,
+            modifiedAt: Date(),
+            ingestedAt: asset.ingestedAt,
+            orphaned: asset.orphaned,
+            prompt: asset.prompt,
+            negativePrompt: asset.negativePrompt,
+            seed: asset.seed,
+            steps: asset.steps,
+            guidance: asset.guidance,
+            modelFamily: asset.modelFamily,
+            rating: rating,
+            favorite: isFavorite,
+            contentMode: asset.contentMode,
+            characterName: asset.characterName
+        )
+        onUpdate(updated)
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/GalleryView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GalleryView.swift
@@ -1,32 +1,430 @@
-// GalleryView.swift — Asset gallery placeholder
+// GalleryView.swift — Asset gallery with grid, search, and filtering
 //
-// Phase 2 will implement a full gallery view with grid layout,
-// filtering, search, and metadata display. For now, shows a
-// placeholder message.
+// Displays DAMStore assets as a grid of thumbnails with sorting,
+// filtering by favorite/content mode/character, and FTS5 search.
+// Clicking a cell opens the AssetDetailView for full metadata
+// display and editing.
 
 import SwiftUI
 
+/// Sort options for the gallery.
+enum GallerySortOrder: String, CaseIterable {
+    case date = "Date"
+    case rating = "Rating"
+    case favorite = "Favorites First"
+}
+
 struct GalleryView: View {
+    let store: DAMStore
+    let ingestor: AssetIngestor
+
+    @State private var assets: [DAMAsset] = []
+    @State private var searchText: String = ""
+    @State private var sortOrder: GallerySortOrder = .date
+    @State private var filterFavorites: Bool = false
+    @State private var filterContentMode: String?
+    @State private var filterCharacter: String?
+    @State private var selectedAsset: DAMAsset?
+    @State private var showingDetail: Bool = false
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    // Available filter values extracted from assets.
+    @State private var contentModes: [String] = []
+    @State private var characters: [String] = []
+
+    private let columns = [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 12)]
+
     var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar: search, sort, filter
+            toolbarView
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(nsColor: .windowBackgroundColor))
+
+            Divider()
+
+            // Gallery grid
+            if isLoading {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Loading gallery...")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if filteredAssets.isEmpty {
+                emptyState
+            } else {
+                galleryGrid
+            }
+        }
+        .sheet(isPresented: $showingDetail) {
+            if let asset = selectedAsset {
+                AssetDetailView(
+                    asset: asset,
+                    thumbnailPath: ingestor.thumbnailPath(for: asset.id),
+                    onUpdate: { updated in
+                        Task { await updateAsset(updated) }
+                        showingDetail = false
+                    }
+                )
+                .frame(minWidth: 800, minHeight: 500)
+            }
+        }
+        .task {
+            await loadAssets()
+        }
+        .onChange(of: ingestor.ingestedCount) { _, _ in
+            Task { await loadAssets() }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbarView: some View {
+        HStack(spacing: 12) {
+            // Search field
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search prompts...", text: $searchText)
+                    .textFieldStyle(.plain)
+                if !searchText.isEmpty {
+                    Button(action: { searchText = "" }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .frame(maxWidth: 300)
+
+            Spacer()
+
+            // Favorite filter
+            Toggle(isOn: $filterFavorites) {
+                Image(systemName: filterFavorites ? "heart.fill" : "heart")
+            }
+            .toggleStyle(.button)
+            .help("Show favorites only")
+
+            // Content mode filter
+            if !contentModes.isEmpty {
+                Picker("Mode", selection: Binding(
+                    get: { filterContentMode ?? "" },
+                    set: { filterContentMode = $0.isEmpty ? nil : $0 }
+                )) {
+                    Text("All Modes").tag("")
+                    ForEach(contentModes, id: \.self) { mode in
+                        Text(mode.capitalized).tag(mode)
+                    }
+                }
+                .frame(width: 120)
+            }
+
+            // Character filter
+            if !characters.isEmpty {
+                Picker("Character", selection: Binding(
+                    get: { filterCharacter ?? "" },
+                    set: { filterCharacter = $0.isEmpty ? nil : $0 }
+                )) {
+                    Text("All Characters").tag("")
+                    ForEach(characters, id: \.self) { name in
+                        Text(name).tag(name)
+                    }
+                }
+                .frame(width: 120)
+            }
+
+            // Sort picker
+            Picker("Sort", selection: $sortOrder) {
+                ForEach(GallerySortOrder.allCases, id: \.self) { order in
+                    Text(order.rawValue).tag(order)
+                }
+            }
+            .frame(width: 140)
+
+            // Refresh button
+            Button(action: { Task { await loadAssets() } }) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .help("Refresh gallery")
+
+            // Asset count
+            Text("\(filteredAssets.count) images")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    // MARK: - Gallery Grid
+
+    private var galleryGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(filteredAssets) { asset in
+                    GalleryCellView(
+                        asset: asset,
+                        thumbnailPath: ingestor.thumbnailPath(for: asset.id)
+                    )
+                    .onTapGesture {
+                        selectedAsset = asset
+                        showingDetail = true
+                    }
+                    .contextMenu {
+                        Button("Reveal in Finder") {
+                            revealInFinder(asset)
+                        }
+                        Button(asset.favorite ? "Unfavorite" : "Favorite") {
+                            Task { await toggleFavorite(asset) }
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "photo.on.rectangle.angled")
                 .font(.system(size: 64))
                 .foregroundStyle(.tertiary)
 
-            Text("Gallery")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-
-            Text("Coming in Phase 2")
-                .font(.body)
-                .foregroundStyle(.tertiary)
-
-            Text("The gallery will display all generated assets with search, filtering, rating, and metadata.")
-                .font(.caption)
-                .foregroundStyle(.quaternary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 300)
+            if !searchText.isEmpty {
+                Text("No results for \"\(searchText)\"")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Try a different search term.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            } else if filterFavorites {
+                Text("No favorites yet")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Heart an image to see it here.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("No images in gallery")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Generate an image or configure the watch directory.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Filtering and Sorting
+
+    private var filteredAssets: [DAMAsset] {
+        var results = assets
+
+        // Apply favorites filter.
+        if filterFavorites {
+            results = results.filter { $0.favorite }
+        }
+
+        // Apply content mode filter.
+        if let mode = filterContentMode {
+            results = results.filter { $0.contentMode == mode }
+        }
+
+        // Apply character filter.
+        if let character = filterCharacter {
+            results = results.filter { $0.characterName == character }
+        }
+
+        // Apply search — client-side for immediate feedback, FTS for big datasets.
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            results = results.filter { asset in
+                (asset.prompt?.lowercased().contains(query) ?? false)
+                    || (asset.negativePrompt?.lowercased().contains(query) ?? false)
+                    || asset.filename.lowercased().contains(query)
+                    || (asset.characterName?.lowercased().contains(query) ?? false)
+            }
+        }
+
+        // Apply sort.
+        switch sortOrder {
+        case .date:
+            results.sort { $0.createdAt > $1.createdAt }
+        case .rating:
+            results.sort { $0.rating > $1.rating }
+        case .favorite:
+            results.sort {
+                if $0.favorite != $1.favorite { return $0.favorite }
+                return $0.createdAt > $1.createdAt
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Data Loading
+
+    private func loadAssets() async {
+        isLoading = assets.isEmpty
+        do {
+            if !searchText.isEmpty {
+                let ftsResults = try await store.searchPrompts(query: searchText, limit: 200)
+                assets = ftsResults
+            } else {
+                assets = try await store.fetchAssets(limit: 500)
+            }
+            extractFilterValues()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func extractFilterValues() {
+        contentModes = Array(Set(assets.compactMap { $0.contentMode })).sorted()
+        characters = Array(Set(assets.compactMap { $0.characterName })).sorted()
+    }
+
+    // MARK: - Actions
+
+    private func updateAsset(_ asset: DAMAsset) async {
+        do {
+            try await store.insertAsset(asset)
+            await loadAssets()
+        } catch {
+            errorMessage = "Failed to update: \(error.localizedDescription)"
+        }
+    }
+
+    private func toggleFavorite(_ asset: DAMAsset) async {
+        let updated = DAMAsset(
+            id: asset.id,
+            kind: asset.kind,
+            filename: asset.filename,
+            absolutePath: asset.absolutePath,
+            fileSize: asset.fileSize,
+            sha256: asset.sha256,
+            width: asset.width,
+            height: asset.height,
+            createdAt: asset.createdAt,
+            modifiedAt: Date(),
+            ingestedAt: asset.ingestedAt,
+            orphaned: asset.orphaned,
+            prompt: asset.prompt,
+            negativePrompt: asset.negativePrompt,
+            seed: asset.seed,
+            steps: asset.steps,
+            guidance: asset.guidance,
+            modelFamily: asset.modelFamily,
+            rating: asset.rating,
+            favorite: !asset.favorite,
+            contentMode: asset.contentMode,
+            characterName: asset.characterName
+        )
+        await updateAsset(updated)
+    }
+
+    private func revealInFinder(_ asset: DAMAsset) {
+        NSWorkspace.shared.selectFile(
+            asset.absolutePath,
+            inFileViewerRootedAtPath: ""
+        )
+    }
+}
+
+// MARK: - Gallery Cell
+
+struct GalleryCellView: View {
+    let asset: DAMAsset
+    let thumbnailPath: String
+
+    @State private var thumbnail: NSImage?
+
+    var body: some View {
+        VStack(spacing: 4) {
+            // Thumbnail
+            ZStack {
+                Color(nsColor: .controlBackgroundColor)
+
+                if let thumb = thumbnail {
+                    Image(nsImage: thumb)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Image(systemName: "photo")
+                        .font(.title)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(height: 160)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            // Prompt preview
+            if let prompt = asset.prompt {
+                Text(prompt)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Rating + favorite
+            HStack(spacing: 4) {
+                if asset.favorite {
+                    Image(systemName: "heart.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                }
+
+                if asset.rating > 0 {
+                    HStack(spacing: 1) {
+                        ForEach(1...5, id: \.self) { star in
+                            Image(systemName: star <= asset.rating ? "star.fill" : "star")
+                                .font(.system(size: 8))
+                                .foregroundStyle(star <= asset.rating ? .yellow : .gray.opacity(0.3))
+                        }
+                    }
+                }
+
+                Spacer()
+
+                if let mode = asset.contentMode {
+                    Text(mode)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                }
+            }
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .task {
+            await loadThumbnail()
+        }
+    }
+
+    private func loadThumbnail() async {
+        let path = thumbnailPath
+        // Also try loading the full image as fallback if no thumbnail.
+        let fullPath = asset.absolutePath
+        let image = await Task.detached {
+            NSImage(contentsOfFile: path) ?? NSImage(contentsOfFile: fullPath)
+        }.value
+        await MainActor.run {
+            thumbnail = image
+        }
     }
 }

--- a/Sources/ComfyBoxDesktop/Views/GenerationView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GenerationView.swift
@@ -2,7 +2,8 @@
 //
 // Provides prompt entry, parameter controls, generation button,
 // and image preview. Communicates with the WarmServer through
-// EngineService.
+// EngineService. On successful generation, calls onGenerated
+// to trigger DAM ingestion.
 
 import SwiftUI
 
@@ -23,6 +24,7 @@ struct ResolutionPreset: Identifiable, Hashable {
 
 struct GenerationView: View {
     @Bindable var engine: EngineService
+    var onGenerated: ((String, GenerationRequest) -> Void)?
 
     // Generation parameters
     @State private var prompt: String = ""
@@ -299,6 +301,8 @@ struct GenerationView: View {
                         displayedImage = image
                     }
                 }
+                // Notify app to ingest the generated file into DAM.
+                onGenerated?(outputPath, request)
             } catch {
                 // Error is already stored in engine.lastError
             }


### PR DESCRIPTION
Rebase of #168 after squash-merge conflict.

## Summary

- **AssetIngestor**: Polls `~/.comfybox/output/` for new .png/.jpg files, reads JSON sidecar metadata, generates 256px JPEG thumbnails to `~/.comfybox/thumbnails/`, and inserts DAMAssets into DAMStore
- **GalleryView**: LazyVGrid thumbnail grid with sort (date/rating/favorites first), filter (favorite toggle, content mode, character name), FTS5 prompt search, context menu (Reveal in Finder, toggle favorite)
- **AssetDetailView**: Full-size image preview with all generation metadata, editable star rating (0-5) and favorite toggle, save back to DAMStore
- **Generation bridge**: GenerationView now calls `onGenerated` callback which auto-ingests output into DAMStore, so new images appear in the gallery immediately
- **DAMStore**: Added `allAssetPaths()` query for ingestor dedup seeding

## Test plan

- [ ] Build succeeds with zero errors and zero warnings
- [ ] App launches, sidebar shows Generate and Gallery tabs
- [ ] Gallery tab shows empty state when no assets exist
- [ ] Place a .png in ~/.comfybox/output/ with a .json sidecar -- verify it appears in gallery within 5 seconds
- [ ] Click a gallery cell -- detail sheet opens with full-size image and metadata
- [ ] Change rating and favorite in detail view -- verify changes persist after closing
- [ ] Search bar filters by prompt text
- [ ] Favorite filter toggle works
- [ ] Sort by date, rating, favorites first all function correctly
- [ ] Generate an image -- verify it auto-appears in gallery without manual refresh
- [ ] Thumbnail cache persists at ~/.comfybox/thumbnails/