### PR TITLE
P0: unified config + canonical port 7870 + AI-provider registry

### DIFF
--- a/Sources/ComfyBox/main.swift
+++ b/Sources/ComfyBox/main.swift
@@ -1292,7 +1292,7 @@ struct ZImageCLI {
       serve                  Start warm HTTP server
         --model, -m          Model path or HuggingFace ID
         --text-encoder-path  Override text encoder directory
-        --port               HTTP port (default 7862)
+        --port               HTTP port (default 7870)
         --lora, -l           Initial LoRA(s)
         Use 'ComfyBox serve --help' for full options
 
@@ -1321,14 +1321,14 @@ struct ZImageCLI {
 
 
       mcp                    Start MCP server (stdio JSON-RPC bridge to WarmServer)
-        --port               WarmServer port (default: 7862)
+        --port               WarmServer port (default: 7870)
         --host               WarmServer host (default: 127.0.0.1)
         Use 'ComfyBox mcp --help' for full options
 
       telegram               Start Telegram bot (receives prompts, renders via WarmServer)
         --bot-token          Telegram Bot API token
         --config             Config file path (default: ~/.comfybox/telegram.json)
-        --port               WarmServer port (default: 7862)
+        --port               WarmServer port (default: 7870)
         --host               WarmServer host (default: 127.0.0.1)
         Use 'ComfyBox telegram --help' for full options
 
@@ -1343,7 +1343,7 @@ struct ZImageCLI {
       ComfyBox -p "landscape" --scheduler heun --sigma-schedule beta -s 5  # Heun at half steps
       ComfyBox -p "refiner pass" --scheduler res_2s --sigma-schedule beta57  # RES 2s + beta57
       ComfyBox -p "scene" --scheduler ddim --eta 0.5  # Semi-stochastic DDIM
-      ComfyBox serve -m ./models/z-image-turbo --port 7862
+      ComfyBox serve -m ./models/z-image-turbo --port 7870
       ComfyBox -p "portrait" --auto-seeds 5 -o portraits.png  # Generate 5 random variations
       ComfyBox -p "cat" --seed 42 --seed 99 --seed 123 -o cats.png  # 3 specific seeds
       ComfyBox -p "scene" --auto-seeds 10 --resume-batch progress.jsonl  # Resume interrupted batch
@@ -1578,17 +1578,21 @@ struct ZImageCLI {
   }
 
   private static func runServe(args: [String]) throws {
-    var model: String?
+    // Load ~/.comfybox/config.json, auto-migrating from ~/.coffeeshop on first launch.
+    // Config supplies defaults; explicit CLI flags below override them.
+    let config = ComfyBoxServerConfig.loadOrMigrate()
+
+    var model: String? = config.modelSpec
     var textEncoderPath: String?
-    var port: UInt16 = 7862
+    var port: UInt16 = config.port
     var cacheLimit: Int?
     var maxSequenceLength = 512
     var loraEntries: [String] = []
     var loraScaleOverrides: [Float] = []
     var forceTransformerOverrideOnly = false
-    var host = "127.0.0.1"
-    var allowedOutputDirectory = FileManager.default.currentDirectoryPath
-    var seedvr2Weights: String? = nil
+    var host = config.host
+    var allowedOutputDirectory = config.allowedOutputDirectory ?? FileManager.default.currentDirectoryPath
+    var seedvr2Weights: String? = config.seedvr2WeightsPath
 
     var iterator = args.makeIterator()
     while let arg = iterator.next() {
@@ -1632,6 +1636,10 @@ struct ZImageCLI {
       }
     }
 
+    if port == ComfyBoxServerConfig.deprecatedAliasPort {
+      logger.warning("Port \(port) is deprecated; ComfyBox's canonical port is \(ComfyBoxServerConfig.canonicalPort). It still works this release — update clients (Krita, warm-worker) to \(ComfyBoxServerConfig.canonicalPort).")
+    }
+
     if let limit = cacheLimit {
       GPU.set(cacheLimit: limit * 1024 * 1024)
       logger.info("GPU cache limit set to \(limit)MB")
@@ -1665,7 +1673,7 @@ struct ZImageCLI {
     Usage: ComfyBox serve [options]
       --model, -m               Model path or HuggingFace ID (default: \(ZImageRepository.id))
       --text-encoder-path       Override text encoder directory
-      --port                    HTTP port (default: 7862)
+      --port                    HTTP port (default: 7870)
       --host                    HTTP host/interface to bind (default: 127.0.0.1)
       --allowed-output-directory  Directory where request outputPath values may write (default: current directory)
       --cache-limit             GPU memory cache limit in MB (default: unlimited)
@@ -1685,7 +1693,7 @@ struct ZImageCLI {
       POST /v1/shutdown         Gracefully stop the server
 
     Example:
-      ComfyBox serve -m /path/to/model --text-encoder-path /path/to/encoder --port 7862 \\
+      ComfyBox serve -m /path/to/model --text-encoder-path /path/to/encoder --port 7870 \\
         --lora /path/to/lora.safetensors=0.8
     """)
   }
@@ -2525,7 +2533,7 @@ struct ZImageCLI {
   // MARK: - MCP Server Subcommand
 
   private static func runMCP(args: [String]) throws {
-    var port: UInt16 = 7862
+    var port: UInt16 = 7870
     var host = "127.0.0.1"
 
     var iterator = args.makeIterator()
@@ -2562,7 +2570,7 @@ struct ZImageCLI {
     Bridges stdio JSON-RPC 2.0 to WarmServer HTTP API.
 
     Usage: ComfyBox mcp [options]
-      --port                    WarmServer port to connect to (default: 7862)
+      --port                    WarmServer port to connect to (default: 7870)
       --host                    WarmServer host to connect to (default: 127.0.0.1)
       --help, -h                Show help
 
@@ -2570,7 +2578,7 @@ struct ZImageCLI {
     to stdout. All logging goes to stderr. Runs until stdin closes.
 
     Registration:
-      claude mcp add comfybox -- comfybox mcp --port 7862
+      claude mcp add comfybox -- comfybox mcp --port 7870
 
     Tools:
       generate_image    Text-to-image / img2img generation
@@ -4490,7 +4498,7 @@ struct ZImageCLI {
   private static func runTelegram(args: [String]) throws {
     var botToken: String? = nil
     var configPath: String? = nil
-    var warmServerPort: UInt16 = 7862
+    var warmServerPort: UInt16 = 7870
     var warmServerHost: String = "127.0.0.1"
     var enhanceOverride: Bool? = nil
 
@@ -4502,7 +4510,7 @@ struct ZImageCLI {
       case "--config":
         configPath = nextValue(for: arg, iterator: &iterator)
       case "--port":
-        let raw = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: 7862)
+        let raw = intValue(for: arg, iterator: &iterator, minimum: 1, fallback: 7870)
         warmServerPort = UInt16(min(raw, Int(UInt16.max)))
       case "--host":
         warmServerHost = nextValue(for: arg, iterator: &iterator)
@@ -4618,7 +4626,7 @@ struct ZImageCLI {
         if warmServerHost == "127.0.0.1", let h = ws["host"] as? String {
           host = h
         }
-        if warmServerPort == 7862, let p = ws["port"] as? Int {
+        if warmServerPort == 7870, let p = ws["port"] as? Int {
           port = UInt16(min(p, Int(UInt16.max)))
         }
       }
@@ -4701,7 +4709,7 @@ struct ZImageCLI {
     Options:
       --bot-token <token>     Telegram Bot API token (or COMFYBOX_TELEGRAM_TOKEN env)
       --config <path>         Config file (default: ~/.comfybox/telegram.json)
-      --port <port>           WarmServer port (default: 7862)
+      --port <port>           WarmServer port (default: 7870)
       --host <host>           WarmServer host (default: 127.0.0.1)
       --enhance [on|off]      Enable/disable prompt optimization (default: on)
       --no-enhance            Disable prompt optimization
@@ -4716,7 +4724,7 @@ struct ZImageCLI {
       {
         "botToken": "123456:ABC...",
         "allowedUserIds": [8754779862],
-        "warmServer": { "host": "127.0.0.1", "port": 7862 },
+        "warmServer": { "host": "127.0.0.1", "port": 7870 },
         "optimizer": {
           "enabled": true,
           "ollamaBaseURL": "http://localhost:11434",
@@ -4730,7 +4738,7 @@ struct ZImageCLI {
 
     Resolution order: CLI flags > env vars > config file > defaults
 
-    Requires a running WarmServer: ComfyBox serve --port 7862
+    Requires a running WarmServer: ComfyBox serve --port 7870
     """)
   }
 

--- a/Sources/ComfyBoxDesktop/AppConfig.swift
+++ b/Sources/ComfyBoxDesktop/AppConfig.swift
@@ -14,6 +14,33 @@ struct AppConfig: Codable {
 
     static let configPath = NSString(string: "~/.comfybox/config.json").expandingTildeInPath
 
+    // Shared with the server's ComfyBoxServerConfig: canonical keys plus legacy
+    // desktop aliases for reading older files. The server owns the full document;
+    // the desktop only manages these three connection fields.
+    private enum CodingKeys: String, CodingKey {
+        case host, port, allowedOutputDirectory
+        case serverHost, serverPort, outputDirectory // legacy
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        serverHost = try c.decodeIfPresent(String.self, forKey: .host)
+            ?? c.decodeIfPresent(String.self, forKey: .serverHost) ?? "127.0.0.1"
+        serverPort = try c.decodeIfPresent(UInt16.self, forKey: .port)
+            ?? c.decodeIfPresent(UInt16.self, forKey: .serverPort) ?? 7870
+        outputDirectory = try c.decodeIfPresent(String.self, forKey: .allowedOutputDirectory)
+            ?? c.decodeIfPresent(String.self, forKey: .outputDirectory) ?? "~/Pictures/ComfyBox"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(serverHost, forKey: .host)
+        try c.encode(serverPort, forKey: .port)
+        try c.encode(outputDirectory, forKey: .allowedOutputDirectory)
+    }
+
     /// Load config from disk. Returns defaults on any failure.
     static func load() -> AppConfig {
         let path = configPath
@@ -25,15 +52,27 @@ struct AppConfig: Codable {
         return config
     }
 
-    /// Save config to disk, creating ~/.comfybox/ if needed.
+    /// Save the connection fields into the shared ~/.comfybox/config.json, preserving
+    /// any server-owned keys (providers, replicate, modelSpec, …) already in the file.
     func save() throws {
         let dir = NSString(string: "~/.comfybox").expandingTildeInPath
-        try FileManager.default.createDirectory(
-            atPath: dir, withIntermediateDirectories: true
-        )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
-        try data.write(to: URL(fileURLWithPath: AppConfig.configPath))
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let url = URL(fileURLWithPath: AppConfig.configPath)
+
+        var root: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            root = existing
+        }
+        // Write canonical keys; drop legacy aliases so the file converges.
+        root["host"] = serverHost
+        root["port"] = Int(serverPort)
+        root["allowedOutputDirectory"] = outputDirectory
+        root.removeValue(forKey: "serverHost")
+        root.removeValue(forKey: "serverPort")
+        root.removeValue(forKey: "outputDirectory")
+
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
     }
 }

--- a/Sources/ZImage/MCP/MCPServer.swift
+++ b/Sources/ZImage/MCP/MCPServer.swift
@@ -20,7 +20,7 @@ public final class MCPServer {
   /// Server version reported in initialize response.
   public static let version = "1.0.0"
 
-  public init(host: String = "127.0.0.1", port: UInt16 = 7862) {
+  public init(host: String = "127.0.0.1", port: UInt16 = 7870) {
     self.client = WarmServerClient(host: host, port: port)
     self.executor = MCPToolExecutor(client: client)
   }

--- a/Sources/ZImage/MCP/WarmServerClient.swift
+++ b/Sources/ZImage/MCP/WarmServerClient.swift
@@ -13,7 +13,7 @@ public final class WarmServerClient: @unchecked Sendable {
   private let session: URLSession
   private let baseURL: String
 
-  public init(host: String = "127.0.0.1", port: UInt16 = 7862) {
+  public init(host: String = "127.0.0.1", port: UInt16 = 7870) {
     self.host = host
     self.port = port
     self.baseURL = "http://\(host):\(port)"

--- a/Sources/ZImage/Server/ComfyBoxServerConfig.swift
+++ b/Sources/ZImage/Server/ComfyBoxServerConfig.swift
@@ -1,0 +1,251 @@
+// ComfyBoxServerConfig.swift — Unified ComfyBox configuration (~/.comfybox/config.json).
+//
+// P0 of the image-service consolidation: one config model, one canonical port, one
+// AI-provider registry. On first launch (config absent) this non-destructively migrates
+// settings from the retiring Coffee Shop image service under ~/.coffeeshop/.
+
+import Foundation
+
+/// Endpoint config for one AI capability, served by an OpenAI-compatible local server
+/// (e.g. LM Studio). Adding a capability is a new field on ``AIProviderRegistry`` — no fork.
+public struct AIProviderEndpoint: Codable, Equatable, Sendable {
+  public var baseUrl: String
+  public var model: String
+  public var apiKey: String?
+
+  public init(baseUrl: String, model: String, apiKey: String? = nil) {
+    self.baseUrl = baseUrl
+    self.model = model
+    self.apiKey = apiKey
+  }
+}
+
+/// Named-capability → endpoint registry. Optional fields so unconfigured capabilities are absent.
+public struct AIProviderRegistry: Codable, Equatable, Sendable {
+  public var promptOptimization: AIProviderEndpoint?
+  public var vision: AIProviderEndpoint?
+  public var captioning: AIProviderEndpoint?
+
+  public init(
+    promptOptimization: AIProviderEndpoint? = nil,
+    vision: AIProviderEndpoint? = nil,
+    captioning: AIProviderEndpoint? = nil
+  ) {
+    self.promptOptimization = promptOptimization
+    self.vision = vision
+    self.captioning = captioning
+  }
+
+  /// Default prompt-optimization endpoint: LM Studio serving Todd's Dan's Personality Engine model.
+  public static let lmStudioPromptDefault = AIProviderEndpoint(
+    baseUrl: "http://localhost:1234/v1",
+    model: "dans-pe-v1.3.0-24b-heresy@8bit"
+  )
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    promptOptimization = try c.decodeIfPresent(AIProviderEndpoint.self, forKey: .promptOptimization)
+    vision = try c.decodeIfPresent(AIProviderEndpoint.self, forKey: .vision)
+    captioning = try c.decodeIfPresent(AIProviderEndpoint.self, forKey: .captioning)
+  }
+}
+
+/// Replicate (remote video / fallback) configuration.
+public struct ReplicateProviderConfig: Codable, Equatable, Sendable {
+  public var apiKey: String?
+  public var baseUrl: String?
+  public var model: String?
+  public var imageModel: String?
+  public var videoModel: String?
+
+  public init(
+    apiKey: String? = nil,
+    baseUrl: String? = nil,
+    model: String? = nil,
+    imageModel: String? = nil,
+    videoModel: String? = nil
+  ) {
+    self.apiKey = apiKey
+    self.baseUrl = baseUrl
+    self.model = model
+    self.imageModel = imageModel
+    self.videoModel = videoModel
+  }
+}
+
+/// Persistent ComfyBox configuration, stored as a single `~/.comfybox/config.json`.
+///
+/// Decoding tolerates missing keys (partial/older files load with defaults), so the
+/// schema can grow across phases without breaking existing installs.
+public struct ComfyBoxServerConfig: Codable, Equatable, Sendable {
+  public var port: UInt16
+  public var host: String
+  public var modelSpec: String?
+  public var allowedOutputDirectory: String?
+  public var seedvr2WeightsPath: String?
+  public var providers: AIProviderRegistry
+  public var replicate: ReplicateProviderConfig?
+
+  /// The one true ComfyBox HTTP port.
+  public static let canonicalPort: UInt16 = 7870
+  /// Legacy port accepted for one release with a deprecation warning (old WarmServer default,
+  /// image-service warm-worker target). Retires with the Node service.
+  public static let deprecatedAliasPort: UInt16 = 7862
+
+  public init(
+    port: UInt16 = ComfyBoxServerConfig.canonicalPort,
+    host: String = "127.0.0.1",
+    modelSpec: String? = nil,
+    allowedOutputDirectory: String? = nil,
+    seedvr2WeightsPath: String? = nil,
+    providers: AIProviderRegistry = AIProviderRegistry(promptOptimization: AIProviderRegistry.lmStudioPromptDefault),
+    replicate: ReplicateProviderConfig? = nil
+  ) {
+    self.port = port
+    self.host = host
+    self.modelSpec = modelSpec
+    self.allowedOutputDirectory = allowedOutputDirectory
+    self.seedvr2WeightsPath = seedvr2WeightsPath
+    self.providers = providers
+    self.replicate = replicate
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case port, host, modelSpec, allowedOutputDirectory, seedvr2WeightsPath, providers, replicate
+    // Legacy keys written by the desktop AppConfig (read-only, for smooth upgrade).
+    case serverPort, serverHost, outputDirectory
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    port = try c.decodeIfPresent(UInt16.self, forKey: .port)
+      ?? c.decodeIfPresent(UInt16.self, forKey: .serverPort)
+      ?? ComfyBoxServerConfig.canonicalPort
+    host = try c.decodeIfPresent(String.self, forKey: .host)
+      ?? c.decodeIfPresent(String.self, forKey: .serverHost)
+      ?? "127.0.0.1"
+    modelSpec = try c.decodeIfPresent(String.self, forKey: .modelSpec)
+    allowedOutputDirectory = try c.decodeIfPresent(String.self, forKey: .allowedOutputDirectory)
+      ?? c.decodeIfPresent(String.self, forKey: .outputDirectory)
+    seedvr2WeightsPath = try c.decodeIfPresent(String.self, forKey: .seedvr2WeightsPath)
+    // Absent `providers` key → seed the default (e.g. upgrading from an old desktop-only
+    // config). An explicit `providers: {}` is respected as intentionally empty.
+    providers = try c.decodeIfPresent(AIProviderRegistry.self, forKey: .providers)
+      ?? AIProviderRegistry(promptOptimization: AIProviderRegistry.lmStudioPromptDefault)
+    replicate = try c.decodeIfPresent(ReplicateProviderConfig.self, forKey: .replicate)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(port, forKey: .port)
+    try c.encode(host, forKey: .host)
+    try c.encodeIfPresent(modelSpec, forKey: .modelSpec)
+    try c.encodeIfPresent(allowedOutputDirectory, forKey: .allowedOutputDirectory)
+    try c.encodeIfPresent(seedvr2WeightsPath, forKey: .seedvr2WeightsPath)
+    try c.encode(providers, forKey: .providers)
+    try c.encodeIfPresent(replicate, forKey: .replicate)
+  }
+
+  // MARK: - Paths
+
+  public static func homeDirectory() -> URL {
+    URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+  }
+
+  /// `~/.comfybox/config.json`.
+  public static func defaultPath() -> URL {
+    homeDirectory().appendingPathComponent(".comfybox/config.json")
+  }
+
+  /// `~/.coffeeshop/providers.json` (retiring image service).
+  public static func coffeeShopProvidersPath() -> URL {
+    homeDirectory().appendingPathComponent(".coffeeshop/providers.json")
+  }
+
+  /// `~/.coffeeshop/image-service/config.json` (retiring image service).
+  public static func coffeeShopConfigPath() -> URL {
+    homeDirectory().appendingPathComponent(".coffeeshop/image-service/config.json")
+  }
+
+  // MARK: - Load / Save / Migrate
+
+  /// Load `~/.comfybox/config.json`. If absent, auto-migrate from `~/.coffeeshop/`
+  /// (non-destructive), persist the result, and return it.
+  @discardableResult
+  public static func loadOrMigrate(
+    at path: URL = ComfyBoxServerConfig.defaultPath(),
+    coffeeShopProviders: URL = ComfyBoxServerConfig.coffeeShopProvidersPath(),
+    coffeeShopConfig: URL = ComfyBoxServerConfig.coffeeShopConfigPath(),
+    fileManager: FileManager = .default
+  ) -> ComfyBoxServerConfig {
+    if fileManager.fileExists(atPath: path.path),
+       let data = try? Data(contentsOf: path),
+       let config = try? JSONDecoder().decode(ComfyBoxServerConfig.self, from: data) {
+      return config
+    }
+
+    let migrated = migrate(
+      coffeeShopProviders: coffeeShopProviders,
+      coffeeShopConfig: coffeeShopConfig,
+      fileManager: fileManager
+    )
+    try? migrated.save(to: path, fileManager: fileManager)
+    return migrated
+  }
+
+  public func save(to path: URL = ComfyBoxServerConfig.defaultPath(), fileManager: FileManager = .default) throws {
+    let dir = path.deletingLastPathComponent()
+    try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(self)
+    try data.write(to: path, options: .atomic)
+  }
+
+  /// Build a fresh config, folding in whatever the retiring image service left under
+  /// `~/.coffeeshop/`. Originals are only read, never modified.
+  public static func migrate(
+    coffeeShopProviders: URL = ComfyBoxServerConfig.coffeeShopProvidersPath(),
+    coffeeShopConfig: URL = ComfyBoxServerConfig.coffeeShopConfigPath(),
+    fileManager: FileManager = .default
+  ) -> ComfyBoxServerConfig {
+    var config = ComfyBoxServerConfig()
+
+    // providers.json → replicate
+    if fileManager.fileExists(atPath: coffeeShopProviders.path),
+       let data = try? Data(contentsOf: coffeeShopProviders),
+       let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       let rep = root["replicate"] as? [String: Any] {
+      config.replicate = ReplicateProviderConfig(
+        apiKey: rep["apiKey"] as? String,
+        baseUrl: rep["baseUrl"] as? String,
+        model: rep["model"] as? String,
+        imageModel: rep["imageModel"] as? String,
+        videoModel: rep["videoModel"] as? String
+      )
+    }
+
+    // image-service config.json → prompt-optimization endpoint + output dir
+    if fileManager.fileExists(atPath: coffeeShopConfig.path),
+       let data = try? Data(contentsOf: coffeeShopConfig),
+       let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      if let enhancer = root["enhancer"] as? [String: Any],
+         let baseUrl = enhancer["baseUrl"] as? String, !baseUrl.isEmpty {
+        config.providers.promptOptimization = AIProviderEndpoint(
+          baseUrl: baseUrl,
+          model: (enhancer["model"] as? String) ?? AIProviderRegistry.lmStudioPromptDefault.model,
+          apiKey: enhancer["apiKey"] as? String
+        )
+      }
+      if let outputDir = (root["outputDir"] ?? root["outputDirectory"]) as? String, !outputDir.isEmpty {
+        config.allowedOutputDirectory = outputDir
+      }
+    }
+
+    // Always leave prompt optimization pointing somewhere usable.
+    if config.providers.promptOptimization == nil {
+      config.providers.promptOptimization = AIProviderRegistry.lmStudioPromptDefault
+    }
+    return config
+  }
+}

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -22,7 +22,7 @@ public struct WarmServerConfiguration: Sendable {
   public var seedvr2WeightsPath: String?
 
   public init(
-    port: UInt16 = 7862,
+    port: UInt16 = ComfyBoxServerConfig.canonicalPort,
     modelSpec: String? = nil,
     textEncoderPath: String? = nil,
     initialLoRAs: [LoRAConfiguration] = [],
@@ -470,6 +470,55 @@ public final class WarmServer {
         return .json(.rawJSON(status: 200, data: data))
       }
       return .error(.error(status: 500, message: "Failed to serialize styles"))
+
+    // MARK: - Config
+    // The config document is served/accepted in its canonical camelCase shape (matching
+    // ~/.comfybox/config.json and the desktop's plain Codable) — not the snake_case DTO
+    // convention used by the render/status routes.
+
+    case ("GET", "/v1/config"):
+      let config = ComfyBoxServerConfig.loadOrMigrate()
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+      if let data = try? encoder.encode(config) {
+        return .json(.rawJSON(status: 200, data: data))
+      }
+      return .error(.error(status: 500, message: "Failed to serialize config"))
+
+    case ("PUT", "/v1/config"):
+      do {
+        let updated = try JSONDecoder().decode(ComfyBoxServerConfig.self, from: request.body)
+        try updated.save()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(updated)
+        // Port/host changes take effect on next server start; the running listener is unchanged.
+        return .json(.rawJSON(status: 200, data: data))
+      } catch {
+        return .error(.error(status: 400, message: "Invalid config: \(error.localizedDescription)"))
+      }
+
+    case ("GET", "/v1/providers/status"):
+      let config = ComfyBoxServerConfig.loadOrMigrate()
+      func status(_ endpoint: AIProviderEndpoint?) -> [String: Any] {
+        guard let endpoint else { return ["configured": false] }
+        return [
+          "configured": true,
+          "model": endpoint.model,
+          "base_url": endpoint.baseUrl,
+          "has_api_key": !(endpoint.apiKey ?? "").isEmpty,
+        ]
+      }
+      let payload: [String: Any] = [
+        "prompt_optimization": status(config.providers.promptOptimization),
+        "vision": status(config.providers.vision),
+        "captioning": status(config.providers.captioning),
+        "replicate": ["configured": !(config.replicate?.apiKey ?? "").isEmpty],
+      ]
+      if let data = try? JSONSerialization.data(withJSONObject: payload) {
+        return .json(.rawJSON(status: 200, data: data))
+      }
+      return .error(.error(status: 500, message: "Failed to serialize provider status"))
 
     // MARK: - Model Pool Endpoints
 

--- a/Sources/ZImage/Telegram/ImageBotCoordinator.swift
+++ b/Sources/ZImage/Telegram/ImageBotCoordinator.swift
@@ -25,7 +25,7 @@ public final class ImageBotCoordinator {
     public init(
       telegram: TelegramBot.Configuration,
       warmServerHost: String = "127.0.0.1",
-      warmServerPort: UInt16 = 7862,
+      warmServerPort: UInt16 = 7870,
       outputDirectory: String = ("~/Pictures/ComfyBox/Telegram" as NSString).expandingTildeInPath,
       galleryDirectory: String? = nil,
       optimizer: PromptOptimizer.Configuration = PromptOptimizer.Configuration(),

--- a/Tests/ZImageTests/Server/ComfyBoxServerConfigTests.swift
+++ b/Tests/ZImageTests/Server/ComfyBoxServerConfigTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import ZImage
+
+final class ComfyBoxServerConfigTests: XCTestCase {
+
+  private func makeTempDir() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-config-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  // MARK: - Defaults & constants
+
+  func testDefaultsUseCanonicalPortAndLMStudioProvider() {
+    let config = ComfyBoxServerConfig()
+    XCTAssertEqual(config.port, 7870)
+    XCTAssertEqual(ComfyBoxServerConfig.canonicalPort, 7870)
+    XCTAssertEqual(ComfyBoxServerConfig.deprecatedAliasPort, 7862)
+    XCTAssertEqual(config.host, "127.0.0.1")
+    XCTAssertEqual(config.providers.promptOptimization?.model, "dans-pe-v1.3.0-24b-heresy@8bit")
+    XCTAssertEqual(config.providers.promptOptimization?.baseUrl, "http://localhost:1234/v1")
+  }
+
+  // MARK: - Codable round-trip & tolerant decode
+
+  func testRoundTripEncodeDecode() throws {
+    var config = ComfyBoxServerConfig(port: 7870, host: "0.0.0.0", modelSpec: "z-image-turbo")
+    config.providers.vision = AIProviderEndpoint(baseUrl: "http://localhost:1235/v1", model: "moondream")
+    config.replicate = ReplicateProviderConfig(apiKey: "k", videoModel: "kwaivgi/kling-v1.6-standard")
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(ComfyBoxServerConfig.self, from: data)
+    XCTAssertEqual(config, decoded)
+  }
+
+  func testPartialJSONDecodesWithDefaults() throws {
+    // Only a host is provided; everything else must fall back to defaults.
+    let json = Data(#"{ "host": "192.168.1.5" }"#.utf8)
+    let config = try JSONDecoder().decode(ComfyBoxServerConfig.self, from: json)
+    XCTAssertEqual(config.host, "192.168.1.5")
+    XCTAssertEqual(config.port, 7870)
+    // Absent providers key seeds the LM Studio default (smooth upgrade from bare configs).
+    XCTAssertEqual(config.providers.promptOptimization, AIProviderRegistry.lmStudioPromptDefault)
+    XCTAssertNil(config.replicate)
+  }
+
+  func testExplicitEmptyProvidersIsRespected() throws {
+    let json = Data(#"{ "host": "h", "providers": {} }"#.utf8)
+    let config = try JSONDecoder().decode(ComfyBoxServerConfig.self, from: json)
+    XCTAssertNil(config.providers.promptOptimization) // explicit empty stays empty
+  }
+
+  func testDecodesLegacyDesktopKeys() throws {
+    // The desktop's old AppConfig shape must still load (and preserve the output dir).
+    let json = Data(#"{ "serverHost": "127.0.0.1", "serverPort": 7870, "outputDirectory": "~/Pictures/ComfyBox" }"#.utf8)
+    let config = try JSONDecoder().decode(ComfyBoxServerConfig.self, from: json)
+    XCTAssertEqual(config.host, "127.0.0.1")
+    XCTAssertEqual(config.port, 7870)
+    XCTAssertEqual(config.allowedOutputDirectory, "~/Pictures/ComfyBox")
+
+    // Re-encoding writes canonical keys, not the legacy ones.
+    let reEncoded = try JSONSerialization.jsonObject(with: try JSONEncoder().encode(config)) as? [String: Any]
+    XCTAssertEqual(reEncoded?["host"] as? String, "127.0.0.1")
+    XCTAssertNil(reEncoded?["serverHost"])
+    XCTAssertNil(reEncoded?["outputDirectory"])
+  }
+
+  // MARK: - Save / load
+
+  func testSaveThenLoadRoundTrips() throws {
+    let dir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let path = dir.appendingPathComponent("config.json")
+
+    let original = ComfyBoxServerConfig(port: 7870, host: "127.0.0.1", modelSpec: "chroma")
+    try original.save(to: path)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+    let loaded = ComfyBoxServerConfig.loadOrMigrate(at: path)
+    XCTAssertEqual(loaded.modelSpec, "chroma")
+    XCTAssertEqual(loaded.port, 7870)
+  }
+
+  // MARK: - Migration (non-destructive)
+
+  func testMigrateFoldsReplicateAndEnhancerLeavingOriginalsUntouched() throws {
+    let dir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let providers = dir.appendingPathComponent("providers.json")
+    let providersJSON = Data(#"""
+    { "replicate": { "apiKey": "sk-x", "model": "prunaai/z-image-turbo", "videoModel": "kwaivgi/kling-v1.6-standard" } }
+    """#.utf8)
+    try providersJSON.write(to: providers)
+
+    let csConfig = dir.appendingPathComponent("image-service-config.json")
+    let csJSON = Data(#"""
+    { "enhancer": { "baseUrl": "http://localhost:4321/v1", "model": "my-optimizer", "apiKey": "e-key" }, "outputDir": "/tmp/renders" }
+    """#.utf8)
+    try csJSON.write(to: csConfig)
+
+    let migrated = ComfyBoxServerConfig.migrate(coffeeShopProviders: providers, coffeeShopConfig: csConfig)
+
+    XCTAssertEqual(migrated.replicate?.apiKey, "sk-x")
+    XCTAssertEqual(migrated.replicate?.videoModel, "kwaivgi/kling-v1.6-standard")
+    XCTAssertEqual(migrated.providers.promptOptimization?.baseUrl, "http://localhost:4321/v1")
+    XCTAssertEqual(migrated.providers.promptOptimization?.model, "my-optimizer")
+    XCTAssertEqual(migrated.allowedOutputDirectory, "/tmp/renders")
+
+    // Originals are read-only: contents unchanged.
+    XCTAssertEqual(try Data(contentsOf: providers), providersJSON)
+    XCTAssertEqual(try Data(contentsOf: csConfig), csJSON)
+  }
+
+  func testMigrateWithNoSourcesFallsBackToLMStudioDefault() {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-absent-\(UUID().uuidString)", isDirectory: true)
+    let migrated = ComfyBoxServerConfig.migrate(
+      coffeeShopProviders: dir.appendingPathComponent("providers.json"),
+      coffeeShopConfig: dir.appendingPathComponent("config.json")
+    )
+    XCTAssertEqual(migrated.providers.promptOptimization, AIProviderRegistry.lmStudioPromptDefault)
+    XCTAssertNil(migrated.replicate)
+  }
+
+  func testLoadOrMigrateWritesFileOnFirstLaunch() throws {
+    let dir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let path = dir.appendingPathComponent("nested/config.json")
+    let absent = dir.appendingPathComponent("nope.json")
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: path.path))
+    let config = ComfyBoxServerConfig.loadOrMigrate(at: path, coffeeShopProviders: absent, coffeeShopConfig: absent)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path.path), "first launch should persist config")
+    XCTAssertEqual(config.port, 7870)
+    XCTAssertEqual(config.providers.promptOptimization, AIProviderRegistry.lmStudioPromptDefault)
+  }
+}

--- a/docs/superpowers/specs/2026-07-02-P0-config-foundation-spec.md
+++ b/docs/superpowers/specs/2026-07-02-P0-config-foundation-spec.md
@@ -1,0 +1,60 @@
+# P0 — Config Foundation & Port Reconciliation (spec)
+
+**Date:** 2026-07-02
+**Parent:** `2026-07-02-imageservice-into-comfybox-decomposition.md` (P0)
+**Status:** Draft spec — awaiting review before implementation
+**Goal:** Establish one config model, one canonical port, and one AI-provider registry in ComfyBox so later phases (mflux-free model ports, queue, creative layer, media library) have a stable foundation — *before* any feature moves off the Node service. No feature migration in P0; this is plumbing + a migration path.
+
+---
+
+## Current state (measured)
+
+**Image service (`~/Projects/coffeeshop-image-service`):**
+- Data dir: `~/.coffeeshop/image-service/`
+- Config: `~/.coffeeshop/image-service/config.json` — big `ImageServiceConfig` (port **7861**, presets, immich, replicate, enhancer, warmWorker, smartTabs, …)
+- **Shared providers: `~/.coffeeshop/providers.json`** (env override `COFFEESHOP_PROVIDER_CONFIG`) — the AI-provider/endpoint config (Replicate, LM Studio, etc.)
+- Queue state + media library index live under the data dir.
+
+**ComfyBox:**
+- Desktop `AppConfig`: `~/.comfybox/config.json` — `serverHost`, `serverPort` **7870**.
+- WarmServer coded default port: **7862** (`WarmServer.swift:25`).
+- Image-service `warm-worker` calls ComfyBox at **`localhost:7862`**.
+- DAM: `~/.comfybox/dam.sqlite3`.
+
+### ⚠️ Live port inconsistency (fix in P0)
+Three ports are in play — **7861** (image service), **7862** (WarmServer default + what warm-worker calls), **7870** (what the desktop app expects). Desktop config says 7870 but the server defaults to 7862, so desktop↔server only works if a config file overrides the port. This must collapse to **one canonical port**.
+
+---
+
+## P0 scope
+
+1. **Canonical port.** Pick one ComfyBox HTTP port and make server default + desktop default + docs agree. **Recommendation: 7870** (already the desktop externalized default; a857040). Keep 7862 accepted for one release as a compatibility alias so the image-service warm-worker and any Krita config keep working during transition; log a deprecation when it's used. Retire 7861 with the Node service.
+
+2. **Config location + model.** Standardize on **`~/.comfybox/`** as ComfyBox's home. Extend the server side beyond the desktop `AppConfig` (host/port only) to a fuller `ComfyBoxConfig` that will absorb the fields later phases need (output dir, default model, provider registry, queue, media, immich, replicate). Add `/v1/config` GET/PUT so the UI can read/write it. Decide: **one `config.json`** with sub-sections, vs. separate files per concern. *Recommendation: one `config.json` + the separate `providers.json` (below), mirroring the image service's split so provider secrets stay isolated.*
+
+3. **AI-provider registry** (ties to `comfybox-configurable-ai-providers`). A **`providers` section inside `~/.comfybox/config.json`** (migrated from `~/.coffeeshop/providers.json`) modeling a map of **named capabilities → endpoint config**:
+   - `promptOptimization` → `{ baseUrl: "http://localhost:1234/v1", model: "dans-pe-v1.3.0-24b-heresy@8bit", apiKey?: "" }` (LM Studio).
+   - `vision`, `captioning` → present in the schema but unconfigured/optional.
+   - Plus the existing `replicate` block (for video). Adding a capability = a new key + a Settings row; no code fork.
+   Expose `/v1/providers/status` (already an image-service route) so the UI can show which capabilities are configured/reachable.
+
+4. **Ancillary read-only routes** the UI/consolidation need early, thin passthroughs over the above: `/v1/catalog` (models/modes), `/v1/stats`, `/v1/memory`, `/v1/audit-log`. (Enhancer route `/v1/enhance*` is P4, but its provider config lands here.)
+
+5. **Migration.** A one-shot migrator (CLI subcommand `comfybox migrate-config` or automatic on first launch) that: reads `~/.coffeeshop/providers.json` → writes `~/.comfybox/providers.json`; maps the still-relevant `ImageServiceConfig` fields (output dir, replicate, immich, enhancer) into `ComfyBoxConfig`; leaves the old files untouched (non-destructive). Presets/characters/media are **not** migrated in P0 (their phases own that).
+
+---
+
+## Explicitly out of scope for P0
+Dual-lane queue (P2), creative-layer stores (P3), enhancer execution + events (P4), media-library unification (P5), any model port. P0 only creates the config surfaces they will populate.
+
+## Decisions (confirmed)
+1. **Canonical port = 7870** — server default + desktop default. `7862` accepted for one release as a deprecation-logged alias (warm-worker / Krita configs). `7861` retires with the Node service.
+2. **Single combined `~/.comfybox/config.json`** — one file with sub-sections, including the AI-provider registry inline (no separate `providers.json`). Migrator folds `~/.coffeeshop/providers.json` into this file's provider section.
+3. **Automatic migration on first launch** — non-destructive (reads `~/.coffeeshop`, writes `~/.comfybox/config.json`, leaves originals untouched). No separate CLI command required.
+
+## Acceptance
+- Server and desktop default to the same port with no config file present; 7862 still works with a deprecation log.
+- `~/.comfybox/providers.json` exists with the `promptOptimization` entry pointing at the LM Studio model; `/v1/providers/status` reports it.
+- `/v1/config` round-trips (GET returns current, PUT persists, reload reflects).
+- Migrator copies `providers.json` from `~/.coffeeshop` without modifying the originals.
+- New unit tests: config load/default/round-trip, provider-registry parse, migrator mapping. No server/model/network needed.

--- a/docs/superpowers/specs/2026-07-02-imageservice-into-comfybox-decomposition.md
+++ b/docs/superpowers/specs/2026-07-02-imageservice-into-comfybox-decomposition.md
@@ -1,0 +1,118 @@
+# Consolidating Coffee Shop Image Service into ComfyBox — Decomposition
+
+**Date:** 2026-07-02
+**Status:** Draft decomposition (awaiting user confirmation on two forks)
+**Goal:** Move *all* functionality of `~/Projects/coffeeshop-image-service` (Node backend + Electron/React UI) into ComfyBox (Swift WarmServer + ComfyBoxDesktop SwiftUI app), then **retire the old image service**. The Swift desktop app becomes the unified front end for both the ComfyBox image engine and the "Coffee Shop" creative layer.
+
+---
+
+## Confirmed constraints
+
+- **No Python, ever.** ComfyBox is self-standing Swift/MLX. It must **not** spawn `mflux-*` or any Python. Every surviving mflux capability is reimplemented natively. (See memory `comfybox-no-python`.)
+- **LoRA training is dropped.** `mflux-train` retires with mflux. ComfyBox keeps native inference + LoRA *bake/apply* (already native); training is out of scope, possibly a separate offline tool someday.
+- **Model priorities (confirmed).**
+  - **Z-Image Turbo** — default, already native. No work.
+  - **Zeta-Chroma** (art creation) — the model Todd actually wants for art. **NOT the existing `Sources/ZImage/Chroma` family** (that one is lodestone's Flux-based Chroma — "not heavy", leave as-is). Zeta-Chroma (`lodestones/Zeta-Chroma`) is built *on Z-Image*: same DiT lineage + Qwen3-4B encoder + **Flux 2 VAE** (all already native in ComfyBox), with three deltas to implement: a **DeCo head**, **fm-x0 prediction** (vs Z-Image's velocity — a scheduler mode), and a **pixel-space** variant that skips the VAE. So it's a **Z-Image *variant* port, not a new family** — small relative to the others. Caveat: it's in **early upstream pretraining (WIP, Apache 2.0)**; port once lodestone stabilizes weights/arch.
+  - **Fibo, Flux2 (= FLUX.2 Klein)** — already native. **Klein = the Flux2 family** (`Flux2Pipeline` is "Flux 2 Klein", IDs `black-forest-labs/FLUX.2-klein-{4B,9B,base}`). Text-to-image ✅ and img2img ✅ (`inputImagePath` + `denoise<1.0`). **GAP: Klein inpainting (masked fill)** — no `mask` param / fill path today. **Higher priority than Chroma** (Todd's call). Contained add: reuse the Z-Image masked-denoise loop (`ZImageControlPipeline`: per-step re-noise + mask composite) on the Flux2 latent/VAE, + a `mask` input on `Flux2GenerationConfig`. Not a model port — a feature on an existing one.
+  - **Existing Flux-based Chroma** — **already fully supported** (ModelPool `.chroma`, detection, CLI). Todd rarely uses it → **low priority, nothing to do.**
+  - **Qwen-Image (+edit) incl. Krea-2** — the main new *family* port (Krea-2 is Qwen-based).
+  - **Depth (Depth Anything) + concept/IP-adapter** — preprocessors.
+  - **FLUX editing** (Kontext/Fill/Redux/in-context/CatVTON) — optional.
+  - **FLUX.1** (dev/schnell/krea) — **deprioritized**; Todd rarely uses it now.
+- **Sequencing = backend-first.** Grow WarmServer into a superset of the image-service API, cut the Electron backend over, then port the UI views, then delete the Electron app. The UI always has a stable target.
+
+---
+
+## Current state (measured)
+
+| | Backend | UI |
+|---|---|---|
+| **Image service (retiring)** | `src/` Node/TS, ~9,240 LOC, HTTP on **:7861**, launchd daemon | Electron/React renderer, ~7,829 LOC, 11 views |
+| **ComfyBox (target)** | `Sources/ZImage/Server` Swift WarmServer on **:7870** (native MLX, mflux-free) | `Sources/ComfyBoxDesktop` SwiftUI, 4 tabs + DAM (SQLite) |
+
+**Key relationship to reverse:** the image service currently delegates *some* generation to ComfyBox's warm server (`src/zimage-warm-client.ts` / `warm-worker.ts` → `localhost:7862`). After consolidation ComfyBox is no longer a sub-worker — it *is* the daemon. The `warm-worker` concept disappears.
+
+**Persistence to migrate** (image service stores under `~/.coffeeshop/` + a data dir): `providers.json`, config, queue-state, media-library index, presets, characters, projects, shot-templates, smart-tabs. ComfyBox stores config under `~/.comfybox/` and its DAM at `~/.comfybox/dam.sqlite3`.
+
+---
+
+## API surface delta (image-service routes → ComfyBox)
+
+ComfyBox **already has** (some names differ): `/health`, `/v1/generate`, `/v1/queue` (bridge), `/v1/models`, `/v1/loras` (+scan/swap), `/v1/upscale`, `/v1/video/generate` + status, `/v1/model/*` pool, `/v1/styles`, `/ws`.
+
+ComfyBox **must gain** to reach parity:
+
+| Route(s) | Subsystem | Notes |
+|---|---|---|
+| `/v1/mflux`, `/mflux/{bake,save,depth,info}` | **Native tools** (no bridge) | Reframed as native ops. `bake`/`save`/`info` ComfyBox already has natively; `depth` needs a native depth model. **`train` and `upgrade` are dropped** (Python-only). |
+| `/v1/characters` | **Character registry** | ComfyBox has a stub that 404s today. |
+| `/v1/presets`, `/v1/presets/resolve` | **Presets** | ComfyBox desktop has local `presets.json`; server-side presets + resolve are new. |
+| `/v1/projects` | **Projects** | New. |
+| `/v1/shot-templates` | **Shot templates** | New. |
+| `/v1/smart-tabs` (+ `/`) | **Smart tabs** | New. |
+| `/v1/content-modes` | **Content modes** (neutral/banana/avocado) | Guidance boost + style variants. Telegram bot already has a content-mode notion — unify. |
+| `/v1/enhance` (+`/preview`,`/status`) | **Prompt enhancer** | LLM via OpenAI-compatible endpoint. ComfyBox desktop *calls* `/v1/enhance` already but the server route doesn't exist — this closes that gap. |
+| `/v1/assets` (+`/folders`,`/rescan`,`/export/immich`) | **Media library** | Overlaps ComfyBox DAM; unify onto DAM + add folders/rescan/Immich export. |
+| `/v1/immich/status` | **Immich integration** | External photo server export. |
+| `/v1/events` (SSE) | **Event stream** | ComfyBox uses WebSocket (`/ws`) for progress; either add SSE or migrate UI to WS. |
+| `/v1/jobs` (+`/batch`,`/explore`) | **Job model** | Richer than current queue; maps onto dual-lane queue. |
+| `/v1/config`, `/v1/prompt-config`, `/v1/catalog`, `/v1/stats`, `/v1/memory`, `/v1/audit-log`, `/v1/providers/status`, `/v1/uploads/image` | **Misc infra** | Config, catalog, memory guard, audit log, provider status, uploads. |
+| dual-lane queue (`chat` / `hq`) | **Queue** | Replace ComfyBox's single FIFO coordinator with two lanes + pause/resume/mutate/duplicate. Careful: the FIFO actor is load-bearing and was just hardened. |
+
+---
+
+## Decomposition into sub-projects (backend-first order)
+
+Each is its own spec → plan → build cycle. Ordered by dependency and risk.
+
+**P0 — Foundation & config unification.** Reconcile `~/.coffeeshop/` and `~/.comfybox/` config models; decide canonical port (keep :7870, alias :7861 during transition); add `/v1/config`, `/v1/providers/status`, `/v1/catalog`, `/v1/stats`, `/v1/memory`, `/v1/audit-log`; data-migration script for existing presets/characters/etc.
+
+**P1 — Native model-family ports (no Python).** Each is its own spec-sized effort; ComfyBox already has the pipeline scaffolding (families share `SafeTensorsReader`, `ModelPool`, scheduler stack — Chroma's VAE-reuse is the template). Sub-items, **in confirmed priority order**:
+- **P1a — Qwen-Image (+edit) incl. Krea-2** — the main new *family* port. Qwen is only a text encoder in ComfyBox today; this adds Qwen *image generation*. Replaces `-qwen`,`-qwen-edit`.
+- **P1b — Depth (Depth Anything) + concept/IP-adapter preprocessors** — replaces `-generate-depth`,`-save-depth`,`-concept*`.
+- **P1c — FLUX editing** (Kontext / Fill / Redux / in-context / CatVTON) — optional; replaces `-kontext`,`-fill`,`-redux`,`-in-context*`.
+- **P1-Klein-fill — Klein (Flux2) generative fill: inpaint + outpaint** — **prioritized** (Todd; key for Krita). **Outpaint = inpaint with the mask on extended canvas** — one feature, not two. The whole delivery path already exists for Z-Image and works via Krita: ComfyBridge carries `inpaintImageId`+`maskImageId` and advertises the inpaint nodes; WarmServer passes `maskImage/maskData/denoise/maskGrow/maskFeather/maskCropX,Y`; `ZImageControlPipeline` consumes them. **The only gap is Flux2/Klein has no mask path** (`Flux2GenerationConfig` has no `mask`). Work = add a `mask` input to `Flux2GenerationConfig` + port the Z-Image masked-denoise loop (per-step re-noise + composite) onto the Flux2 latent/VAE, then route Klein through the existing bridge inpaint path. Test seam quality on outpaint (mask over blank margin). Replaces `mflux-generate-fill`.
+- **P1d — FLUX.1** (dev/schnell/krea) — **deprioritized** (rarely used now); port late or skip. Replaces `mflux-generate`.
+- **P1e — Zeta-Chroma** (art) — **LOW PRIORITY, deferred until the model matures** (early upstream pretraining). A **Z-Image variant**, not a new family: reuses native Z-Image DiT + Qwen3-4B encoder + Flux2 VAE; new code is the DeCo head, an fm-x0 scheduler mode, and a pixel-space (VAE-less) decode path. **A prior Python/MLX port exists as reference** (`~/Projects/coffeeshop-server/scripts/zeta-chroma-mlx.py`, `chroma-generate/ZETA_CHROMA_IMPLEMENTATION_PLAN.md`) — re-port to native Swift.
+- Already native, no port: **Z-Image/Turbo (default)**, existing Chroma (Flux-based, low priority), Fibo, Flux2, SeedVR2/ESRGAN upscale, quantize/save, inpaint/fill (Z-Image), ControlNet (Z-Image), info.
+- **Dropped:** `mflux-train` (training), `mflux-upgrade` (Python version mgmt).
+
+**P2 — Dual-lane queue.** Extend the WarmServer coordinator to two lanes (chat/hq) with pause/resume/cancel/mutate/duplicate and the `/v1/jobs` model. Must preserve the leaked-continuation safety the current actor has.
+
+**P3 — Creative layer.** Character registry, presets + resolve, projects, shot-templates, smart-tabs, content modes. Mostly CRUD over JSON stores → Swift `Codable` + files (or DAM's SQLite).
+
+**P4 — Configurable local-AI providers + prompt enhancer + events.**
+- **AI provider registry (new, UI-configurable):** a set of *named capabilities* — `promptOptimization` (now), `vision` and `captioning` (future) — each independently configured to an OpenAI-compatible local endpoint (base URL, model id, api key). Current preference: a **"Dan's" model in LM Studio** for prompt optimization. Backed by `~/.coffeeshop`/`~/.comfybox` `providers.json` (image service already has `getSharedProviderConfigPath()` → `~/.coffeeshop/providers.json` — reuse/migrate). Must be extensible: adding a new capability = a new config entry + a Settings panel row, no code fork.
+- **Prompt enhancer:** `/v1/enhance*` consumes the `promptOptimization` provider. ComfyBox desktop already *calls* `/v1/enhance` but the route doesn't exist server-side — this closes that gap.
+- **Events:** the SSE (`/v1/events`) vs unify-on-WebSocket decision (defer to P4 spec).
+
+**P5 — Media library unification.** Fold `/v1/assets*` onto the ComfyBox DAM; add folders, rescan, sidecar parity, Immich export + status.
+
+**P6 — Backend cutover.** Point any remaining image-service consumers (Telegram bot, Obsidian Coffee Shop plugin, `warm-worker` callers) at ComfyBox; retire the Node daemon + launchd plist.
+
+**P7 — UI port + UX upgrades (not a 1:1 clone).** Bring the Electron views into ComfyBoxDesktop as SwiftUI (Dashboard, Queue, Gallery, Presets, Characters, Models&LoRAs, Config, Server, plus the current Generate/Compare). Reference the React components for layout/behavior, not code. **Three areas are explicitly to be *improved*, not just ported (Todd):**
+- **LoRA management** — beyond the current library list: browse/search/filter the LoRA library (uses `LoRALibrary`/`LoRAScanner`/compatibility already in-tree), trigger/adjust the multi-LoRA stack with live scales (incl. negative/slider LoRAs per the MCP scale change), see compatibility/quarantine state, import + metadata. Replaces the Electron `ModelsAndLoras` + `LoraImportDialog`.
+- **Prompt management** — a real prompt workflow: history, reusable snippets/wildcards, the configurable prompt-optimizer (P4 provider) inline with before/after preview, per-preset prompt+negative, and prompt metadata surfaced from the DAM. Replaces scattered prompt fields.
+- **DAM functions** — richer than today's basic Gallery: folders, robust FTS search over prompt/seed/model (fixing the current FTS-dup + annotation-loss bugs from the remediation pass), rating/favorite/tags, compare, sidecar metadata for app-generated images, Immich export. Builds on `DAMStore`.
+
+The rest of the views are straight ports. **Note:** MfluxTools view is dropped (Python tools retired); its still-native actions (bake/save/quantize/depth) resurface inside the LoRA/model management UI.
+
+**P8 — Electron retirement.** Delete the Electron renderer + main process; keep the old repo archived or reduce it to the mflux Python venv if that's where mflux lives.
+
+---
+
+## Open decisions to confirm
+
+1. ~~mflux strategy~~ — **Resolved: native only, no Python. Training dropped.**
+2. ~~"Krea2"~~ — **Resolved: Krea-2 is a Qwen-based model; folds into the Qwen-Image port (P1a).**
+3. ~~Model-port priority~~ — **Resolved: Qwen-Image/Krea-2 (P1a) → depth/concept (P1b) → FLUX editing (P1c, optional) → FLUX.1 (P1d, deprioritized). Z-Image Turbo + Chroma already native.**
+4. ~~AI provider config~~ — **Resolved: prompt-opt = `dans-pe-v1.3.0-24b-heresy@8bit` via LM Studio (`http://localhost:1234/v1`); vision + captioning stubbed for later.**
+5. **Event transport** — add SSE `/v1/events` for compatibility, or migrate the new UI to the existing WebSocket? (Defer to P4.)
+6. **Queue model** — replace the just-hardened single-FIFO actor with dual lanes, or run dual lanes *on top of* it? (Defer to P2, but flag: don't regress the continuation-safety work.)
+7. **Content modes** — the ComfyBox Telegram bot and the image service each have their own content-mode notion; pick one canonical implementation.
+
+---
+
+## Relationship to the in-flight remediation branch
+
+A separate multi-agent remediation is currently fixing review findings on `claude/queue-progress-telemetry` (desktop/Telegram snake_case decode bugs, server security, control-pipeline CFG cache, LoRA alpha, CI, and the ComfyBridge/Krita integration). **That work should land first** — it stabilizes exactly the surfaces (WarmServer response contract, DAM, desktop client, queue telemetry) that P0–P2 here build on. This consolidation starts from the post-remediation baseline.


### PR DESCRIPTION
First phase of the Coffee Shop image-service → ComfyBox consolidation (supersedes #187, rebased onto main after #186 merged).

## What this does
- **One config model** — `~/.comfybox/config.json` via `ComfyBoxServerConfig` (tolerant decode so the schema grows across phases).
- **AI-provider registry** — `promptOptimization`/`vision`/`captioning`, each an OpenAI-compatible local endpoint; default seeds LM Studio `dans-pe-v1.3.0-24b-heresy@8bit`.
- **Canonical port 7870** everywhere; `7862` kept as a deprecation-logged alias. Fixes the prior server(7862)/desktop(7870) split.
- **Non-destructive auto-migration** on first launch from `~/.coffeeshop`.
- **Shared desktop/server schema** with legacy-key reading + key-preserving desktop merge-save.
- **Routes** — `GET`/`PUT /v1/config`, `GET /v1/providers/status` (no secrets).

## Verification
- Config unit suite 9/9, ComfyBoxDesktopTests 89/89, CLI builds, live `/v1/config` + `/v1/providers/status` round-trip against an existing legacy config (file left unchanged).

Note: repo CI `typecheck` job has been failing on all of `main` for ~1 month (MLX Metal shader compile times out on hosted runners) — unrelated infra issue, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)