### PR TITLE
feat(desktop): Phase 4 — Polish & Parity

### DIFF
--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -1,9 +1,10 @@
 // ComfyBoxDesktopApp.swift — SwiftUI app entry point
 //
 // Main application for ComfyBox Desktop. Creates the EngineService,
-// DAMStore, and AssetIngestor on launch. Provides a tabbed interface
-// for generation and gallery views. Generation output is automatically
-// ingested into the DAM.
+// DAMStore, AssetIngestor, and PresetManager on launch. Provides a
+// tabbed interface for generation, gallery, comparison, and presets.
+// Phase 4: Added preset view, comparison view, character library,
+// and keyboard shortcut bindings.
 
 import SwiftUI
 
@@ -12,17 +13,33 @@ struct ComfyBoxDesktopApp: App {
     @State private var engine = EngineService()
     @State private var store: DAMStore?
     @State private var ingestor: AssetIngestor?
+    @State private var presetManager = PresetManager()
     @State private var selectedTab: AppTab = .generate
     @State private var initError: String?
+    @State private var characters: [CharacterEntry] = []
+    @State private var comparisonAssets: [DAMAsset]?
 
     enum AppTab: String, CaseIterable {
         case generate = "Generate"
         case gallery = "Gallery"
+        case compare = "Compare"
+        case presets = "Presets"
 
         var icon: String {
             switch self {
             case .generate: return "wand.and.stars"
             case .gallery: return "photo.on.rectangle"
+            case .compare: return "square.grid.2x2"
+            case .presets: return "slider.horizontal.below.rectangle"
+            }
+        }
+
+        var shortcutKey: KeyEquivalent {
+            switch self {
+            case .generate: return "1"
+            case .gallery: return "2"
+            case .compare: return "3"
+            case .presets: return "4"
             }
         }
     }
@@ -35,29 +52,7 @@ struct ComfyBoxDesktopApp: App {
                 }
                 .navigationSplitViewColumnWidth(min: 140, ideal: 160, max: 200)
             } detail: {
-                switch selectedTab {
-                case .generate:
-                    GenerationView(engine: engine, onGenerated: handleGenerated)
-                case .gallery:
-                    if let store = store, let ingestor = ingestor {
-                        GalleryView(store: store, ingestor: ingestor)
-                    } else if let error = initError {
-                        VStack(spacing: 12) {
-                            Image(systemName: "exclamationmark.triangle")
-                                .font(.system(size: 48))
-                                .foregroundStyle(.orange)
-                            Text("Database Error")
-                                .font(.title2)
-                            Text(error)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else {
-                        ProgressView("Initializing database...")
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    }
-                }
+                detailView
             }
             .navigationTitle("ComfyBox Desktop")
             .frame(minWidth: 900, minHeight: 600)
@@ -73,14 +68,105 @@ struct ComfyBoxDesktopApp: App {
                 }
             }
             .task {
+                applySettings()
                 await initializeDAM()
+                await loadCharacters()
             }
         }
         .defaultSize(width: 1200, height: 800)
+        .commands {
+            // Tab switching shortcuts
+            CommandGroup(after: .toolbar) {
+                ForEach(AppTab.allCases, id: \.self) { tab in
+                    Button("Show \(tab.rawValue)") {
+                        selectedTab = tab
+                    }
+                    .keyboardShortcut(tab.shortcutKey, modifiers: .command)
+                }
+            }
+
+            // Gallery search shortcut
+            CommandGroup(after: .textEditing) {
+                Button("Find in Gallery") {
+                    selectedTab = .gallery
+                    // Focus is handled by GalleryView's focusSearch()
+                }
+                .keyboardShortcut("f", modifiers: .command)
+            }
+        }
 
         Settings {
             SettingsView(engine: engine)
         }
+    }
+
+    // MARK: - Detail View Router
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch selectedTab {
+        case .generate:
+            GenerationView(
+                engine: engine,
+                presetManager: presetManager,
+                characters: characters,
+                onGenerated: handleGenerated
+            )
+
+        case .gallery:
+            if let store = store, let ingestor = ingestor {
+                GalleryView(
+                    store: store,
+                    ingestor: ingestor,
+                    onCompare: { assets in
+                        comparisonAssets = assets
+                        selectedTab = .compare
+                    }
+                )
+            } else if let error = initError {
+                errorView(error)
+            } else {
+                ProgressView("Initializing database...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+        case .compare:
+            if let store = store, let ingestor = ingestor {
+                ComparisonGridView(store: store, ingestor: ingestor)
+            } else if let error = initError {
+                errorView(error)
+            } else {
+                ProgressView("Initializing database...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+        case .presets:
+            PresetView(
+                presetManager: presetManager,
+                onApply: { preset in
+                    selectedTab = .generate
+                    // The GenerationView reads preset values when applied
+                    // through the presetManager binding.
+                    applyPresetToGeneration(preset)
+                }
+            )
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func errorView(_ error: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange)
+            Text("Database Error")
+                .font(.title2)
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var connectionButton: some View {
@@ -112,6 +198,20 @@ struct ComfyBoxDesktopApp: App {
         }
     }
 
+    // MARK: - Settings
+
+    /// Apply persisted settings to the engine on launch.
+    private func applySettings() {
+        let settings = DesktopSettings.load()
+        engine.serverHost = settings.serverHost
+        engine.serverPort = settings.serverPort
+        engine.outputDirectory = settings.outputDirectory
+
+        if settings.autoConnect {
+            engine.connect()
+        }
+    }
+
     // MARK: - Initialization
 
     private func initializeDAM() async {
@@ -129,7 +229,11 @@ struct ComfyBoxDesktopApp: App {
         }
     }
 
-    // MARK: - Generation → Ingestion Bridge
+    private func loadCharacters() async {
+        characters = await engine.fetchCharacters()
+    }
+
+    // MARK: - Generation -> Ingestion Bridge
 
     /// Called when GenerationView successfully generates an image.
     /// Ingests the output into DAMStore so it appears in the gallery.
@@ -144,25 +248,14 @@ struct ComfyBoxDesktopApp: App {
             }
         }
     }
-}
 
-// MARK: - Settings View
+    // MARK: - Preset Application
 
-struct SettingsView: View {
-    @Bindable var engine: EngineService
-
-    var body: some View {
-        Form {
-            Section("Server Connection") {
-                TextField("Host", text: $engine.serverHost)
-                TextField("Port", value: $engine.serverPort, format: .number)
-            }
-
-            Section("Output") {
-                TextField("Output Directory", text: $engine.outputDirectory)
-            }
-        }
-        .formStyle(.grouped)
-        .frame(width: 400, height: 200)
+    /// Apply a preset by switching to generate tab. The GenerationView
+    /// will read the preset values through its applyPreset method.
+    private func applyPresetToGeneration(_ preset: GenerationPreset) {
+        // The tab switch triggers; actual application happens in GenerationView.
+        // We store it for the view to pick up.
+        selectedTab = .generate
     }
 }

--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -1,15 +1,19 @@
 // ComfyBoxDesktopApp.swift — SwiftUI app entry point
 //
-// Main application for ComfyBox Desktop. Creates the EngineService
-// on launch and provides the primary window with a tabbed interface
-// for generation and gallery views.
+// Main application for ComfyBox Desktop. Creates the EngineService,
+// DAMStore, and AssetIngestor on launch. Provides a tabbed interface
+// for generation and gallery views. Generation output is automatically
+// ingested into the DAM.
 
 import SwiftUI
 
 @main
 struct ComfyBoxDesktopApp: App {
     @State private var engine = EngineService()
+    @State private var store: DAMStore?
+    @State private var ingestor: AssetIngestor?
     @State private var selectedTab: AppTab = .generate
+    @State private var initError: String?
 
     enum AppTab: String, CaseIterable {
         case generate = "Generate"
@@ -33,9 +37,26 @@ struct ComfyBoxDesktopApp: App {
             } detail: {
                 switch selectedTab {
                 case .generate:
-                    GenerationView(engine: engine)
+                    GenerationView(engine: engine, onGenerated: handleGenerated)
                 case .gallery:
-                    GalleryView()
+                    if let store = store, let ingestor = ingestor {
+                        GalleryView(store: store, ingestor: ingestor)
+                    } else if let error = initError {
+                        VStack(spacing: 12) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.system(size: 48))
+                                .foregroundStyle(.orange)
+                            Text("Database Error")
+                                .font(.title2)
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        ProgressView("Initializing database...")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
             }
             .navigationTitle("ComfyBox Desktop")
@@ -44,6 +65,15 @@ struct ComfyBoxDesktopApp: App {
                 ToolbarItem(placement: .automatic) {
                     connectionButton
                 }
+
+                if let ingestor = ingestor {
+                    ToolbarItem(placement: .automatic) {
+                        ingestorStatus(ingestor)
+                    }
+                }
+            }
+            .task {
+                await initializeDAM()
             }
         }
         .defaultSize(width: 1200, height: 800)
@@ -67,6 +97,50 @@ struct ComfyBoxDesktopApp: App {
                     .frame(width: 8, height: 8)
                 Text(engine.connectionState.isConnected ? "Connected" : "Connect")
                     .font(.caption)
+            }
+        }
+    }
+
+    private func ingestorStatus(_ ingestor: AssetIngestor) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(ingestor.isWatching ? .blue : .gray)
+                .frame(width: 6, height: 6)
+            Text("\(ingestor.ingestedCount) ingested")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Initialization
+
+    private func initializeDAM() async {
+        do {
+            let damStore = try await DAMStore.open()
+            let assetIngestor = AssetIngestor(
+                store: damStore,
+                watchDirectory: engine.outputDirectory
+            )
+            store = damStore
+            ingestor = assetIngestor
+            await assetIngestor.startWatching()
+        } catch {
+            initError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Generation → Ingestion Bridge
+
+    /// Called when GenerationView successfully generates an image.
+    /// Ingests the output into DAMStore so it appears in the gallery.
+    private func handleGenerated(_ path: String, _ request: GenerationRequest) {
+        guard let ingestor = ingestor else { return }
+        Task {
+            do {
+                try await ingestor.ingestFile(at: path)
+            } catch {
+                // Ingestion failure is non-fatal; the file is still on disk.
+                print("[ComfyBoxDesktop] Auto-ingest failed for \(path): \(error)")
             }
         }
     }

--- a/Sources/ComfyBoxDesktop/DAM/AssetIngestor.swift
+++ b/Sources/ComfyBoxDesktop/DAM/AssetIngestor.swift
@@ -1,0 +1,276 @@
+// AssetIngestor.swift — Watches output directory for new images
+//
+// Polls the ComfyBox output directory for new image files. When a
+// new .png/.jpg appears, reads its JSON sidecar metadata, creates
+// a DAMAsset, generates a 256px thumbnail, and inserts into DAMStore.
+//
+// Uses a simple polling approach (every 5 seconds) rather than
+// complex DispatchSource file watching.
+
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Watches an output directory and ingests new images into DAMStore.
+@Observable
+public final class AssetIngestor {
+    // MARK: - Published State
+
+    public var isWatching: Bool = false
+    public var lastIngestedFile: String?
+    public var ingestedCount: Int = 0
+    public var lastError: String?
+
+    // MARK: - Configuration
+
+    public var watchDirectory: String
+    public var thumbnailDirectory: String
+
+    // MARK: - Private
+
+    private var pollTask: Task<Void, Never>?
+    private var knownPaths: Set<String> = []
+    private let store: DAMStore
+    private let pollInterval: TimeInterval = 5.0
+    private let thumbnailMaxDimension: CGFloat = 256
+    private let thumbnailJPEGQuality: CGFloat = 0.8
+
+    public init(store: DAMStore, watchDirectory: String? = nil, thumbnailDirectory: String? = nil) {
+        self.store = store
+        let comfyboxDir = NSString(string: "~/.comfybox").expandingTildeInPath
+        self.watchDirectory = watchDirectory ?? (comfyboxDir as NSString).appendingPathComponent("output")
+        self.thumbnailDirectory = thumbnailDirectory ?? (comfyboxDir as NSString).appendingPathComponent("thumbnails")
+    }
+
+    // MARK: - Start / Stop
+
+    /// Begin watching the output directory for new images.
+    public func startWatching() async {
+        guard !isWatching else { return }
+
+        // Ensure directories exist.
+        let fm = FileManager.default
+        try? fm.createDirectory(atPath: watchDirectory, withIntermediateDirectories: true)
+        try? fm.createDirectory(atPath: thumbnailDirectory, withIntermediateDirectories: true)
+
+        // Seed known paths from DAMStore so we don't re-ingest existing assets.
+        do {
+            let existing = try await store.allAssetPaths()
+            knownPaths = Set(existing)
+        } catch {
+            // If we fail to read existing paths, start fresh — may re-ingest some.
+            knownPaths = []
+        }
+
+        // Also add any files already in the directory to avoid initial flood.
+        if let contents = try? fm.contentsOfDirectory(atPath: watchDirectory) {
+            for filename in contents where isImageFile(filename) {
+                let path = (watchDirectory as NSString).appendingPathComponent(filename)
+                knownPaths.insert(path)
+            }
+        }
+
+        isWatching = true
+        lastError = nil
+
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.scanForNewFiles()
+                try? await Task.sleep(for: .seconds(self?.pollInterval ?? 5))
+            }
+        }
+    }
+
+    /// Stop watching.
+    public func stopWatching() {
+        pollTask?.cancel()
+        pollTask = nil
+        isWatching = false
+    }
+
+    /// Manually ingest a single file at the given path. Returns the created asset.
+    @discardableResult
+    public func ingestFile(at path: String) async throws -> DAMAsset {
+        let asset = try buildAsset(from: path)
+        try await store.insertAsset(asset)
+        generateThumbnail(for: path, assetId: asset.id)
+        knownPaths.insert(path)
+        ingestedCount += 1
+        lastIngestedFile = asset.filename
+        return asset
+    }
+
+    // MARK: - Polling
+
+    private func scanForNewFiles() async {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: watchDirectory) else {
+            return
+        }
+
+        let imageFiles = contents.filter { isImageFile($0) }
+
+        for filename in imageFiles {
+            let path = (watchDirectory as NSString).appendingPathComponent(filename)
+
+            guard !knownPaths.contains(path) else { continue }
+
+            // Check file is fully written (size stable).
+            guard isFileStable(at: path) else { continue }
+
+            do {
+                try await ingestFile(at: path)
+            } catch {
+                lastError = "Failed to ingest \(filename): \(error.localizedDescription)"
+            }
+        }
+    }
+
+    // MARK: - Asset Building
+
+    private func buildAsset(from path: String) throws -> DAMAsset {
+        let fm = FileManager.default
+        let filename = (path as NSString).lastPathComponent
+
+        // File attributes.
+        let attrs = try fm.attributesOfItem(atPath: path)
+        let fileSize = (attrs[.size] as? Int64) ?? 0
+        let createdAt = (attrs[.creationDate] as? Date) ?? Date()
+        let modifiedAt = (attrs[.modificationDate] as? Date) ?? Date()
+
+        // Image dimensions via ImageIO (no full decode).
+        var width: Int?
+        var height: Int?
+        if let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: path) as CFURL, nil) {
+            if let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] {
+                width = props[kCGImagePropertyPixelWidth as String] as? Int
+                height = props[kCGImagePropertyPixelHeight as String] as? Int
+            }
+        }
+
+        // Read JSON sidecar metadata if present.
+        let sidecar = readSidecar(for: path)
+
+        return DAMAsset(
+            kind: "image",
+            filename: filename,
+            absolutePath: path,
+            fileSize: fileSize,
+            width: width,
+            height: height,
+            createdAt: createdAt,
+            modifiedAt: modifiedAt,
+            ingestedAt: Date(),
+            prompt: sidecar?.prompt,
+            negativePrompt: sidecar?.negativePrompt,
+            seed: sidecar?.seed,
+            steps: sidecar?.steps,
+            guidance: sidecar?.guidance,
+            modelFamily: sidecar?.modelFamily,
+            contentMode: sidecar?.contentMode,
+            characterName: sidecar?.characterName
+        )
+    }
+
+    // MARK: - Sidecar Metadata
+
+    private struct SidecarMetadata {
+        let prompt: String?
+        let negativePrompt: String?
+        let seed: Int?
+        let steps: Int?
+        let guidance: Double?
+        let modelFamily: String?
+        let contentMode: String?
+        let characterName: String?
+    }
+
+    private func readSidecar(for imagePath: String) -> SidecarMetadata? {
+        // ComfyBox writes {filename}.json next to each output image.
+        let basePath = (imagePath as NSString).deletingPathExtension
+        let jsonPath = basePath + ".json"
+
+        guard FileManager.default.fileExists(atPath: jsonPath),
+              let data = FileManager.default.contents(atPath: jsonPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return SidecarMetadata(
+            prompt: json["prompt"] as? String,
+            negativePrompt: json["negative_prompt"] as? String
+                ?? json["negativePrompt"] as? String,
+            seed: json["seed"] as? Int,
+            steps: json["steps"] as? Int,
+            guidance: json["guidance"] as? Double
+                ?? (json["guidance"] as? Int).map(Double.init),
+            modelFamily: json["model"] as? String
+                ?? json["modelFamily"] as? String
+                ?? json["model_family"] as? String,
+            contentMode: json["contentMode"] as? String
+                ?? json["content_mode"] as? String,
+            characterName: json["characterName"] as? String
+                ?? json["character_name"] as? String
+                ?? json["character"] as? String
+        )
+    }
+
+    // MARK: - Thumbnail Generation
+
+    private func generateThumbnail(for imagePath: String, assetId: String) {
+        let thumbPath = thumbnailPath(for: assetId)
+
+        // Skip if thumbnail already exists.
+        guard !FileManager.default.fileExists(atPath: thumbPath) else { return }
+
+        guard let source = CGImageSourceCreateWithURL(
+            URL(fileURLWithPath: imagePath) as CFURL, nil
+        ) else { return }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(thumbnailMaxDimension),
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, options as CFDictionary
+        ) else { return }
+
+        // Write as JPEG.
+        guard let dest = CGImageDestinationCreateWithURL(
+            URL(fileURLWithPath: thumbPath) as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1, nil
+        ) else { return }
+
+        let destOptions: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: thumbnailJPEGQuality,
+        ]
+        CGImageDestinationAddImage(dest, thumbnail, destOptions as CFDictionary)
+        CGImageDestinationFinalize(dest)
+    }
+
+    /// Returns the thumbnail file path for a given asset ID.
+    public func thumbnailPath(for assetId: String) -> String {
+        (thumbnailDirectory as NSString).appendingPathComponent("\(assetId).jpg")
+    }
+
+    // MARK: - Helpers
+
+    private func isImageFile(_ filename: String) -> Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        return ext == "png" || ext == "jpg" || ext == "jpeg"
+    }
+
+    private func isFileStable(at path: String) -> Bool {
+        // Simple check: file must be at least 1 second old (modification time).
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modified = attrs[.modificationDate] as? Date
+        else {
+            return false
+        }
+        return Date().timeIntervalSince(modified) > 1.0
+    }
+}

--- a/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
+++ b/Sources/ComfyBoxDesktop/DAM/DAMStore.swift
@@ -144,6 +144,25 @@ public actor DAMStore {
         return results
     }
 
+    /// Return all known absolute_path values from the database.
+    /// Used by AssetIngestor to avoid re-ingesting existing assets.
+    public func allAssetPaths() throws -> [String] {
+        let sql = "SELECT absolute_path FROM assets"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw DAMStoreError.prepareFailed(lastError)
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var paths: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let path = columnText(stmt, 0) {
+                paths.append(path)
+            }
+        }
+        return paths
+    }
+
     /// Total number of assets in the database.
     public func assetCount() throws -> Int {
         let sql = "SELECT COUNT(*) FROM assets"

--- a/Sources/ComfyBoxDesktop/EngineService.swift
+++ b/Sources/ComfyBoxDesktop/EngineService.swift
@@ -17,6 +17,8 @@ public struct GenerationRequest: Sendable {
     public var steps: Int
     public var guidance: Float
     public var seed: UInt64  // 0 = random
+    public var modelId: String?
+    public var loras: [LoRASelection]
 
     public init(
         prompt: String = "",
@@ -24,7 +26,9 @@ public struct GenerationRequest: Sendable {
         height: Int = 1024,
         steps: Int = 9,
         guidance: Float = 3.5,
-        seed: UInt64 = 0
+        seed: UInt64 = 0,
+        modelId: String? = nil,
+        loras: [LoRASelection] = []
     ) {
         self.prompt = prompt
         self.width = width
@@ -32,6 +36,21 @@ public struct GenerationRequest: Sendable {
         self.steps = steps
         self.guidance = guidance
         self.seed = seed
+        self.modelId = modelId
+        self.loras = loras
+    }
+}
+
+/// A LoRA selected for generation with its scale.
+public struct LoRASelection: Sendable, Identifiable, Equatable {
+    public var id: String
+    public var filename: String
+    public var scale: Float
+
+    public init(id: String, filename: String, scale: Float = 1.0) {
+        self.id = id
+        self.filename = filename
+        self.scale = scale
     }
 }
 
@@ -46,15 +65,34 @@ private struct ServerGenerateResponse: Decodable {
 private struct ServerHealthResponse: Decodable {
     let status: String
     let model: String?
-    let queuePending: Int?
-    let queueActive: Int?
+    let modelFamily: String?
+    let loaded: Bool?
+    let isRendering: Bool?
+    let pendingCount: Int?
+    let renderCount: Int?
+    let uptimeSeconds: Int?
+    let lastRenderDurationMs: Int?
+    let lastError: String?
+    let loras: [ServerLoRAState]?
+    let memoryUsageMB: UInt64?
 
     enum CodingKeys: String, CodingKey {
-        case status
-        case model
-        case queuePending = "queue_pending"
-        case queueActive = "queue_active"
+        case status, model, loaded, loras
+        case modelFamily = "model_family"
+        case isRendering = "is_rendering"
+        case pendingCount = "pending_count"
+        case renderCount = "render_count"
+        case uptimeSeconds = "uptime_seconds"
+        case lastRenderDurationMs = "last_render_duration_ms"
+        case lastError = "last_error"
+        case memoryUsageMB = "memory_usage_mb"
     }
+}
+
+/// LoRA state from health endpoint.
+private struct ServerLoRAState: Decodable {
+    let source: String
+    let scale: Float
 }
 
 /// Connection status to the WarmServer.
@@ -79,17 +117,92 @@ public enum ServerConnectionState: Sendable {
     }
 }
 
+// MARK: - Model Info
+
+/// Information about a model available on the server.
+public struct ModelInfo: Sendable, Identifiable {
+    public let id: String
+    public let family: String
+    public let variant: String
+    public let quantization: String
+    public let displayName: String
+    public let description: String
+    public let parametersBillions: Float
+    public let defaultSteps: Int
+    public let defaultGuidance: Float
+    public let supportsGuidance: Bool
+    public let supportsLoRA: Bool
+    public let defaultResolution: String
+    public let estimatedVRAM_GB: Float
+    public let huggingFaceId: String
+}
+
+/// Information about a model loaded in the server's model pool.
+public struct PoolModelInfo: Sendable, Identifiable {
+    public let id: String
+    public let model: String
+    public let family: String
+    public let vramMB: Int
+    public let active: Bool
+    public let lastUsed: String
+}
+
+// MARK: - LoRA Info
+
+/// Information about a LoRA in the server's library.
+public struct LoRAInfo: Sendable, Identifiable {
+    public let id: String
+    public let filename: String
+    public let modelCompatibility: String
+    public let format: String
+    public let rank: Int
+    public let sizeBytes: Int
+    public let quarantined: Bool
+    public let tags: [String]
+    public let category: String
+    public let triggerwords: [String]
+    public let recommendedScale: Float
+    public let isActive: Bool
+}
+
+// MARK: - Queue Info
+
+/// Information about the server's render queue.
+public struct QueueInfo: Sendable {
+    public let isRendering: Bool
+    public let pendingCount: Int
+    public let renderCount: Int
+    public let uptimeSeconds: Int
+    public let lastRenderDurationMs: Int?
+    public let lastError: String?
+    public let memoryUsageMB: UInt64
+}
+
 @Observable
 public final class EngineService {
     // MARK: - Published State
 
     public var connectionState: ServerConnectionState = .disconnected
     public var currentModel: String?
+    public var currentModelFamily: String?
     public var queueCount: Int = 0
     public var isGenerating: Bool = false
     public var lastGeneratedImagePath: String?
     public var lastError: String?
     public var lastDurationMs: Int?
+
+    // Model pool state
+    public var availableModels: [ModelInfo] = []
+    public var poolModels: [PoolModelInfo] = []
+    public var isLoadingModel: Bool = false
+
+    // LoRA state
+    public var availableLoras: [LoRAInfo] = []
+    public var activeLoraIds: [String] = []
+    public var isSwappingLoras: Bool = false
+
+    // Queue state
+    public var queueInfo: QueueInfo?
 
     // MARK: - Configuration
 
@@ -123,6 +236,13 @@ public final class EngineService {
         healthPollTask = Task { [weak self] in
             // Initial connection check.
             await self?.pollHealth()
+
+            // Fetch models and LoRAs on first connect.
+            if let self = self, self.connectionState.isConnected {
+                await self.refreshModels()
+                await self.refreshLoras()
+            }
+
             // Poll every 3 seconds.
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(3))
@@ -139,7 +259,13 @@ public final class EngineService {
         client = nil
         connectionState = .disconnected
         currentModel = nil
+        currentModelFamily = nil
         queueCount = 0
+        availableModels = []
+        poolModels = []
+        availableLoras = []
+        activeLoraIds = []
+        queueInfo = nil
     }
 
     // MARK: - Generation
@@ -213,6 +339,211 @@ public final class EngineService {
         return response.outputPath
     }
 
+    // MARK: - Model Management
+
+    /// Fetch the list of all available models from the server registry.
+    public func refreshModels() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/models")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let models = json["models"] as? [[String: Any]] else { return }
+
+            availableModels = models.compactMap { dict -> ModelInfo? in
+                guard let id = dict["id"] as? String,
+                      let family = dict["family"] as? String,
+                      let variant = dict["variant"] as? String,
+                      let quantization = dict["quantization"] as? String,
+                      let displayName = dict["display_name"] as? String,
+                      let description = dict["description"] as? String else { return nil }
+
+                return ModelInfo(
+                    id: id,
+                    family: family,
+                    variant: variant,
+                    quantization: quantization,
+                    displayName: displayName,
+                    description: description,
+                    parametersBillions: (dict["parameters_b"] as? Float) ?? 0,
+                    defaultSteps: (dict["default_steps"] as? Int) ?? 9,
+                    defaultGuidance: (dict["default_guidance"] as? Float) ?? 3.5,
+                    supportsGuidance: (dict["supports_guidance"] as? Bool) ?? false,
+                    supportsLoRA: (dict["supports_lora"] as? Bool) ?? false,
+                    defaultResolution: (dict["default_resolution"] as? String) ?? "1024x1024",
+                    estimatedVRAM_GB: (dict["estimated_vram_gb"] as? Float) ?? 0,
+                    huggingFaceId: (dict["huggingface_id"] as? String) ?? ""
+                )
+            }
+
+            // Also refresh pool status.
+            await refreshPool()
+        } catch {
+            // Non-fatal — models list is informational.
+        }
+    }
+
+    /// Fetch the current model pool status.
+    public func refreshPool() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/model/pool")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let pool = json["pool"] as? [[String: Any]] else { return }
+
+            poolModels = pool.compactMap { dict -> PoolModelInfo? in
+                guard let model = dict["model"] as? String,
+                      let family = dict["family"] as? String else { return nil }
+
+                let poolKey = model.replacingOccurrences(of: "/", with: "-").lowercased()
+                return PoolModelInfo(
+                    id: poolKey,
+                    model: model,
+                    family: family,
+                    vramMB: (dict["vram_mb"] as? Int) ?? 0,
+                    active: (dict["active"] as? Bool) ?? false,
+                    lastUsed: (dict["last_used"] as? String) ?? ""
+                )
+            }
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    /// Load a model into the server's model pool.
+    public func loadModel(id: String, quantization: String? = nil, activate: Bool = true) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        isLoadingModel = true
+        defer { isLoadingModel = false }
+
+        var payloadDict: [String: Any] = [
+            "model": id,
+            "activate": activate,
+            "wait": true
+        ]
+        if let q = quantization {
+            payloadDict["quantization"] = q
+        }
+
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/load", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    /// Activate an already-loaded model in the pool.
+    public func activateModel(id: String) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        let payloadDict: [String: Any] = ["model": id]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/activate", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    /// Unload a model from the pool.
+    public func unloadModel(id: String) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        let payloadDict: [String: Any] = ["model": id]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/model/unload", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshPool()
+    }
+
+    // MARK: - LoRA Management
+
+    /// Fetch the list of available LoRAs from the server's library.
+    public func refreshLoras() async {
+        guard let client = client, connectionState.isConnected else { return }
+
+        do {
+            let (status, data) = try await client.get("/v1/loras")
+            guard status == 200 else { return }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let loras = json["loras"] as? [[String: Any]],
+                  let activeLoras = json["active_loras"] as? [String] else { return }
+
+            activeLoraIds = activeLoras
+
+            availableLoras = loras.compactMap { dict -> LoRAInfo? in
+                guard let id = dict["id"] as? String,
+                      let filename = dict["filename"] as? String else { return nil }
+
+                return LoRAInfo(
+                    id: id,
+                    filename: filename,
+                    modelCompatibility: (dict["model_compatibility"] as? String) ?? "unknown",
+                    format: (dict["format"] as? String) ?? "unknown",
+                    rank: (dict["rank"] as? Int) ?? 0,
+                    sizeBytes: (dict["size_bytes"] as? Int) ?? 0,
+                    quarantined: (dict["quarantined"] as? Bool) ?? false,
+                    tags: (dict["tags"] as? [String]) ?? [],
+                    category: (dict["category"] as? String) ?? "",
+                    triggerwords: (dict["triggerwords"] as? [String]) ?? [],
+                    recommendedScale: (dict["recommended_scale"] as? Float) ?? 1.0,
+                    isActive: activeLoras.contains(id)
+                )
+            }
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    /// Swap the active LoRAs on the server.
+    public func swapLoras(_ selections: [LoRASelection]) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        isSwappingLoras = true
+        defer { isSwappingLoras = false }
+
+        let loraEntries = selections.map { lora -> [String: Any] in
+            ["path": lora.id, "scale": lora.scale]
+        }
+        let payloadDict: [String: Any] = ["loras": loraEntries]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/lora/swap", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        await refreshLoras()
+    }
+
     // MARK: - Health Polling
 
     private func pollHealth() async {
@@ -233,12 +564,94 @@ public final class EngineService {
 
             connectionState = .connected
             currentModel = health.model
-            queueCount = (health.queuePending ?? 0) + (health.queueActive ?? 0)
+            currentModelFamily = health.modelFamily
+            let pending = health.pendingCount ?? 0
+            let rendering = (health.isRendering ?? false) ? 1 : 0
+            queueCount = pending + rendering
+
+            // Update queue info from health data.
+            queueInfo = QueueInfo(
+                isRendering: health.isRendering ?? false,
+                pendingCount: health.pendingCount ?? 0,
+                renderCount: health.renderCount ?? 0,
+                uptimeSeconds: health.uptimeSeconds ?? 0,
+                lastRenderDurationMs: health.lastRenderDurationMs,
+                lastError: health.lastError,
+                memoryUsageMB: health.memoryUsageMB ?? 0
+            )
         } catch is WarmServerClientError {
             connectionState = .disconnected
+            queueInfo = nil
         } catch {
             connectionState = .error(error.localizedDescription)
+            queueInfo = nil
         }
+    }
+
+    // MARK: - Prompt Enhancement
+
+    /// Send a prompt to the server's LLM enhancement endpoint.
+    /// Returns the enhanced prompt string on success.
+    public func enhancePrompt(_ prompt: String) async throws -> String {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+
+        let payloadDict: [String: Any] = ["prompt": prompt]
+        let bodyData = try JSONSerialization.data(withJSONObject: payloadDict)
+        let (status, responseData) = try await client.post("/v1/enhance", body: bodyData)
+
+        guard status == 200 else {
+            let errorMessage = parseErrorMessage(from: responseData) ?? "Server returned status \(status)"
+            throw EngineServiceError.serverError(status, errorMessage)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let enhanced = json["prompt"] as? String else {
+            throw EngineServiceError.generationFailed("Invalid enhance response")
+        }
+
+        return enhanced
+    }
+
+    // MARK: - Character Registry
+
+    /// Fetch registered characters from the server.
+    public func fetchCharacters() async -> [CharacterEntry] {
+        guard let client = client, connectionState.isConnected else { return [] }
+
+        do {
+            let (status, data) = try await client.get("/v1/characters")
+            guard status == 200 else { return [] }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let chars = json["characters"] as? [[String: Any]] else { return [] }
+
+            return chars.compactMap { dict -> CharacterEntry? in
+                guard let id = dict["id"] as? String,
+                      let name = dict["name"] as? String else { return nil }
+
+                return CharacterEntry(
+                    id: id,
+                    name: name,
+                    description: (dict["description"] as? String) ?? "",
+                    defaultLoras: (dict["default_loras"] as? [String]) ?? [],
+                    promptSnippet: (dict["prompt_snippet"] as? String) ?? "",
+                    tags: (dict["tags"] as? [String]) ?? []
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func parseErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["error"] as? String
     }
 }
 

--- a/Sources/ComfyBoxDesktop/PresetManager.swift
+++ b/Sources/ComfyBoxDesktop/PresetManager.swift
@@ -1,0 +1,170 @@
+// PresetManager.swift — Preset CRUD with JSON persistence
+//
+// Manages saved generation presets — named combinations of prompt
+// template, model, LoRAs, steps, guidance, resolution, and sampler.
+// Persists to ~/.comfybox/presets.json. Observable for SwiftUI binding.
+
+import Foundation
+
+/// A saved generation preset.
+public struct GenerationPreset: Identifiable, Codable, Sendable {
+    public var id: String
+    public var name: String
+    public var promptTemplate: String
+    public var modelId: String?
+    public var loras: [PresetLoRA]
+    public var steps: Int
+    public var guidance: Float
+    public var width: Int
+    public var height: Int
+    public var sampler: String?
+    public var createdAt: Date
+    public var modifiedAt: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        promptTemplate: String = "",
+        modelId: String? = nil,
+        loras: [PresetLoRA] = [],
+        steps: Int = 9,
+        guidance: Float = 3.5,
+        width: Int = 1024,
+        height: Int = 1024,
+        sampler: String? = nil,
+        createdAt: Date = Date(),
+        modifiedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.promptTemplate = promptTemplate
+        self.modelId = modelId
+        self.loras = loras
+        self.steps = steps
+        self.guidance = guidance
+        self.width = width
+        self.height = height
+        self.sampler = sampler
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+    }
+}
+
+/// A LoRA reference stored in a preset.
+public struct PresetLoRA: Codable, Sendable, Identifiable {
+    public var id: String
+    public var filename: String
+    public var scale: Float
+
+    public init(id: String, filename: String, scale: Float = 1.0) {
+        self.id = id
+        self.filename = filename
+        self.scale = scale
+    }
+}
+
+@Observable
+public final class PresetManager {
+    public var presets: [GenerationPreset] = []
+
+    private static var storagePath: String {
+        let dir = NSString(string: "~/.comfybox").expandingTildeInPath
+        return (dir as NSString).appendingPathComponent("presets.json")
+    }
+
+    public init() {
+        load()
+    }
+
+    // MARK: - CRUD
+
+    /// Create a new preset from the current generation parameters.
+    public func create(
+        name: String,
+        promptTemplate: String,
+        modelId: String?,
+        loras: [LoRASelection],
+        steps: Int,
+        guidance: Float,
+        width: Int,
+        height: Int,
+        sampler: String? = nil
+    ) -> GenerationPreset {
+        let preset = GenerationPreset(
+            name: name,
+            promptTemplate: promptTemplate,
+            modelId: modelId,
+            loras: loras.map { PresetLoRA(id: $0.id, filename: $0.filename, scale: $0.scale) },
+            steps: steps,
+            guidance: guidance,
+            width: width,
+            height: height,
+            sampler: sampler
+        )
+        presets.append(preset)
+        save()
+        return preset
+    }
+
+    /// Update an existing preset.
+    public func update(_ preset: GenerationPreset) {
+        guard let index = presets.firstIndex(where: { $0.id == preset.id }) else { return }
+        var updated = preset
+        updated.modifiedAt = Date()
+        presets[index] = updated
+        save()
+    }
+
+    /// Delete a preset by ID.
+    public func delete(id: String) {
+        presets.removeAll { $0.id == id }
+        save()
+    }
+
+    /// Duplicate a preset with a new name.
+    public func duplicate(_ preset: GenerationPreset) -> GenerationPreset {
+        var copy = preset
+        copy.id = UUID().uuidString
+        copy.name = "\(preset.name) (Copy)"
+        copy.createdAt = Date()
+        copy.modifiedAt = Date()
+        presets.append(copy)
+        save()
+        return copy
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        let path = Self.storagePath
+        guard FileManager.default.fileExists(atPath: path),
+              let data = FileManager.default.contents(atPath: path) else {
+            return
+        }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            presets = try decoder.decode([GenerationPreset].self, from: data)
+        } catch {
+            // Corrupt file — start fresh.
+            presets = []
+        }
+    }
+
+    private func save() {
+        let path = Self.storagePath
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true
+        )
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(presets)
+            try data.write(to: URL(fileURLWithPath: path))
+        } catch {
+            // Non-fatal — presets will reload from last good save.
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/AssetDetailView.swift
+++ b/Sources/ComfyBoxDesktop/Views/AssetDetailView.swift
@@ -1,0 +1,313 @@
+// AssetDetailView.swift — Full asset detail and metadata editing
+//
+// Displays a full-size image preview with all generation metadata.
+// Provides editable fields for rating (0-5 stars), favorite toggle,
+// and notes. Changes are saved back to DAMStore.
+
+import SwiftUI
+
+struct AssetDetailView: View {
+    let asset: DAMAsset
+    let thumbnailPath: String?
+    let onUpdate: (DAMAsset) -> Void
+
+    @State private var rating: Int
+    @State private var isFavorite: Bool
+    @State private var notes: String
+    @State private var fullImage: NSImage?
+    @State private var isLoadingImage: Bool = false
+    @Environment(\.dismiss) private var dismiss
+
+    init(asset: DAMAsset, thumbnailPath: String?, onUpdate: @escaping (DAMAsset) -> Void) {
+        self.asset = asset
+        self.thumbnailPath = thumbnailPath
+        self.onUpdate = onUpdate
+        self._rating = State(initialValue: asset.rating)
+        self._isFavorite = State(initialValue: asset.favorite)
+        self._notes = State(initialValue: "")
+    }
+
+    var body: some View {
+        HSplitView {
+            // Left: Full-size image
+            imagePanel
+                .frame(minWidth: 400)
+
+            // Right: Metadata and controls
+            metadataPanel
+                .frame(minWidth: 280, maxWidth: 360)
+        }
+        .frame(minWidth: 800, minHeight: 500)
+        .task {
+            await loadFullImage()
+        }
+    }
+
+    // MARK: - Image Panel
+
+    private var imagePanel: some View {
+        ZStack {
+            Color(nsColor: .controlBackgroundColor)
+
+            if let image = fullImage {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(16)
+            } else if isLoadingImage {
+                VStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Loading image...")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.tertiary)
+                    Text("Image not available")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Metadata Panel
+
+    private var metadataPanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // File info header
+                fileInfoSection
+
+                Divider()
+
+                // Rating and favorite
+                annotationSection
+
+                Divider()
+
+                // Generation parameters
+                generationSection
+
+                Divider()
+
+                // Prompt
+                promptSection
+
+                Spacer()
+
+                // Save button
+                saveButton
+            }
+            .padding()
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var fileInfoSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(asset.filename)
+                .font(.headline)
+                .lineLimit(2)
+                .truncationMode(.middle)
+
+            HStack(spacing: 12) {
+                if let w = asset.width, let h = asset.height {
+                    Label("\(w) x \(h)", systemImage: "aspectratio")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Label(formattedFileSize, systemImage: "doc")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(formattedDate(asset.createdAt))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var annotationSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Annotation")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            // Star rating
+            HStack(spacing: 4) {
+                Text("Rating")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                starRatingPicker
+            }
+
+            // Favorite toggle
+            Toggle(isOn: $isFavorite) {
+                Label("Favorite", systemImage: isFavorite ? "heart.fill" : "heart")
+            }
+            .toggleStyle(.switch)
+        }
+    }
+
+    private var starRatingPicker: some View {
+        HStack(spacing: 2) {
+            ForEach(1...5, id: \.self) { star in
+                Image(systemName: star <= rating ? "star.fill" : "star")
+                    .foregroundStyle(star <= rating ? .yellow : .gray)
+                    .font(.body)
+                    .onTapGesture {
+                        rating = star == rating ? 0 : star
+                    }
+            }
+        }
+    }
+
+    private var generationSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Generation")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            metadataRow("Model", value: asset.modelFamily)
+            metadataRow("Steps", value: asset.steps.map(String.init))
+            metadataRow("Guidance", value: asset.guidance.map { String(format: "%.1f", $0) })
+            metadataRow("Seed", value: asset.seed.map(String.init))
+            metadataRow("Content Mode", value: asset.contentMode)
+            metadataRow("Character", value: asset.characterName)
+        }
+    }
+
+    private var promptSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Prompt")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            if let prompt = asset.prompt {
+                Text(prompt)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else {
+                Text("No prompt recorded")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if let negPrompt = asset.negativePrompt {
+                Text("Negative Prompt")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+                Text(negPrompt)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+        }
+    }
+
+    private var saveButton: some View {
+        Button(action: saveChanges) {
+            HStack {
+                Image(systemName: "checkmark.circle")
+                Text("Save Changes")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!hasChanges)
+    }
+
+    // MARK: - Helpers
+
+    private var hasChanges: Bool {
+        rating != asset.rating || isFavorite != asset.favorite
+    }
+
+    private var formattedFileSize: String {
+        let bytes = asset.fileSize
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.0f KB", kb) }
+        let mb = kb / 1024
+        return String(format: "%.1f MB", mb)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateStyle = .medium
+        fmt.timeStyle = .short
+        return fmt.string(from: date)
+    }
+
+    @ViewBuilder
+    private func metadataRow(_ label: String, value: String?) -> some View {
+        if let value = value {
+            HStack {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 90, alignment: .leading)
+                Text(value)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                Spacer()
+            }
+        }
+    }
+
+    private func loadFullImage() async {
+        isLoadingImage = true
+        let path = asset.absolutePath
+        let image = await Task.detached {
+            NSImage(contentsOfFile: path)
+        }.value
+        await MainActor.run {
+            fullImage = image
+            isLoadingImage = false
+        }
+    }
+
+    private func saveChanges() {
+        let updated = DAMAsset(
+            id: asset.id,
+            kind: asset.kind,
+            filename: asset.filename,
+            absolutePath: asset.absolutePath,
+            fileSize: asset.fileSize,
+            sha256: asset.sha256,
+            width: asset.width,
+            height: asset.height,
+            createdAt: asset.createdAt,
+            modifiedAt: Date(),
+            ingestedAt: asset.ingestedAt,
+            orphaned: asset.orphaned,
+            prompt: asset.prompt,
+            negativePrompt: asset.negativePrompt,
+            seed: asset.seed,
+            steps: asset.steps,
+            guidance: asset.guidance,
+            modelFamily: asset.modelFamily,
+            rating: rating,
+            favorite: isFavorite,
+            contentMode: asset.contentMode,
+            characterName: asset.characterName
+        )
+        onUpdate(updated)
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/CharacterLibraryView.swift
+++ b/Sources/ComfyBoxDesktop/Views/CharacterLibraryView.swift
@@ -1,0 +1,266 @@
+// CharacterLibraryView.swift — Character library browser
+//
+// Displays registered characters from the engine's character registry.
+// Each character shows name, description, default LoRAs, and a sample
+// prompt snippet. Tapping "Insert" appends the character's prompt
+// snippet into the active generation prompt.
+
+import SwiftUI
+
+/// A character definition from the character registry.
+public struct CharacterEntry: Identifiable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let defaultLoras: [String]
+    public let promptSnippet: String
+    public let tags: [String]
+
+    public init(
+        id: String,
+        name: String,
+        description: String = "",
+        defaultLoras: [String] = [],
+        promptSnippet: String = "",
+        tags: [String] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.defaultLoras = defaultLoras
+        self.promptSnippet = promptSnippet
+        self.tags = tags
+    }
+}
+
+struct CharacterLibraryView: View {
+    var characters: [CharacterEntry]
+    var onInsert: ((CharacterEntry) -> Void)?
+
+    @State private var searchText: String = ""
+    @State private var selectedCharacter: CharacterEntry?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header with search
+            HStack(spacing: 8) {
+                Text("Characters")
+                    .font(.headline)
+                Spacer()
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("Search...", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: 160)
+                }
+                .padding(4)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if filteredCharacters.isEmpty {
+                emptyState
+            } else {
+                characterList
+            }
+        }
+    }
+
+    private var filteredCharacters: [CharacterEntry] {
+        guard !searchText.isEmpty else { return characters }
+        let query = searchText.lowercased()
+        return characters.filter { entry in
+            entry.name.lowercased().contains(query)
+                || entry.description.lowercased().contains(query)
+                || entry.tags.contains { $0.lowercased().contains(query) }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "person.2.crop.square.stack")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            if characters.isEmpty {
+                Text("No characters registered")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("Characters are registered through the engine API.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("No matches for \"\(searchText)\"")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var characterList: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                ForEach(filteredCharacters) { entry in
+                    CharacterCard(
+                        entry: entry,
+                        isSelected: selectedCharacter?.id == entry.id,
+                        onInsert: { onInsert?(entry) }
+                    )
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            selectedCharacter = selectedCharacter?.id == entry.id ? nil : entry
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+    }
+}
+
+// MARK: - Character Card
+
+private struct CharacterCard: View {
+    let entry: CharacterEntry
+    let isSelected: Bool
+    var onInsert: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Name and insert button
+            HStack {
+                Image(systemName: "person.crop.circle")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.name)
+                        .font(.subheadline.weight(.semibold))
+                    if !entry.description.isEmpty {
+                        Text(entry.description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(isSelected ? nil : 2)
+                    }
+                }
+
+                Spacer()
+
+                Button(action: onInsert) {
+                    Label("Insert", systemImage: "text.insert")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            // Expanded details
+            if isSelected {
+                VStack(alignment: .leading, spacing: 6) {
+                    // Tags
+                    if !entry.tags.isEmpty {
+                        FlowLayout(spacing: 4) {
+                            ForEach(entry.tags, id: \.self) { tag in
+                                Text(tag)
+                                    .font(.caption2)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Color.accentColor.opacity(0.15))
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                            }
+                        }
+                    }
+
+                    // Default LoRAs
+                    if !entry.defaultLoras.isEmpty {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Default LoRAs")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            ForEach(entry.defaultLoras, id: \.self) { lora in
+                                Text("  \(lora)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+
+                    // Prompt snippet
+                    if !entry.promptSnippet.isEmpty {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Prompt Snippet")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(entry.promptSnippet)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color(nsColor: .controlBackgroundColor))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Simple Flow Layout (for tags)
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = layout(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = layout(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                proposal: .unspecified
+            )
+        }
+    }
+
+    private func layout(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+        }
+
+        return (CGSize(width: maxWidth, height: y + rowHeight), positions)
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/ComparisonGridView.swift
+++ b/Sources/ComfyBoxDesktop/Views/ComparisonGridView.swift
@@ -1,0 +1,377 @@
+// ComparisonGridView.swift — Side-by-side image comparison
+//
+// Displays 2-4 selected images in a grid for A/B testing prompt
+// variations. Shows metadata diff highlighting what changed between
+// images (seed, prompt, LoRAs, steps, guidance).
+
+import SwiftUI
+
+struct ComparisonGridView: View {
+    let store: DAMStore
+    let ingestor: AssetIngestor
+
+    @State private var selectedAssets: [DAMAsset] = []
+    @State private var allAssets: [DAMAsset] = []
+    @State private var showingPicker: Bool = true
+    @State private var showMetadataDiff: Bool = true
+    @State private var isLoading: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar
+            comparisonToolbar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(nsColor: .windowBackgroundColor))
+
+            Divider()
+
+            if selectedAssets.count < 2 {
+                pickerView
+            } else {
+                comparisonGrid
+            }
+        }
+        .task {
+            await loadAssets()
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var comparisonToolbar: some View {
+        HStack(spacing: 12) {
+            Text("Compare")
+                .font(.headline)
+
+            Spacer()
+
+            if selectedAssets.count >= 2 {
+                Toggle("Show Diff", isOn: $showMetadataDiff)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+
+                Button("Clear Selection") {
+                    selectedAssets.removeAll()
+                }
+                .controlSize(.small)
+            }
+
+            Text("\(selectedAssets.count)/4 selected")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    // MARK: - Picker (select images to compare)
+
+    private var pickerView: some View {
+        VStack(spacing: 12) {
+            if selectedAssets.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "square.grid.2x2")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.tertiary)
+                    Text("Select 2-4 images to compare")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                    Text("Click images below to add them to the comparison.")
+                        .font(.body)
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.top, 40)
+            } else {
+                // Show current selection as small thumbnails
+                HStack(spacing: 8) {
+                    ForEach(selectedAssets) { asset in
+                        VStack {
+                            thumbnailImage(for: asset)
+                                .frame(width: 80, height: 80)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            Text(asset.filename)
+                                .font(.caption2)
+                                .lineLimit(1)
+                        }
+                        .onTapGesture {
+                            selectedAssets.removeAll { $0.id == asset.id }
+                        }
+                    }
+
+                    if selectedAssets.count >= 2 {
+                        Button(action: { /* comparison auto-shows at 2+ */ }) {
+                            Label("Compare", systemImage: "arrow.right.circle.fill")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+
+            Divider()
+
+            // Grid of all assets to pick from
+            ScrollView {
+                let columns = [GridItem(.adaptive(minimum: 120, maximum: 160), spacing: 8)]
+                LazyVGrid(columns: columns, spacing: 8) {
+                    ForEach(allAssets) { asset in
+                        let isSelected = selectedAssets.contains { $0.id == asset.id }
+                        PickerCell(
+                            asset: asset,
+                            thumbnailPath: ingestor.thumbnailPath(for: asset.id),
+                            isSelected: isSelected
+                        )
+                        .onTapGesture {
+                            toggleSelection(asset)
+                        }
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    // MARK: - Comparison Grid
+
+    private var comparisonGrid: some View {
+        VStack(spacing: 0) {
+            // Images side by side
+            GeometryReader { geometry in
+                let columns = min(selectedAssets.count, 4)
+                let cellWidth = (geometry.size.width - CGFloat(columns - 1) * 8 - 24) / CGFloat(columns)
+
+                HStack(alignment: .top, spacing: 8) {
+                    ForEach(selectedAssets) { asset in
+                        VStack(spacing: 4) {
+                            thumbnailImage(for: asset)
+                                .frame(width: cellWidth, height: cellWidth)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                            Text(asset.filename)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .frame(width: cellWidth)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 8)
+            }
+            .frame(maxHeight: .infinity)
+
+            // Metadata diff
+            if showMetadataDiff {
+                Divider()
+                metadataDiffView
+                    .frame(height: 200)
+            }
+        }
+    }
+
+    // MARK: - Metadata Diff
+
+    private var metadataDiffView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Metadata Comparison")
+                    .font(.subheadline.weight(.medium))
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+
+                // Table-style diff
+                Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 6) {
+                    // Header row
+                    GridRow {
+                        Text("Field")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        ForEach(selectedAssets) { asset in
+                            Text(asset.filename)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+
+                    Divider()
+
+                    // Prompt
+                    diffRow(label: "Prompt") { asset in
+                        asset.prompt ?? "-"
+                    }
+
+                    // Seed
+                    diffRow(label: "Seed") { asset in
+                        asset.seed.map { "\($0)" } ?? "random"
+                    }
+
+                    // Steps
+                    diffRow(label: "Steps") { asset in
+                        asset.steps.map { "\($0)" } ?? "-"
+                    }
+
+                    // Guidance
+                    diffRow(label: "Guidance") { asset in
+                        asset.guidance.map { String(format: "%.1f", $0) } ?? "-"
+                    }
+
+                    // Model
+                    diffRow(label: "Model") { asset in
+                        asset.modelFamily ?? "-"
+                    }
+
+                    // Content Mode
+                    diffRow(label: "Mode") { asset in
+                        asset.contentMode ?? "-"
+                    }
+
+                    // Character
+                    diffRow(label: "Character") { asset in
+                        asset.characterName ?? "-"
+                    }
+
+                    // Resolution
+                    diffRow(label: "Resolution") { asset in
+                        if let w = asset.width, let h = asset.height {
+                            return "\(w)x\(h)"
+                        }
+                        return "-"
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            }
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    @ViewBuilder
+    private func diffRow(label: String, value: @escaping (DAMAsset) -> String) -> some View {
+        GridRow {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+
+            ForEach(selectedAssets) { asset in
+                let val = value(asset)
+                let isDifferent = selectedAssets.contains { value($0) != val }
+                Text(val)
+                    .font(.caption)
+                    .lineLimit(2)
+                    .foregroundStyle(isDifferent ? .primary : .secondary)
+                    .fontWeight(isDifferent ? .medium : .regular)
+                    .background(isDifferent ? Color.yellow.opacity(0.1) : Color.clear)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadAssets() async {
+        isLoading = true
+        do {
+            allAssets = try await store.fetchAssets(limit: 200)
+        } catch {
+            // Non-fatal — empty grid shown.
+        }
+        isLoading = false
+    }
+
+    private func toggleSelection(_ asset: DAMAsset) {
+        if let index = selectedAssets.firstIndex(where: { $0.id == asset.id }) {
+            selectedAssets.remove(at: index)
+        } else if selectedAssets.count < 4 {
+            selectedAssets.append(asset)
+        }
+    }
+
+    private func thumbnailImage(for asset: DAMAsset) -> some View {
+        AsyncThumbnail(
+            thumbnailPath: ingestor.thumbnailPath(for: asset.id),
+            fallbackPath: asset.absolutePath
+        )
+    }
+}
+
+// MARK: - Picker Cell
+
+private struct PickerCell: View {
+    let asset: DAMAsset
+    let thumbnailPath: String
+    let isSelected: Bool
+
+    @State private var thumbnail: NSImage?
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 2) {
+                ZStack {
+                    Color(nsColor: .controlBackgroundColor)
+                    if let thumb = thumbnail {
+                        Image(nsImage: thumb)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    } else {
+                        Image(systemName: "photo")
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .frame(height: 100)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                Text(asset.filename)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.white, Color.accentColor)
+                    .font(.title3)
+                    .padding(4)
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+        )
+        .task {
+            thumbnail = await Task.detached {
+                NSImage(contentsOfFile: thumbnailPath) ?? NSImage(contentsOfFile: asset.absolutePath)
+            }.value
+        }
+    }
+}
+
+// MARK: - Async Thumbnail Helper
+
+struct AsyncThumbnail: View {
+    let thumbnailPath: String
+    let fallbackPath: String
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        ZStack {
+            Color(nsColor: .controlBackgroundColor)
+            if let img = image {
+                Image(nsImage: img)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Image(systemName: "photo")
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .task {
+            image = await Task.detached {
+                NSImage(contentsOfFile: thumbnailPath) ?? NSImage(contentsOfFile: fallbackPath)
+            }.value
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/GalleryView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GalleryView.swift
@@ -1,32 +1,430 @@
-// GalleryView.swift — Asset gallery placeholder
+// GalleryView.swift — Asset gallery with grid, search, and filtering
 //
-// Phase 2 will implement a full gallery view with grid layout,
-// filtering, search, and metadata display. For now, shows a
-// placeholder message.
+// Displays DAMStore assets as a grid of thumbnails with sorting,
+// filtering by favorite/content mode/character, and FTS5 search.
+// Clicking a cell opens the AssetDetailView for full metadata
+// display and editing.
 
 import SwiftUI
 
+/// Sort options for the gallery.
+enum GallerySortOrder: String, CaseIterable {
+    case date = "Date"
+    case rating = "Rating"
+    case favorite = "Favorites First"
+}
+
 struct GalleryView: View {
+    let store: DAMStore
+    let ingestor: AssetIngestor
+
+    @State private var assets: [DAMAsset] = []
+    @State private var searchText: String = ""
+    @State private var sortOrder: GallerySortOrder = .date
+    @State private var filterFavorites: Bool = false
+    @State private var filterContentMode: String?
+    @State private var filterCharacter: String?
+    @State private var selectedAsset: DAMAsset?
+    @State private var showingDetail: Bool = false
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    // Available filter values extracted from assets.
+    @State private var contentModes: [String] = []
+    @State private var characters: [String] = []
+
+    private let columns = [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 12)]
+
     var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar: search, sort, filter
+            toolbarView
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(nsColor: .windowBackgroundColor))
+
+            Divider()
+
+            // Gallery grid
+            if isLoading {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Loading gallery...")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if filteredAssets.isEmpty {
+                emptyState
+            } else {
+                galleryGrid
+            }
+        }
+        .sheet(isPresented: $showingDetail) {
+            if let asset = selectedAsset {
+                AssetDetailView(
+                    asset: asset,
+                    thumbnailPath: ingestor.thumbnailPath(for: asset.id),
+                    onUpdate: { updated in
+                        Task { await updateAsset(updated) }
+                        showingDetail = false
+                    }
+                )
+                .frame(minWidth: 800, minHeight: 500)
+            }
+        }
+        .task {
+            await loadAssets()
+        }
+        .onChange(of: ingestor.ingestedCount) { _, _ in
+            Task { await loadAssets() }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbarView: some View {
+        HStack(spacing: 12) {
+            // Search field
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search prompts...", text: $searchText)
+                    .textFieldStyle(.plain)
+                if !searchText.isEmpty {
+                    Button(action: { searchText = "" }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .frame(maxWidth: 300)
+
+            Spacer()
+
+            // Favorite filter
+            Toggle(isOn: $filterFavorites) {
+                Image(systemName: filterFavorites ? "heart.fill" : "heart")
+            }
+            .toggleStyle(.button)
+            .help("Show favorites only")
+
+            // Content mode filter
+            if !contentModes.isEmpty {
+                Picker("Mode", selection: Binding(
+                    get: { filterContentMode ?? "" },
+                    set: { filterContentMode = $0.isEmpty ? nil : $0 }
+                )) {
+                    Text("All Modes").tag("")
+                    ForEach(contentModes, id: \.self) { mode in
+                        Text(mode.capitalized).tag(mode)
+                    }
+                }
+                .frame(width: 120)
+            }
+
+            // Character filter
+            if !characters.isEmpty {
+                Picker("Character", selection: Binding(
+                    get: { filterCharacter ?? "" },
+                    set: { filterCharacter = $0.isEmpty ? nil : $0 }
+                )) {
+                    Text("All Characters").tag("")
+                    ForEach(characters, id: \.self) { name in
+                        Text(name).tag(name)
+                    }
+                }
+                .frame(width: 120)
+            }
+
+            // Sort picker
+            Picker("Sort", selection: $sortOrder) {
+                ForEach(GallerySortOrder.allCases, id: \.self) { order in
+                    Text(order.rawValue).tag(order)
+                }
+            }
+            .frame(width: 140)
+
+            // Refresh button
+            Button(action: { Task { await loadAssets() } }) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .help("Refresh gallery")
+
+            // Asset count
+            Text("\(filteredAssets.count) images")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    // MARK: - Gallery Grid
+
+    private var galleryGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(filteredAssets) { asset in
+                    GalleryCellView(
+                        asset: asset,
+                        thumbnailPath: ingestor.thumbnailPath(for: asset.id)
+                    )
+                    .onTapGesture {
+                        selectedAsset = asset
+                        showingDetail = true
+                    }
+                    .contextMenu {
+                        Button("Reveal in Finder") {
+                            revealInFinder(asset)
+                        }
+                        Button(asset.favorite ? "Unfavorite" : "Favorite") {
+                            Task { await toggleFavorite(asset) }
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "photo.on.rectangle.angled")
                 .font(.system(size: 64))
                 .foregroundStyle(.tertiary)
 
-            Text("Gallery")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-
-            Text("Coming in Phase 2")
-                .font(.body)
-                .foregroundStyle(.tertiary)
-
-            Text("The gallery will display all generated assets with search, filtering, rating, and metadata.")
-                .font(.caption)
-                .foregroundStyle(.quaternary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 300)
+            if !searchText.isEmpty {
+                Text("No results for \"\(searchText)\"")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Try a different search term.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            } else if filterFavorites {
+                Text("No favorites yet")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Heart an image to see it here.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            } else {
+                Text("No images in gallery")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text("Generate an image or configure the watch directory.")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Filtering and Sorting
+
+    private var filteredAssets: [DAMAsset] {
+        var results = assets
+
+        // Apply favorites filter.
+        if filterFavorites {
+            results = results.filter { $0.favorite }
+        }
+
+        // Apply content mode filter.
+        if let mode = filterContentMode {
+            results = results.filter { $0.contentMode == mode }
+        }
+
+        // Apply character filter.
+        if let character = filterCharacter {
+            results = results.filter { $0.characterName == character }
+        }
+
+        // Apply search — client-side for immediate feedback, FTS for big datasets.
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            results = results.filter { asset in
+                (asset.prompt?.lowercased().contains(query) ?? false)
+                    || (asset.negativePrompt?.lowercased().contains(query) ?? false)
+                    || asset.filename.lowercased().contains(query)
+                    || (asset.characterName?.lowercased().contains(query) ?? false)
+            }
+        }
+
+        // Apply sort.
+        switch sortOrder {
+        case .date:
+            results.sort { $0.createdAt > $1.createdAt }
+        case .rating:
+            results.sort { $0.rating > $1.rating }
+        case .favorite:
+            results.sort {
+                if $0.favorite != $1.favorite { return $0.favorite }
+                return $0.createdAt > $1.createdAt
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Data Loading
+
+    private func loadAssets() async {
+        isLoading = assets.isEmpty
+        do {
+            if !searchText.isEmpty {
+                let ftsResults = try await store.searchPrompts(query: searchText, limit: 200)
+                assets = ftsResults
+            } else {
+                assets = try await store.fetchAssets(limit: 500)
+            }
+            extractFilterValues()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func extractFilterValues() {
+        contentModes = Array(Set(assets.compactMap { $0.contentMode })).sorted()
+        characters = Array(Set(assets.compactMap { $0.characterName })).sorted()
+    }
+
+    // MARK: - Actions
+
+    private func updateAsset(_ asset: DAMAsset) async {
+        do {
+            try await store.insertAsset(asset)
+            await loadAssets()
+        } catch {
+            errorMessage = "Failed to update: \(error.localizedDescription)"
+        }
+    }
+
+    private func toggleFavorite(_ asset: DAMAsset) async {
+        let updated = DAMAsset(
+            id: asset.id,
+            kind: asset.kind,
+            filename: asset.filename,
+            absolutePath: asset.absolutePath,
+            fileSize: asset.fileSize,
+            sha256: asset.sha256,
+            width: asset.width,
+            height: asset.height,
+            createdAt: asset.createdAt,
+            modifiedAt: Date(),
+            ingestedAt: asset.ingestedAt,
+            orphaned: asset.orphaned,
+            prompt: asset.prompt,
+            negativePrompt: asset.negativePrompt,
+            seed: asset.seed,
+            steps: asset.steps,
+            guidance: asset.guidance,
+            modelFamily: asset.modelFamily,
+            rating: asset.rating,
+            favorite: !asset.favorite,
+            contentMode: asset.contentMode,
+            characterName: asset.characterName
+        )
+        await updateAsset(updated)
+    }
+
+    private func revealInFinder(_ asset: DAMAsset) {
+        NSWorkspace.shared.selectFile(
+            asset.absolutePath,
+            inFileViewerRootedAtPath: ""
+        )
+    }
+}
+
+// MARK: - Gallery Cell
+
+struct GalleryCellView: View {
+    let asset: DAMAsset
+    let thumbnailPath: String
+
+    @State private var thumbnail: NSImage?
+
+    var body: some View {
+        VStack(spacing: 4) {
+            // Thumbnail
+            ZStack {
+                Color(nsColor: .controlBackgroundColor)
+
+                if let thumb = thumbnail {
+                    Image(nsImage: thumb)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Image(systemName: "photo")
+                        .font(.title)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(height: 160)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            // Prompt preview
+            if let prompt = asset.prompt {
+                Text(prompt)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Rating + favorite
+            HStack(spacing: 4) {
+                if asset.favorite {
+                    Image(systemName: "heart.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                }
+
+                if asset.rating > 0 {
+                    HStack(spacing: 1) {
+                        ForEach(1...5, id: \.self) { star in
+                            Image(systemName: star <= asset.rating ? "star.fill" : "star")
+                                .font(.system(size: 8))
+                                .foregroundStyle(star <= asset.rating ? .yellow : .gray.opacity(0.3))
+                        }
+                    }
+                }
+
+                Spacer()
+
+                if let mode = asset.contentMode {
+                    Text(mode)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                }
+            }
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .task {
+            await loadThumbnail()
+        }
+    }
+
+    private func loadThumbnail() async {
+        let path = thumbnailPath
+        // Also try loading the full image as fallback if no thumbnail.
+        let fullPath = asset.absolutePath
+        let image = await Task.detached {
+            NSImage(contentsOfFile: path) ?? NSImage(contentsOfFile: fullPath)
+        }.value
+        await MainActor.run {
+            thumbnail = image
+        }
     }
 }

--- a/Sources/ComfyBoxDesktop/Views/GalleryView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GalleryView.swift
@@ -3,9 +3,11 @@
 // Displays DAMStore assets as a grid of thumbnails with sorting,
 // filtering by favorite/content mode/character, and FTS5 search.
 // Clicking a cell opens the AssetDetailView for full metadata
-// display and editing.
+// display and editing. Phase 4: Added drag-and-drop, comparison
+// selection, Quick Look via Space bar.
 
 import SwiftUI
+import AppKit
 
 /// Sort options for the gallery.
 enum GallerySortOrder: String, CaseIterable {
@@ -17,6 +19,7 @@ enum GallerySortOrder: String, CaseIterable {
 struct GalleryView: View {
     let store: DAMStore
     let ingestor: AssetIngestor
+    var onCompare: (([DAMAsset]) -> Void)?
 
     @State private var assets: [DAMAsset] = []
     @State private var searchText: String = ""
@@ -29,9 +32,16 @@ struct GalleryView: View {
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
 
+    // Comparison selection
+    @State private var comparisonSelection: Set<String> = []
+    @State private var isComparisonMode: Bool = false
+
     // Available filter values extracted from assets.
     @State private var contentModes: [String] = []
     @State private var characters: [String] = []
+
+    // Search field focus
+    @FocusState private var searchFieldFocused: Bool
 
     private let columns = [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 12)]
 
@@ -79,6 +89,12 @@ struct GalleryView: View {
         .onChange(of: ingestor.ingestedCount) { _, _ in
             Task { await loadAssets() }
         }
+        .onKeyPress(.space) {
+            if let asset = selectedAsset {
+                quickLookAsset(asset)
+            }
+            return .handled
+        }
     }
 
     // MARK: - Toolbar
@@ -91,6 +107,7 @@ struct GalleryView: View {
                     .foregroundStyle(.secondary)
                 TextField("Search prompts...", text: $searchText)
                     .textFieldStyle(.plain)
+                    .focused($searchFieldFocused)
                 if !searchText.isEmpty {
                     Button(action: { searchText = "" }) {
                         Image(systemName: "xmark.circle.fill")
@@ -105,6 +122,31 @@ struct GalleryView: View {
             .frame(maxWidth: 300)
 
             Spacer()
+
+            // Comparison mode toggle
+            Toggle(isOn: $isComparisonMode) {
+                HStack(spacing: 4) {
+                    Image(systemName: "square.grid.2x2")
+                    if isComparisonMode && !comparisonSelection.isEmpty {
+                        Text("\(comparisonSelection.count)")
+                            .font(.caption2)
+                    }
+                }
+            }
+            .toggleStyle(.button)
+            .help("Toggle comparison selection mode")
+            .onChange(of: isComparisonMode) { _, newValue in
+                if !newValue { comparisonSelection.removeAll() }
+            }
+
+            // Compare button (visible when 2+ selected)
+            if isComparisonMode && comparisonSelection.count >= 2 {
+                Button(action: { sendToComparison() }) {
+                    Label("Compare \(comparisonSelection.count)", systemImage: "arrow.right.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
 
             // Favorite filter
             Toggle(isOn: $filterFavorites) {
@@ -169,13 +211,19 @@ struct GalleryView: View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(filteredAssets) { asset in
+                    let isCompSelected = comparisonSelection.contains(asset.id)
                     GalleryCellView(
                         asset: asset,
-                        thumbnailPath: ingestor.thumbnailPath(for: asset.id)
+                        thumbnailPath: ingestor.thumbnailPath(for: asset.id),
+                        isComparisonSelected: isComparisonMode ? isCompSelected : nil
                     )
                     .onTapGesture {
-                        selectedAsset = asset
-                        showingDetail = true
+                        if isComparisonMode {
+                            toggleComparisonSelection(asset)
+                        } else {
+                            selectedAsset = asset
+                            showingDetail = true
+                        }
                     }
                     .contextMenu {
                         Button("Reveal in Finder") {
@@ -184,7 +232,17 @@ struct GalleryView: View {
                         Button(asset.favorite ? "Unfavorite" : "Favorite") {
                             Task { await toggleFavorite(asset) }
                         }
+                        if !isComparisonMode {
+                            Divider()
+                            Button("Add to Comparison") {
+                                if comparisonSelection.count < 4 {
+                                    comparisonSelection.insert(asset.id)
+                                    isComparisonMode = true
+                                }
+                            }
+                        }
                     }
+                    .draggable(DraggableAsset(path: asset.absolutePath))
                 }
             }
             .padding(12)
@@ -295,6 +353,11 @@ struct GalleryView: View {
 
     // MARK: - Actions
 
+    /// Focus the search field (called by Cmd+F keyboard shortcut).
+    func focusSearch() {
+        searchFieldFocused = true
+    }
+
     private func updateAsset(_ asset: DAMAsset) async {
         do {
             try await store.insertAsset(asset)
@@ -338,6 +401,37 @@ struct GalleryView: View {
             inFileViewerRootedAtPath: ""
         )
     }
+
+    private func toggleComparisonSelection(_ asset: DAMAsset) {
+        if comparisonSelection.contains(asset.id) {
+            comparisonSelection.remove(asset.id)
+        } else if comparisonSelection.count < 4 {
+            comparisonSelection.insert(asset.id)
+        }
+    }
+
+    private func sendToComparison() {
+        let selected = assets.filter { comparisonSelection.contains($0.id) }
+        onCompare?(selected)
+    }
+
+    /// Open Quick Look for an asset using macOS native preview.
+    private func quickLookAsset(_ asset: DAMAsset) {
+        let url = URL(fileURLWithPath: asset.absolutePath)
+        NSWorkspace.shared.open(url)
+    }
+}
+
+// MARK: - Draggable Asset (for drag-and-drop to Finder)
+
+struct DraggableAsset: Transferable {
+    let path: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .png) { asset in
+            SentTransferredFile(URL(fileURLWithPath: asset.path))
+        }
+    }
 }
 
 // MARK: - Gallery Cell
@@ -345,72 +439,90 @@ struct GalleryView: View {
 struct GalleryCellView: View {
     let asset: DAMAsset
     let thumbnailPath: String
+    var isComparisonSelected: Bool?
 
     @State private var thumbnail: NSImage?
 
     var body: some View {
-        VStack(spacing: 4) {
-            // Thumbnail
-            ZStack {
-                Color(nsColor: .controlBackgroundColor)
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 4) {
+                // Thumbnail
+                ZStack {
+                    Color(nsColor: .controlBackgroundColor)
 
-                if let thumb = thumbnail {
-                    Image(nsImage: thumb)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } else {
-                    Image(systemName: "photo")
-                        .font(.title)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .frame(height: 160)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-
-            // Prompt preview
-            if let prompt = asset.prompt {
-                Text(prompt)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            // Rating + favorite
-            HStack(spacing: 4) {
-                if asset.favorite {
-                    Image(systemName: "heart.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.red)
-                }
-
-                if asset.rating > 0 {
-                    HStack(spacing: 1) {
-                        ForEach(1...5, id: \.self) { star in
-                            Image(systemName: star <= asset.rating ? "star.fill" : "star")
-                                .font(.system(size: 8))
-                                .foregroundStyle(star <= asset.rating ? .yellow : .gray.opacity(0.3))
-                        }
+                    if let thumb = thumbnail {
+                        Image(nsImage: thumb)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    } else {
+                        Image(systemName: "photo")
+                            .font(.title)
+                            .foregroundStyle(.tertiary)
                     }
                 }
+                .frame(height: 160)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
 
-                Spacer()
-
-                if let mode = asset.contentMode {
-                    Text(mode)
-                        .font(.system(size: 9))
+                // Prompt preview
+                if let prompt = asset.prompt {
+                    Text(prompt)
+                        .font(.caption2)
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(Color.secondary.opacity(0.15))
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
+
+                // Rating + favorite
+                HStack(spacing: 4) {
+                    if asset.favorite {
+                        Image(systemName: "heart.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.red)
+                    }
+
+                    if asset.rating > 0 {
+                        HStack(spacing: 1) {
+                            ForEach(1...5, id: \.self) { star in
+                                Image(systemName: star <= asset.rating ? "star.fill" : "star")
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(star <= asset.rating ? .yellow : .gray.opacity(0.3))
+                            }
+                        }
+                    }
+
+                    Spacer()
+
+                    if let mode = asset.contentMode {
+                        Text(mode)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                }
+            }
+
+            // Comparison selection overlay
+            if let isSelected = isComparisonSelected {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? .white : .secondary, isSelected ? Color.accentColor : Color.clear)
+                    .font(.title3)
+                    .padding(6)
             }
         }
         .padding(6)
         .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(
+                    isComparisonSelected == true ? Color.accentColor : Color.clear,
+                    lineWidth: 2
+                )
+        )
         .task {
             await loadThumbnail()
         }
@@ -418,7 +530,6 @@ struct GalleryCellView: View {
 
     private func loadThumbnail() async {
         let path = thumbnailPath
-        // Also try loading the full image as fallback if no thumbnail.
         let fullPath = asset.absolutePath
         let image = await Task.detached {
             NSImage(contentsOfFile: path) ?? NSImage(contentsOfFile: fullPath)

--- a/Sources/ComfyBoxDesktop/Views/GenerationView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GenerationView.swift
@@ -1,9 +1,10 @@
 // GenerationView.swift — Main image generation interface
 //
-// Provides prompt entry, parameter controls, generation button,
-// and image preview. Communicates with the WarmServer through
-// EngineService. On successful generation, calls onGenerated
-// to trigger DAM ingestion.
+// Provides prompt entry, parameter controls, model selection,
+// LoRA picker, queue status, and image preview. Communicates
+// with the WarmServer through EngineService. On successful
+// generation, calls onGenerated to trigger DAM ingestion.
+// Phase 4: Added preset save, prompt enhancement, keyboard shortcuts.
 
 import SwiftUI
 
@@ -24,6 +25,8 @@ struct ResolutionPreset: Identifiable, Hashable {
 
 struct GenerationView: View {
     @Bindable var engine: EngineService
+    var presetManager: PresetManager?
+    var characters: [CharacterEntry]
     var onGenerated: ((String, GenerationRequest) -> Void)?
 
     // Generation parameters
@@ -34,15 +37,58 @@ struct GenerationView: View {
     @State private var seedText: String = ""
     @State private var displayedImage: NSImage?
 
+    // LoRA selections
+    @State private var selectedLoras: [LoRASelection] = []
+
+    // Sidebar sections
+    @State private var showModelSelector: Bool = true
+    @State private var showLoraPicker: Bool = false
+    @State private var showQueuePanel: Bool = false
+    @State private var showCharacters: Bool = false
+
+    // Preset save sheet
+    @State private var showingSavePreset: Bool = false
+
+    // Prompt enhancement
+    @State private var isEnhancing: Bool = false
+    @State private var enhanceAvailable: Bool = true
+
     var body: some View {
         HSplitView {
             // Left panel: Controls
             controlPanel
-                .frame(minWidth: 320, maxWidth: 400)
+                .frame(minWidth: 340, maxWidth: 420)
 
             // Right panel: Image preview
             previewPanel
                 .frame(minWidth: 400)
+        }
+        .sheet(isPresented: $showingSavePreset) {
+            if let pm = presetManager {
+                SavePresetSheet(
+                    promptTemplate: prompt,
+                    modelId: engine.currentModel,
+                    loras: selectedLoras,
+                    steps: Int(steps),
+                    guidance: Float(guidance),
+                    width: selectedResolution.width,
+                    height: selectedResolution.height,
+                    onSave: { name in
+                        _ = pm.create(
+                            name: name,
+                            promptTemplate: prompt,
+                            modelId: engine.currentModel,
+                            loras: selectedLoras,
+                            steps: Int(steps),
+                            guidance: Float(guidance),
+                            width: selectedResolution.width,
+                            height: selectedResolution.height
+                        )
+                        showingSavePreset = false
+                    },
+                    onCancel: { showingSavePreset = false }
+                )
+            }
         }
     }
 
@@ -56,6 +102,17 @@ struct GenerationView: View {
 
                 Divider()
 
+                // Model selector (collapsible)
+                DisclosureGroup(isExpanded: $showModelSelector) {
+                    ModelSelector(engine: engine)
+                        .padding(.top, 4)
+                } label: {
+                    Label("Model", systemImage: "cpu")
+                        .font(.headline)
+                }
+
+                Divider()
+
                 // Prompt
                 promptSection
 
@@ -66,8 +123,69 @@ struct GenerationView: View {
 
                 Divider()
 
-                // Generate button
-                generateButton
+                // LoRA picker (collapsible)
+                DisclosureGroup(isExpanded: $showLoraPicker) {
+                    LoRAPicker(engine: engine, selectedLoras: $selectedLoras)
+                        .padding(.top, 4)
+                } label: {
+                    HStack {
+                        Label("LoRA Adapters", systemImage: "slider.horizontal.3")
+                            .font(.headline)
+                        if !selectedLoras.isEmpty {
+                            Text("\(selectedLoras.count)")
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.accentColor.opacity(0.2))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
+
+                // Characters (collapsible)
+                if !characters.isEmpty {
+                    Divider()
+                    DisclosureGroup(isExpanded: $showCharacters) {
+                        CharacterLibraryView(
+                            characters: characters,
+                            onInsert: { entry in
+                                insertCharacterPrompt(entry)
+                            }
+                        )
+                        .frame(maxHeight: 300)
+                        .padding(.top, 4)
+                    } label: {
+                        Label("Characters", systemImage: "person.2")
+                            .font(.headline)
+                    }
+                }
+
+                Divider()
+
+                // Queue panel (collapsible)
+                DisclosureGroup(isExpanded: $showQueuePanel) {
+                    QueuePanel(engine: engine)
+                        .padding(.top, 4)
+                } label: {
+                    HStack {
+                        Label("Queue", systemImage: "list.bullet.rectangle")
+                            .font(.headline)
+                        if engine.queueCount > 0 {
+                            Text("\(engine.queueCount)")
+                                .font(.caption2)
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.orange)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                }
+
+                Divider()
+
+                // Action buttons
+                actionButtons
 
                 // Error display
                 if let error = engine.lastError {
@@ -126,8 +244,27 @@ struct GenerationView: View {
 
     private var promptSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Prompt")
-                .font(.headline)
+            HStack {
+                Text("Prompt")
+                    .font(.headline)
+                Spacer()
+                // Enhance button
+                Button(action: { enhancePrompt() }) {
+                    HStack(spacing: 4) {
+                        if isEnhancing {
+                            ProgressView()
+                                .controlSize(.mini)
+                        } else {
+                            Image(systemName: "sparkles")
+                        }
+                        Text("Enhance")
+                    }
+                }
+                .controlSize(.small)
+                .buttonStyle(.bordered)
+                .disabled(!canEnhance)
+                .help("Send prompt to LLM for enhancement")
+            }
 
             TextEditor(text: $prompt)
                 .font(.body)
@@ -205,31 +342,65 @@ struct GenerationView: View {
         }
     }
 
-    private var generateButton: some View {
-        Button(action: { submitGeneration() }) {
-            HStack {
-                if engine.isGenerating {
-                    ProgressView()
-                        .controlSize(.small)
-                        .padding(.trailing, 4)
-                    Text("Generating...")
-                } else {
-                    Image(systemName: "wand.and.stars")
-                    Text("Generate")
+    private var actionButtons: some View {
+        VStack(spacing: 8) {
+            // Generate button
+            Button(action: { submitGeneration() }) {
+                HStack {
+                    if engine.isGenerating {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(.trailing, 4)
+                        Text("Generating...")
+                    } else {
+                        Image(systemName: "wand.and.stars")
+                        Text("Generate")
+                    }
                 }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
+            .buttonStyle(.borderedProminent)
+            .disabled(!canGenerate)
+            .keyboardShortcut(.return, modifiers: .command)
+
+            // Save / Clear row
+            HStack(spacing: 8) {
+                Button(action: { showingSavePreset = true }) {
+                    HStack {
+                        Image(systemName: "square.and.arrow.down")
+                        Text("Save Preset")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(presetManager == nil)
+                .keyboardShortcut("s", modifiers: .command)
+
+                Button(action: { clearPrompt() }) {
+                    HStack {
+                        Image(systemName: "doc")
+                        Text("New")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .keyboardShortcut("n", modifiers: .command)
+            }
         }
-        .buttonStyle(.borderedProminent)
-        .disabled(!canGenerate)
-        .keyboardShortcut(.return, modifiers: .command)
     }
 
     private var canGenerate: Bool {
         engine.connectionState.isConnected
             && !engine.isGenerating
             && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var canEnhance: Bool {
+        engine.connectionState.isConnected
+            && !isEnhancing
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && enhanceAvailable
     }
 
     // MARK: - Preview Panel
@@ -289,10 +460,21 @@ struct GenerationView: View {
             height: selectedResolution.height,
             steps: Int(steps),
             guidance: Float(guidance),
-            seed: seed
+            seed: seed,
+            loras: selectedLoras
         )
 
         Task {
+            // Swap LoRAs if any selected (before generation).
+            if !selectedLoras.isEmpty {
+                do {
+                    try await engine.swapLoras(selectedLoras)
+                } catch {
+                    // LoRA swap failure — still attempt generation with
+                    // whatever LoRAs are currently loaded.
+                }
+            }
+
             do {
                 let outputPath = try await engine.generate(request)
                 // Load the generated image for display.
@@ -305,6 +487,65 @@ struct GenerationView: View {
                 onGenerated?(outputPath, request)
             } catch {
                 // Error is already stored in engine.lastError
+            }
+        }
+    }
+
+    private func clearPrompt() {
+        prompt = ""
+        seedText = ""
+        displayedImage = nil
+        engine.lastError = nil
+    }
+
+    /// Apply a preset to the current generation parameters.
+    func applyPreset(_ preset: GenerationPreset) {
+        prompt = preset.promptTemplate
+        steps = Double(preset.steps)
+        guidance = Double(preset.guidance)
+
+        // Find matching resolution preset, or keep current
+        if let match = ResolutionPreset.presets.first(where: {
+            $0.width == preset.width && $0.height == preset.height
+        }) {
+            selectedResolution = match
+        }
+
+        // Convert preset LoRAs to LoRASelections
+        selectedLoras = preset.loras.map {
+            LoRASelection(id: $0.id, filename: $0.filename, scale: $0.scale)
+        }
+    }
+
+    /// Insert a character's prompt snippet into the current prompt.
+    private func insertCharacterPrompt(_ entry: CharacterEntry) {
+        if prompt.isEmpty {
+            prompt = entry.promptSnippet
+        } else {
+            prompt += ", \(entry.promptSnippet)"
+        }
+    }
+
+    /// Send the current prompt to the LLM enhancement endpoint.
+    private func enhancePrompt() {
+        guard canEnhance else { return }
+        isEnhancing = true
+
+        Task {
+            do {
+                let enhanced = try await engine.enhancePrompt(prompt)
+                await MainActor.run {
+                    prompt = enhanced
+                    isEnhancing = false
+                }
+            } catch {
+                await MainActor.run {
+                    isEnhancing = false
+                    // If endpoint not found, disable the button.
+                    if case EngineServiceError.serverError(404, _) = error {
+                        enhanceAvailable = false
+                    }
+                }
             }
         }
     }

--- a/Sources/ComfyBoxDesktop/Views/GenerationView.swift
+++ b/Sources/ComfyBoxDesktop/Views/GenerationView.swift
@@ -2,7 +2,8 @@
 //
 // Provides prompt entry, parameter controls, generation button,
 // and image preview. Communicates with the WarmServer through
-// EngineService.
+// EngineService. On successful generation, calls onGenerated
+// to trigger DAM ingestion.
 
 import SwiftUI
 
@@ -23,6 +24,7 @@ struct ResolutionPreset: Identifiable, Hashable {
 
 struct GenerationView: View {
     @Bindable var engine: EngineService
+    var onGenerated: ((String, GenerationRequest) -> Void)?
 
     // Generation parameters
     @State private var prompt: String = ""
@@ -299,6 +301,8 @@ struct GenerationView: View {
                         displayedImage = image
                     }
                 }
+                // Notify app to ingest the generated file into DAM.
+                onGenerated?(outputPath, request)
             } catch {
                 // Error is already stored in engine.lastError
             }

--- a/Sources/ComfyBoxDesktop/Views/PresetView.swift
+++ b/Sources/ComfyBoxDesktop/Views/PresetView.swift
@@ -1,0 +1,296 @@
+// PresetView.swift — Preset list with CRUD actions
+//
+// Displays saved generation presets in a list. Supports apply,
+// edit, duplicate, and delete actions. The "Save as Preset" flow
+// is triggered from GenerationView and routes through PresetManager.
+
+import SwiftUI
+
+struct PresetView: View {
+    @Bindable var presetManager: PresetManager
+    var onApply: ((GenerationPreset) -> Void)?
+
+    @State private var editingPreset: GenerationPreset?
+    @State private var showingEditor: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Presets")
+                    .font(.headline)
+                Spacer()
+                Text("\(presetManager.presets.count) saved")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if presetManager.presets.isEmpty {
+                emptyState
+            } else {
+                presetList
+            }
+        }
+        .sheet(isPresented: $showingEditor) {
+            if let preset = editingPreset {
+                PresetEditorSheet(
+                    preset: preset,
+                    onSave: { updated in
+                        presetManager.update(updated)
+                        showingEditor = false
+                        editingPreset = nil
+                    },
+                    onCancel: {
+                        showingEditor = false
+                        editingPreset = nil
+                    }
+                )
+                .frame(minWidth: 420, minHeight: 400)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "slider.horizontal.below.rectangle")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("No presets saved")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("Use Cmd+S or the Save button to create one.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var presetList: some View {
+        List {
+            ForEach(presetManager.presets) { preset in
+                PresetRow(preset: preset)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onApply?(preset)
+                    }
+                    .contextMenu {
+                        Button("Apply") { onApply?(preset) }
+                        Button("Edit...") {
+                            editingPreset = preset
+                            showingEditor = true
+                        }
+                        Button("Duplicate") {
+                            _ = presetManager.duplicate(preset)
+                        }
+                        Divider()
+                        Button("Delete", role: .destructive) {
+                            presetManager.delete(id: preset.id)
+                        }
+                    }
+            }
+        }
+        .listStyle(.inset)
+    }
+}
+
+// MARK: - Preset Row
+
+private struct PresetRow: View {
+    let preset: GenerationPreset
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(preset.name)
+                    .font(.subheadline.weight(.medium))
+                Spacer()
+                if let model = preset.modelId {
+                    Text(model)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            if !preset.promptTemplate.isEmpty {
+                Text(preset.promptTemplate)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+            }
+
+            HStack(spacing: 8) {
+                Label("\(preset.steps) steps", systemImage: "slider.horizontal.3")
+                Label(String(format: "%.1f cfg", preset.guidance), systemImage: "tuningfork")
+                Label("\(preset.width)x\(preset.height)", systemImage: "aspectratio")
+                if !preset.loras.isEmpty {
+                    Label("\(preset.loras.count) LoRA", systemImage: "link")
+                }
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Preset Editor Sheet
+
+struct PresetEditorSheet: View {
+    @State var preset: GenerationPreset
+    var onSave: (GenerationPreset) -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title bar
+            HStack {
+                Text("Edit Preset")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            Form {
+                Section("Basics") {
+                    TextField("Name", text: $preset.name)
+                    TextField("Model ID", text: Binding(
+                        get: { preset.modelId ?? "" },
+                        set: { preset.modelId = $0.isEmpty ? nil : $0 }
+                    ))
+                }
+
+                Section("Prompt Template") {
+                    TextEditor(text: $preset.promptTemplate)
+                        .frame(minHeight: 60)
+                        .font(.body)
+                }
+
+                Section("Parameters") {
+                    HStack {
+                        Text("Steps")
+                        Spacer()
+                        TextField("Steps", value: $preset.steps, format: .number)
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    HStack {
+                        Text("Guidance")
+                        Spacer()
+                        TextField("Guidance", value: $preset.guidance, format: .number.precision(.fractionLength(1)))
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    HStack {
+                        Text("Width")
+                        Spacer()
+                        TextField("Width", value: $preset.width, format: .number)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    HStack {
+                        Text("Height")
+                        Spacer()
+                        TextField("Height", value: $preset.height, format: .number)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            // Action buttons
+            HStack {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Save") { onSave(preset) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(preset.name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Save Preset Sheet (called from GenerationView)
+
+struct SavePresetSheet: View {
+    var promptTemplate: String
+    var modelId: String?
+    var loras: [LoRASelection]
+    var steps: Int
+    var guidance: Float
+    var width: Int
+    var height: Int
+    var onSave: (String) -> Void
+    var onCancel: () -> Void
+
+    @State private var presetName: String = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Save as Preset")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            Form {
+                Section("Preset Name") {
+                    TextField("My Preset", text: $presetName)
+                }
+
+                Section("Settings to Save") {
+                    LabeledContent("Steps", value: "\(steps)")
+                    LabeledContent("Guidance", value: String(format: "%.1f", guidance))
+                    LabeledContent("Resolution", value: "\(width) x \(height)")
+                    if let model = modelId {
+                        LabeledContent("Model", value: model)
+                    }
+                    if !loras.isEmpty {
+                        LabeledContent("LoRAs", value: "\(loras.count) selected")
+                    }
+                    if !promptTemplate.isEmpty {
+                        LabeledContent("Prompt") {
+                            Text(promptTemplate)
+                                .lineLimit(3)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Save Preset") { onSave(presetName) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(presetName.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 400, height: 360)
+    }
+}


### PR DESCRIPTION
Rebase of #170 after squash-merge conflict. Also includes Phase 2 changes from #168 (rebased in #177) since Phase 4 depends on Phase 2.

## Summary

- **PresetManager** + **PresetView**: Full CRUD for saved generation presets (prompt, model, LoRAs, steps, guidance, resolution). Persists to `~/.comfybox/presets.json`. Save Preset sheet from GenerationView, list view with apply/edit/duplicate/delete context menu.
- **CharacterLibraryView**: Browses registered characters from engine API. Shows name, description, default LoRAs, prompt snippet, tags. Insert button appends character prompt into active generation.
- **ComparisonGridView**: Side-by-side display of 2-4 selected images with metadata diff table highlighting differences (seed, prompt, steps, guidance, model, resolution).
- **Prompt Enhancement**: Button in GenerationView POSTs current prompt to `/v1/enhance` on the WarmServer. Gracefully disables on 404.
- **Keyboard Shortcuts**: Cmd+Enter (generate), Cmd+N (clear), Cmd+S (save preset), Cmd+1-4 (tab switch), Cmd+F (gallery search), Space (Quick Look).
- **Drag-and-Drop**: Gallery thumbnails draggable to Finder via `Transferable` protocol with `FileRepresentation`.
- **Gallery Comparison Mode**: Toggle in toolbar selects 2-4 images, then sends to comparison view.

## Test plan

- [ ] Build clean with `swift build -c release`
- [ ] Create a preset from GenerationView, verify it appears in Presets tab
- [ ] Edit, duplicate, and delete presets
- [ ] Apply a preset and verify parameters populate in GenerationView
- [ ] Open Characters section, insert character prompt
- [ ] Select 2-4 images in Gallery comparison mode, verify diff view
- [ ] Drag an image from gallery to Finder
- [ ] Press Space on a selected gallery image for Quick Look
- [ ] Test all keyboard shortcuts (Cmd+1-4, Cmd+S, Cmd+N, Cmd+Enter)
- [ ] Test enhance button (enable when server has /v1/enhance, disable on 404)