### PR TITLE
UI port #1: AI-provider Settings panel

### DIFF
--- a/Sources/ComfyBoxDesktop/EngineService.swift
+++ b/Sources/ComfyBoxDesktop/EngineService.swift
@@ -674,6 +674,34 @@ public final class EngineService {
         }
     }
 
+    // MARK: - Server Config (/v1/config)
+
+    /// Fetch the server config document (~/.comfybox/config.json). The config document
+    /// is canonical camelCase, decoded with a plain decoder (not the snake_case API DTOs).
+    public func fetchServerConfig() async throws -> ComfyBoxServerConfig {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+        let (status, data) = try await client.get("/v1/config")
+        guard status == 200 else {
+            throw EngineServiceError.serverError(status, parseErrorMessage(from: data) ?? "Failed to load config")
+        }
+        return try JSONDecoder().decode(ComfyBoxServerConfig.self, from: data)
+    }
+
+    /// Persist the full server config document. PUT replaces the document, so callers
+    /// should fetch, mutate, and save to preserve fields they don't manage.
+    public func saveServerConfig(_ config: ComfyBoxServerConfig) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+        let body = try JSONEncoder().encode(config)
+        let (status, data) = try await client.put("/v1/config", body: body)
+        guard status == 200 else {
+            throw EngineServiceError.serverError(status, parseErrorMessage(from: data) ?? "Failed to save config")
+        }
+    }
+
     // MARK: - Helpers
 
     private func parseErrorMessage(from data: Data) -> String? {

--- a/Sources/ComfyBoxDesktop/Views/SettingsView.swift
+++ b/Sources/ComfyBoxDesktop/Views/SettingsView.swift
@@ -5,6 +5,54 @@
 // persist to ~/.comfybox/desktop-config.json.
 
 import SwiftUI
+import ZImage
+
+// MARK: - AI Provider form models
+
+/// Editable string fields for one AI-provider endpoint, mapped to/from `AIProviderEndpoint`.
+struct EndpointForm {
+    var baseUrl: String = ""
+    var model: String = ""
+    var apiKey: String = ""
+
+    init() {}
+    init(_ endpoint: AIProviderEndpoint?) {
+        baseUrl = endpoint?.baseUrl ?? ""
+        model = endpoint?.model ?? ""
+        apiKey = endpoint?.apiKey ?? ""
+    }
+
+    /// A configured endpoint requires both a base URL and a model; otherwise it's absent.
+    func toEndpoint() -> AIProviderEndpoint? {
+        let b = baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let m = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !b.isEmpty, !m.isEmpty else { return nil }
+        let k = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return AIProviderEndpoint(baseUrl: b, model: m, apiKey: k.isEmpty ? nil : k)
+    }
+}
+
+/// The full editable provider registry for the Settings form.
+struct ProviderFormBundle {
+    var prompt = EndpointForm()
+    var vision = EndpointForm()
+    var captioning = EndpointForm()
+
+    init() {}
+    init(_ registry: AIProviderRegistry) {
+        prompt = EndpointForm(registry.promptOptimization)
+        vision = EndpointForm(registry.vision)
+        captioning = EndpointForm(registry.captioning)
+    }
+
+    func toRegistry() -> AIProviderRegistry {
+        AIProviderRegistry(
+            promptOptimization: prompt.toEndpoint(),
+            vision: vision.toEndpoint(),
+            captioning: captioning.toEndpoint()
+        )
+    }
+}
 
 // MARK: - Settings Storage
 
@@ -83,6 +131,12 @@ struct SettingsView: View {
     @State private var hasUnsavedChanges: Bool = false
     @State private var showingSaveConfirmation: Bool = false
 
+    // AI provider registry (server config, /v1/config)
+    @State private var providerForm = ProviderFormBundle()
+    @State private var loadedServerConfig: ComfyBoxServerConfig?
+    @State private var providerStatus: String?
+    @State private var providerIsError: Bool = false
+
     init(engine: EngineService) {
         self.engine = engine
         self._settings = State(initialValue: DesktopSettings.load())
@@ -104,8 +158,13 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Gallery", systemImage: "photo.on.rectangle")
                 }
+
+            providersTab
+                .tabItem {
+                    Label("AI Providers", systemImage: "brain")
+                }
         }
-        .frame(width: 480, height: 340)
+        .frame(width: 480, height: 460)
         .onDisappear {
             if hasUnsavedChanges {
                 applyAndSave()
@@ -280,6 +339,93 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    // MARK: - AI Providers Tab
+
+    private var providersTab: some View {
+        Form {
+            Section {
+                Text("Local AI endpoints (OpenAI-compatible, e.g. LM Studio). Stored server-side in ~/.comfybox/config.json.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            endpointSection("Prompt Optimization", form: $providerForm.prompt)
+            endpointSection("Vision (optional)", form: $providerForm.vision)
+            endpointSection("Captioning (optional)", form: $providerForm.captioning)
+
+            if let status = providerStatus {
+                Section {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(providerIsError ? .red : .secondary)
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Reload") { Task { await loadProviders() } }
+                    Button("Save") { Task { await saveProviders() } }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!engine.connectionState.isConnected)
+                    Spacer()
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .task { await loadProviders() }
+    }
+
+    @ViewBuilder
+    private func endpointSection(_ title: String, form: Binding<EndpointForm>) -> some View {
+        Section(title) {
+            TextField("Base URL", text: form.baseUrl)
+                .textContentType(.URL)
+                .autocorrectionDisabled()
+            TextField("Model", text: form.model)
+                .autocorrectionDisabled()
+            SecureField("API Key (optional)", text: form.apiKey)
+        }
+    }
+
+    private func loadProviders() async {
+        guard engine.connectionState.isConnected else {
+            providerStatus = "Connect to the server to edit AI providers."
+            providerIsError = true
+            return
+        }
+        do {
+            let config = try await engine.fetchServerConfig()
+            loadedServerConfig = config
+            providerForm = ProviderFormBundle(config.providers)
+            providerStatus = nil
+            providerIsError = false
+        } catch {
+            providerStatus = "Failed to load: \(error.localizedDescription)"
+            providerIsError = true
+        }
+    }
+
+    private func saveProviders() async {
+        do {
+            // Fetch-mutate-save so we preserve server-owned fields PUT would otherwise reset.
+            var config: ComfyBoxServerConfig
+            if let loaded = loadedServerConfig {
+                config = loaded
+            } else {
+                config = try await engine.fetchServerConfig()
+            }
+            config.providers = providerForm.toRegistry()
+            try await engine.saveServerConfig(config)
+            loadedServerConfig = config
+            providerStatus = "Saved to ~/.comfybox/config.json"
+            providerIsError = false
+        } catch {
+            providerStatus = "Failed to save: \(error.localizedDescription)"
+            providerIsError = true
+        }
     }
 
     // MARK: - Actions

--- a/Sources/ZImage/MCP/WarmServerClient.swift
+++ b/Sources/ZImage/MCP/WarmServerClient.swift
@@ -54,6 +54,21 @@ public final class WarmServerClient: @unchecked Sendable {
     return (response.statusCode, data)
   }
 
+  /// Perform a PUT request. Returns (HTTP status code, response body).
+  public func put(_ path: String, body: Data) async throws -> (Int, Data) {
+    guard let url = URL(string: baseURL + path) else {
+      throw WarmServerClientError.invalidURL(path)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "PUT"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.httpBody = body
+
+    let (data, response) = try await perform(request)
+    return (response.statusCode, data)
+  }
+
   /// Perform a DELETE request. Returns (HTTP status code, response body).
   public func delete(_ path: String) async throws -> (Int, Data) {
     guard let url = URL(string: baseURL + path) else {

--- a/Tests/ComfyBoxDesktopTests/ProviderFormTests.swift
+++ b/Tests/ComfyBoxDesktopTests/ProviderFormTests.swift
@@ -1,0 +1,64 @@
+// ProviderFormTests.swift — AI-provider Settings form ↔ registry mapping.
+
+import Testing
+import Foundation
+import ZImage
+@testable import ComfyBoxDesktop
+
+@Suite("ProviderForm")
+struct ProviderFormTests {
+
+    @Test("empty form maps to no endpoint")
+    func emptyIsNil() {
+        #expect(EndpointForm().toEndpoint() == nil)
+    }
+
+    @Test("base URL without model is not a configured endpoint")
+    func requiresBothUrlAndModel() {
+        var f = EndpointForm()
+        f.baseUrl = "http://localhost:1234/v1"
+        #expect(f.toEndpoint() == nil)
+    }
+
+    @Test("populated form maps to an endpoint; empty api key stays nil")
+    func populatedMapsThrough() {
+        var f = EndpointForm()
+        f.baseUrl = "http://localhost:1234/v1"
+        f.model = "dans-pe-v1.3.0-24b-heresy@8bit"
+        let e = f.toEndpoint()
+        #expect(e?.baseUrl == "http://localhost:1234/v1")
+        #expect(e?.model == "dans-pe-v1.3.0-24b-heresy@8bit")
+        #expect(e?.apiKey == nil)
+
+        f.apiKey = "sk-123"
+        #expect(f.toEndpoint()?.apiKey == "sk-123")
+    }
+
+    @Test("whitespace is trimmed and blanks ignored")
+    func trimsWhitespace() {
+        var f = EndpointForm()
+        f.baseUrl = "  http://h/v1  "
+        f.model = " m "
+        f.apiKey = "   "
+        let e = f.toEndpoint()
+        #expect(e?.baseUrl == "http://h/v1")
+        #expect(e?.model == "m")
+        #expect(e?.apiKey == nil)
+    }
+
+    @Test("registry round-trips through the form bundle")
+    func registryRoundTrip() {
+        let registry = AIProviderRegistry(
+            promptOptimization: AIProviderEndpoint(baseUrl: "http://localhost:1234/v1", model: "dans-pe-v1.3.0-24b-heresy@8bit"),
+            vision: AIProviderEndpoint(baseUrl: "http://localhost:1235/v1", model: "moondream", apiKey: "k")
+        )
+        let bundle = ProviderFormBundle(registry)
+        #expect(bundle.prompt.model == "dans-pe-v1.3.0-24b-heresy@8bit")
+        #expect(bundle.vision.apiKey == "k")
+        #expect(bundle.captioning.baseUrl.isEmpty)
+
+        let back = bundle.toRegistry()
+        #expect(back == registry)
+        #expect(back.captioning == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-07-02-P7-ui-port-spec.md
+++ b/docs/superpowers/specs/2026-07-02-P7-ui-port-spec.md
@@ -1,0 +1,88 @@
+# P7 — Electron → SwiftUI UI Port (spec)
+
+**Date:** 2026-07-02
+**Parent:** `2026-07-02-imageservice-into-comfybox-decomposition.md` (P7)
+**Status:** Draft spec — planning the full UI port before building (Todd: "plan the full UI port first").
+**Goal:** Replace the Coffee Shop image service's Electron/React UI (~7,800 LOC, 9 sidebar views) with native SwiftUI in **ComfyBoxDesktop**, so the Electron app can be retired. **Improve, don't clone** — LoRA management, prompt management, and DAM get real UX upgrades, not 1:1 ports. Build **view-by-view**, gated on backend availability (some views' backends already ship; others wait on P3/P4/P5).
+
+---
+
+## Design stance
+
+Native macOS app, not a re-skinned webview. Reference `frontend-design` at implementation time. Principles:
+- SwiftUI `NavigationSplitView` shell with a sidebar (mirrors the Electron sidebar), `@Observable` state via `EngineService` + `DAMStore`.
+- Talks to the warm server over HTTP (`WarmServerClient`/`EngineService`), plus the **local DAM** (SQLite) for assets. No pipeline linkage.
+- Match platform idioms (toolbars, inspectors, `Table`, drag-and-drop, quicklook) rather than reproducing web layouts.
+- All new view logic covered by model-free Swift Testing (the existing 89-test desktop suite is the pattern; no server/model needed).
+
+---
+
+## View inventory & mapping
+
+| Electron view (LOC) | Existing SwiftUI | Action | Backend | Gate |
+|---|---|---|---|---|
+| **Dashboard** (496) | — (missing) | **New** — status, queue summary, live progress (uses the new `current_job_id`/`progress_percent`), recent renders, provider/health tiles | `/health`, `/v1/models`, DAM | **Now** |
+| **Gallery** (1429) | `GalleryView`, `AssetDetailView`, `ComparisonGridView` | **Upgrade** (DAM area) | DAM (local) | **Now** |
+| **Queue** (149) | `QueuePanel` | **Upgrade** — determinate progress, cancel/reorder | `/v1/queue`, `/health` | **Now** (dual-lane after P2) |
+| **Presets** (264) | `PresetView`, `PresetManager`, `PresetForm` | **Upgrade** | local + `/v1/presets` | **Now** (local); server presets after **P3** |
+| **Characters** (327) | `CharacterLibraryView` | **Upgrade** | `/v1/characters` | **P3** (route absent today) |
+| **Models & LoRAs** (591) | `ModelSelector`, `LoRAPicker` | **Upgrade** (LoRA area) + fold in native bake/save/depth | `/v1/models`, `/v1/loras*` | **Now** (bake/depth after those native ops land) |
+| **mflux Tools** (631) | — | **Drop** — Python retired; native bake/save/depth resurface inside Models & LoRAs | — | — |
+| **Server** (423) | — (missing) | **New** — model pool load/activate/unload, server status, shutdown, logs | `/v1/model/*`, `/health`, `/v1/shutdown` | **Now** |
+| **Config** (1146) | `SettingsView` | **Upgrade** — full config incl. **AI-provider registry** editor | `/v1/config`, `/v1/providers/status` | **Now** (routes deployed in P0) |
+
+Components → SwiftUI equivalents: `JobSubmitForm`→`GenerationView` (exists), `JobCard`/`StatusBadge`→list cells, `LoraImportDialog`→LoRA import sheet, `BakeDialog`→bake sheet (native op), `PresetForm`→preset editor, `ImmichStatus`→DAM export (P5), `Sidebar`→`NavigationSplitView` sidebar.
+
+---
+
+## The three "improve, don't clone" areas
+
+**1. LoRA management** (upgrade `LoRAPicker`/`ModelSelector` → a real manager).
+- Browse/search/filter the LoRA library (backed by in-tree `LoRALibrary`/`LoRAScanner`/`LoRACompatibility`).
+- Multi-LoRA stack with live scale sliders incl. **negative/slider LoRAs** (per the MCP scale change), compatibility + quarantine badges, trigger words, import + metadata edit.
+- Fold in native **bake/save/quantize/depth** actions (the surviving mflux-tools functions).
+
+**2. Prompt management** (new surface, not just a text field).
+- Prompt history, reusable snippets/wildcards, per-preset prompt+negative.
+- Inline **prompt optimization** via the configurable provider (P0 registry → P4 `/v1/enhance`) with before/after preview.
+- Prompt metadata surfaced from the DAM (reuse a render's exact prompt/seed).
+
+**3. DAM functions** (upgrade `GalleryView`/`AssetDetailView`).
+- Folders, robust FTS search over prompt/seed/model, rating/favorite/tags, compare, sidecar metadata for app-generated images (the remediation already fixed the FTS-dup + annotation-loss bugs).
+- Immich export + status (**P5**).
+
+---
+
+## Build order (interleaved with backend phases)
+
+**UI-Now (backends already shipped):** Config/provider-registry Settings panel → Server view → Dashboard → Queue upgrade → Models&LoRAs (LoRA manager) → Gallery/DAM upgrade → Presets (local).
+- **First increment: the AI-provider Settings panel** — small, exercises the deployed `/v1/config` + `/v1/providers/status`, establishes the port pattern, closes P0's deferred UI item.
+
+**UI-Gated (wait on backend phase):**
+- Characters → after **P3**.
+- Prompt-optimization inline UI → after **P4** (`/v1/enhance`); the provider *config* is already editable now.
+- DAM Immich export, media `/v1/assets*` unification → after **P5**.
+- Dual-lane Queue affordances → after **P2**.
+
+**Retire:** delete the Electron renderer + main process once the UI-Now set + P3/P4/P5-gated views reach parity (**P8**).
+
+---
+
+## Shared infrastructure to add
+- `EngineService`: config get/put (`/v1/config`), provider status, model-pool ops, server control — extend the existing client.
+- A small `ConfigStore` (`@Observable`) wrapping `ComfyBoxServerConfig` fetched from `/v1/config` for the Settings UI.
+- Sidebar-driven `NavigationSplitView` shell replacing the current 4-tab layout; preserve existing views as destinations.
+
+## Acceptance (per view)
+- Renders from live server/DAM data; no hardcoded ports/paths (uses `AppConfig`/`/v1/config`).
+- Errors surfaced to the UI (not swallowed — the remediation's lesson).
+- Model-free Swift Testing for view models/state; no server/weights in tests.
+- The Electron view it replaces is verified redundant before P8 deletion.
+
+## Decisions (confirmed)
+1. **Shell:** full sidebar `NavigationSplitView` (matches Electron, scales to 9+ destinations).
+2. **Prompt management:** inspector panel on Generate + a history sheet.
+3. **First increment:** the AI-provider Settings panel.
+
+## Governing principle: parity proof, then expansion (Todd)
+For **every** ported view: first build to **parity** with the Electron original and prove it (the SwiftUI view does what the web view did against live data), **then** layer the "improve, don't clone" expansions. Parity is the checkpoint that de-risks each port before investing in enhancements; don't start an Electron view's deletion (P8) until its SwiftUI replacement has passed parity.


### PR DESCRIPTION
First increment of the Electron→SwiftUI UI port (P7). **Parity-first**: edits the same AI-provider config the Electron Config view exposed, via the P0 `/v1/config` routes.

## Changes
- `WarmServerClient.put` — config writes.
- `EngineService.fetchServerConfig()` / `saveServerConfig()` — GET/PUT `/v1/config` (canonical camelCase document; save is fetch-mutate-save to preserve server-owned fields).
- SettingsView **AI Providers** tab — Base URL / Model / API Key for prompt optimization, vision, captioning; loads live, saves to `~/.comfybox/config.json`.
- `ProviderFormTests` — form↔registry mapping (model-free).
- **P7 UI-port spec** — full view inventory, improve-don't-clone areas (LoRA/prompt/DAM), parity-then-expansion principle, and backend-gated build order.

## Verification
- `ComfyBoxDesktopTests`: 94/94 (89 + 5 new).
- Live PUT/GET round-trip through `/v1/config` against the running server on 7870 — provider added, confirmed via `/v1/providers/status`, original restored.

Note: repo CI `typecheck` is chronically red on hosted runners (MLX Metal compile timeout) — pre-existing infra, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)