### PR TITLE
UI port #2: sidebar + Dashboard & Server views

### DIFF
--- a/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
+++ b/Sources/ComfyBoxDesktop/ComfyBoxDesktopApp.swift
@@ -14,7 +14,7 @@ struct ComfyBoxDesktopApp: App {
     @State private var store: DAMStore?
     @State private var ingestor: AssetIngestor?
     @State private var presetManager = PresetManager()
-    @State private var selectedTab: AppTab = .generate
+    @State private var selectedTab: AppTab = .dashboard
     @State private var initError: String?
     @State private var characters: [CharacterEntry] = []
     @State private var comparisonAssets: [DAMAsset]?
@@ -22,26 +22,32 @@ struct ComfyBoxDesktopApp: App {
     @State private var gallerySearchFocusRequests: Int = 0
 
     enum AppTab: String, CaseIterable {
+        case dashboard = "Dashboard"
         case generate = "Generate"
         case gallery = "Gallery"
         case compare = "Compare"
         case presets = "Presets"
+        case server = "Server"
 
         var icon: String {
             switch self {
+            case .dashboard: return "gauge.with.dots.needle.bottom.50percent"
             case .generate: return "wand.and.stars"
             case .gallery: return "photo.on.rectangle"
             case .compare: return "square.grid.2x2"
             case .presets: return "slider.horizontal.below.rectangle"
+            case .server: return "server.rack"
             }
         }
 
         var shortcutKey: KeyEquivalent {
             switch self {
-            case .generate: return "1"
-            case .gallery: return "2"
-            case .compare: return "3"
-            case .presets: return "4"
+            case .dashboard: return "1"
+            case .generate: return "2"
+            case .gallery: return "3"
+            case .compare: return "4"
+            case .presets: return "5"
+            case .server: return "6"
             }
         }
     }
@@ -109,6 +115,12 @@ struct ComfyBoxDesktopApp: App {
     @ViewBuilder
     private var detailView: some View {
         switch selectedTab {
+        case .dashboard:
+            DashboardView(engine: engine, store: store, ingestor: ingestor)
+
+        case .server:
+            ServerView(engine: engine)
+
         case .generate:
             GenerationView(
                 engine: engine,

--- a/Sources/ComfyBoxDesktop/EngineService.swift
+++ b/Sources/ComfyBoxDesktop/EngineService.swift
@@ -674,6 +674,34 @@ public final class EngineService {
         }
     }
 
+    // MARK: - Server Config (/v1/config)
+
+    /// Fetch the server config document (~/.comfybox/config.json). The config document
+    /// is canonical camelCase, decoded with a plain decoder (not the snake_case API DTOs).
+    public func fetchServerConfig() async throws -> ComfyBoxServerConfig {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+        let (status, data) = try await client.get("/v1/config")
+        guard status == 200 else {
+            throw EngineServiceError.serverError(status, parseErrorMessage(from: data) ?? "Failed to load config")
+        }
+        return try JSONDecoder().decode(ComfyBoxServerConfig.self, from: data)
+    }
+
+    /// Persist the full server config document. PUT replaces the document, so callers
+    /// should fetch, mutate, and save to preserve fields they don't manage.
+    public func saveServerConfig(_ config: ComfyBoxServerConfig) async throws {
+        guard let client = client, connectionState.isConnected else {
+            throw EngineServiceError.notConnected
+        }
+        let body = try JSONEncoder().encode(config)
+        let (status, data) = try await client.put("/v1/config", body: body)
+        guard status == 200 else {
+            throw EngineServiceError.serverError(status, parseErrorMessage(from: data) ?? "Failed to save config")
+        }
+    }
+
     // MARK: - Helpers
 
     private func parseErrorMessage(from data: Data) -> String? {

--- a/Sources/ComfyBoxDesktop/Views/DashboardView.swift
+++ b/Sources/ComfyBoxDesktop/Views/DashboardView.swift
@@ -1,0 +1,190 @@
+// DashboardView.swift — At-a-glance status: connection, model, queue, live
+// progress, and recent renders. Reads EngineService state (polled every 3s)
+// and the DAM for recent assets. Ports the Electron Dashboard view (parity).
+
+import SwiftUI
+
+struct DashboardView: View {
+    @Bindable var engine: EngineService
+    let store: DAMStore?
+    let ingestor: AssetIngestor?
+
+    @State private var recent: [DAMAsset] = []
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                statTiles
+                if let q = engine.queueInfo, q.isRendering, let pct = q.progressPercent {
+                    renderProgress(pct)
+                }
+                recentRenders
+            }
+            .padding(20)
+        }
+        .navigationTitle("Dashboard")
+        .task(id: ingestor?.ingestedCount) { await loadRecent() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(engine.connectionState.isConnected ? Color.green : Color.gray)
+                .frame(width: 10, height: 10)
+            Text(engine.connectionState.isConnected ? "Connected" : "Disconnected")
+                .font(.headline)
+            Spacer()
+            if let model = engine.currentModel {
+                Label(model, systemImage: "cube")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+    }
+
+    // MARK: - Stat tiles
+
+    private var statTiles: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
+            let q = engine.queueInfo
+            StatTile(title: "Status",
+                     value: (q?.isRendering ?? false) ? "Rendering" : "Idle",
+                     systemImage: "bolt.fill",
+                     tint: (q?.isRendering ?? false) ? .orange : .green)
+            StatTile(title: "Pending", value: "\(q?.pendingCount ?? engine.queueCount)", systemImage: "tray.full")
+            StatTile(title: "Renders", value: "\(q?.renderCount ?? 0)", systemImage: "photo.stack")
+            StatTile(title: "Uptime", value: formatUptime(q?.uptimeSeconds ?? 0), systemImage: "clock")
+            StatTile(title: "Memory", value: formatMemory(q?.memoryUsageMB ?? 0), systemImage: "memorychip")
+            if let ms = q?.lastRenderDurationMs {
+                StatTile(title: "Last render", value: String(format: "%.1fs", Double(ms) / 1000), systemImage: "timer")
+            }
+        }
+    }
+
+    private func renderProgress(_ pct: Double) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Current render")
+                    .font(.subheadline).bold()
+                Spacer()
+                Text("\(Int(pct * 100))%")
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            ProgressView(value: min(max(pct, 0), 1))
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Recent renders
+
+    private var recentRenders: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recent renders")
+                .font(.headline)
+            if recent.isEmpty {
+                Text("No renders yet.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(recent) { asset in
+                            DashboardThumbnail(
+                                path: ingestor?.thumbnailPath(for: asset.id) ?? asset.absolutePath,
+                                caption: asset.prompt
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Data
+
+    private func loadRecent() async {
+        guard let store else { return }
+        recent = (try? await store.fetchAssets(limit: 12)) ?? []
+    }
+
+    // MARK: - Formatting
+
+    private func formatUptime(_ seconds: Int) -> String {
+        if seconds <= 0 { return "—" }
+        let h = seconds / 3600, m = (seconds % 3600) / 60
+        if h > 0 { return "\(h)h \(m)m" }
+        if m > 0 { return "\(m)m" }
+        return "\(seconds)s"
+    }
+
+    private func formatMemory(_ mb: UInt64) -> String {
+        if mb == 0 { return "—" }
+        if mb >= 1024 { return String(format: "%.1f GB", Double(mb) / 1024) }
+        return "\(mb) MB"
+    }
+}
+
+// MARK: - Reusable tile
+
+struct StatTile: View {
+    let title: String
+    let value: String
+    var systemImage: String = "circle"
+    var tint: Color = .accentColor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .labelStyle(.titleAndIcon)
+            Text(value)
+                .font(.title3).bold()
+                .foregroundStyle(tint)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+        .padding(12)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+// MARK: - Thumbnail
+
+private struct DashboardThumbnail: View {
+    let path: String
+    let caption: String?
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Group {
+                if let image {
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    RoundedRectangle(cornerRadius: 8).fill(.quaternary)
+                }
+            }
+            .frame(width: 120, height: 120)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .frame(width: 120)
+        .help(caption ?? "")
+        .task {
+            let p = path
+            image = await Task.detached { NSImage(contentsOfFile: p) }.value
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/ServerView.swift
+++ b/Sources/ComfyBoxDesktop/Views/ServerView.swift
@@ -1,0 +1,168 @@
+// ServerView.swift — Server status and model-pool control: view loaded models,
+// activate/unload, and load available models. Ports the Electron Server view.
+
+import SwiftUI
+
+struct ServerView: View {
+    @Bindable var engine: EngineService
+
+    @State private var busy: String?          // id of a model with an op in flight
+    @State private var actionError: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                statusSection
+                loadedPoolSection
+                availableModelsSection
+            }
+            .padding(20)
+        }
+        .navigationTitle("Server")
+        .task { await refreshAll() }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Circle()
+                    .fill(engine.connectionState.isConnected ? Color.green : Color.gray)
+                    .frame(width: 10, height: 10)
+                Text(engine.connectionState.label).font(.headline)
+                Spacer()
+                Button {
+                    engine.connectionState.isConnected ? engine.disconnect() : engine.connect()
+                } label: {
+                    Text(engine.connectionState.isConnected ? "Disconnect" : "Connect")
+                }
+            }
+            if let q = engine.queueInfo {
+                HStack(spacing: 12) {
+                    StatTile(title: "Status", value: q.isRendering ? "Rendering" : "Idle",
+                             systemImage: "bolt.fill", tint: q.isRendering ? .orange : .green)
+                    StatTile(title: "Pending", value: "\(q.pendingCount)", systemImage: "tray.full")
+                    StatTile(title: "Memory",
+                             value: q.memoryUsageMB >= 1024 ? String(format: "%.1f GB", Double(q.memoryUsageMB) / 1024) : "\(q.memoryUsageMB) MB",
+                             systemImage: "memorychip")
+                }
+            }
+            if let err = actionError {
+                Text(err).font(.caption).foregroundStyle(.red)
+            }
+        }
+    }
+
+    // MARK: - Loaded pool
+
+    private var loadedPoolSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Model Pool").font(.headline)
+                Spacer()
+                Button { Task { await engine.refreshPool() } } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!engine.connectionState.isConnected)
+            }
+
+            if engine.poolModels.isEmpty {
+                emptyRow("No models loaded.")
+            } else {
+                ForEach(engine.poolModels) { m in
+                    HStack(spacing: 10) {
+                        Circle().fill(m.active ? Color.green : Color.secondary.opacity(0.4))
+                            .frame(width: 8, height: 8)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(m.model).lineLimit(1).truncationMode(.middle)
+                            Text("\(m.family) · \(m.vramMB >= 1024 ? String(format: "%.1f GB", Double(m.vramMB) / 1024) : "\(m.vramMB) MB")")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if m.active {
+                            Text("Active").font(.caption).foregroundStyle(.green)
+                        } else {
+                            Button("Activate") { Task { await run(m.id) { try await engine.activateModel(id: m.id) } } }
+                                .buttonStyle(.bordered)
+                        }
+                        Button {
+                            Task { await run(m.id) { try await engine.unloadModel(id: m.id) } }
+                        } label: {
+                            Image(systemName: "eject")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Unload")
+                        if busy == m.id { ProgressView().controlSize(.small) }
+                    }
+                    .padding(10)
+                    .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+
+    // MARK: - Available models
+
+    private var availableModelsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Available Models").font(.headline)
+                Spacer()
+                Button { Task { await engine.refreshModels() } } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!engine.connectionState.isConnected)
+            }
+
+            if engine.availableModels.isEmpty {
+                emptyRow("No catalog models reported.")
+            } else {
+                ForEach(engine.availableModels) { m in
+                    HStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(m.displayName).lineLimit(1)
+                            Text("\(m.family) · \(m.quantization) · \(String(format: "%.1f", m.estimatedVRAM_GB)) GB")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Load") { Task { await run(m.id) { try await engine.loadModel(id: m.id) } } }
+                            .buttonStyle(.bordered)
+                            .disabled(!engine.connectionState.isConnected)
+                        if busy == m.id { ProgressView().controlSize(.small) }
+                    }
+                    .padding(10)
+                    .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+
+    private func emptyRow(_ text: String) -> some View {
+        Text(text).font(.callout).foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+    }
+
+    // MARK: - Actions
+
+    private func refreshAll() async {
+        guard engine.connectionState.isConnected else { return }
+        await engine.refreshModels()
+        await engine.refreshPool()
+    }
+
+    private func run(_ id: String, _ op: @escaping () async throws -> Void) async {
+        busy = id
+        actionError = nil
+        defer { busy = nil }
+        do {
+            try await op()
+            await engine.refreshPool()
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/SettingsView.swift
+++ b/Sources/ComfyBoxDesktop/Views/SettingsView.swift
@@ -5,6 +5,54 @@
 // persist to ~/.comfybox/desktop-config.json.
 
 import SwiftUI
+import ZImage
+
+// MARK: - AI Provider form models
+
+/// Editable string fields for one AI-provider endpoint, mapped to/from `AIProviderEndpoint`.
+struct EndpointForm {
+    var baseUrl: String = ""
+    var model: String = ""
+    var apiKey: String = ""
+
+    init() {}
+    init(_ endpoint: AIProviderEndpoint?) {
+        baseUrl = endpoint?.baseUrl ?? ""
+        model = endpoint?.model ?? ""
+        apiKey = endpoint?.apiKey ?? ""
+    }
+
+    /// A configured endpoint requires both a base URL and a model; otherwise it's absent.
+    func toEndpoint() -> AIProviderEndpoint? {
+        let b = baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let m = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !b.isEmpty, !m.isEmpty else { return nil }
+        let k = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return AIProviderEndpoint(baseUrl: b, model: m, apiKey: k.isEmpty ? nil : k)
+    }
+}
+
+/// The full editable provider registry for the Settings form.
+struct ProviderFormBundle {
+    var prompt = EndpointForm()
+    var vision = EndpointForm()
+    var captioning = EndpointForm()
+
+    init() {}
+    init(_ registry: AIProviderRegistry) {
+        prompt = EndpointForm(registry.promptOptimization)
+        vision = EndpointForm(registry.vision)
+        captioning = EndpointForm(registry.captioning)
+    }
+
+    func toRegistry() -> AIProviderRegistry {
+        AIProviderRegistry(
+            promptOptimization: prompt.toEndpoint(),
+            vision: vision.toEndpoint(),
+            captioning: captioning.toEndpoint()
+        )
+    }
+}
 
 // MARK: - Settings Storage
 
@@ -83,6 +131,12 @@ struct SettingsView: View {
     @State private var hasUnsavedChanges: Bool = false
     @State private var showingSaveConfirmation: Bool = false
 
+    // AI provider registry (server config, /v1/config)
+    @State private var providerForm = ProviderFormBundle()
+    @State private var loadedServerConfig: ComfyBoxServerConfig?
+    @State private var providerStatus: String?
+    @State private var providerIsError: Bool = false
+
     init(engine: EngineService) {
         self.engine = engine
         self._settings = State(initialValue: DesktopSettings.load())
@@ -104,8 +158,13 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Gallery", systemImage: "photo.on.rectangle")
                 }
+
+            providersTab
+                .tabItem {
+                    Label("AI Providers", systemImage: "brain")
+                }
         }
-        .frame(width: 480, height: 340)
+        .frame(width: 480, height: 460)
         .onDisappear {
             if hasUnsavedChanges {
                 applyAndSave()
@@ -280,6 +339,93 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    // MARK: - AI Providers Tab
+
+    private var providersTab: some View {
+        Form {
+            Section {
+                Text("Local AI endpoints (OpenAI-compatible, e.g. LM Studio). Stored server-side in ~/.comfybox/config.json.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            endpointSection("Prompt Optimization", form: $providerForm.prompt)
+            endpointSection("Vision (optional)", form: $providerForm.vision)
+            endpointSection("Captioning (optional)", form: $providerForm.captioning)
+
+            if let status = providerStatus {
+                Section {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(providerIsError ? .red : .secondary)
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Button("Reload") { Task { await loadProviders() } }
+                    Button("Save") { Task { await saveProviders() } }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!engine.connectionState.isConnected)
+                    Spacer()
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .task { await loadProviders() }
+    }
+
+    @ViewBuilder
+    private func endpointSection(_ title: String, form: Binding<EndpointForm>) -> some View {
+        Section(title) {
+            TextField("Base URL", text: form.baseUrl)
+                .textContentType(.URL)
+                .autocorrectionDisabled()
+            TextField("Model", text: form.model)
+                .autocorrectionDisabled()
+            SecureField("API Key (optional)", text: form.apiKey)
+        }
+    }
+
+    private func loadProviders() async {
+        guard engine.connectionState.isConnected else {
+            providerStatus = "Connect to the server to edit AI providers."
+            providerIsError = true
+            return
+        }
+        do {
+            let config = try await engine.fetchServerConfig()
+            loadedServerConfig = config
+            providerForm = ProviderFormBundle(config.providers)
+            providerStatus = nil
+            providerIsError = false
+        } catch {
+            providerStatus = "Failed to load: \(error.localizedDescription)"
+            providerIsError = true
+        }
+    }
+
+    private func saveProviders() async {
+        do {
+            // Fetch-mutate-save so we preserve server-owned fields PUT would otherwise reset.
+            var config: ComfyBoxServerConfig
+            if let loaded = loadedServerConfig {
+                config = loaded
+            } else {
+                config = try await engine.fetchServerConfig()
+            }
+            config.providers = providerForm.toRegistry()
+            try await engine.saveServerConfig(config)
+            loadedServerConfig = config
+            providerStatus = "Saved to ~/.comfybox/config.json"
+            providerIsError = false
+        } catch {
+            providerStatus = "Failed to save: \(error.localizedDescription)"
+            providerIsError = true
+        }
     }
 
     // MARK: - Actions

--- a/Sources/ZImage/MCP/WarmServerClient.swift
+++ b/Sources/ZImage/MCP/WarmServerClient.swift
@@ -54,6 +54,21 @@ public final class WarmServerClient: @unchecked Sendable {
     return (response.statusCode, data)
   }
 
+  /// Perform a PUT request. Returns (HTTP status code, response body).
+  public func put(_ path: String, body: Data) async throws -> (Int, Data) {
+    guard let url = URL(string: baseURL + path) else {
+      throw WarmServerClientError.invalidURL(path)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "PUT"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.httpBody = body
+
+    let (data, response) = try await perform(request)
+    return (response.statusCode, data)
+  }
+
   /// Perform a DELETE request. Returns (HTTP status code, response body).
   public func delete(_ path: String) async throws -> (Int, Data) {
     guard let url = URL(string: baseURL + path) else {

--- a/Tests/ComfyBoxDesktopTests/ProviderFormTests.swift
+++ b/Tests/ComfyBoxDesktopTests/ProviderFormTests.swift
@@ -1,0 +1,64 @@
+// ProviderFormTests.swift — AI-provider Settings form ↔ registry mapping.
+
+import Testing
+import Foundation
+import ZImage
+@testable import ComfyBoxDesktop
+
+@Suite("ProviderForm")
+struct ProviderFormTests {
+
+    @Test("empty form maps to no endpoint")
+    func emptyIsNil() {
+        #expect(EndpointForm().toEndpoint() == nil)
+    }
+
+    @Test("base URL without model is not a configured endpoint")
+    func requiresBothUrlAndModel() {
+        var f = EndpointForm()
+        f.baseUrl = "http://localhost:1234/v1"
+        #expect(f.toEndpoint() == nil)
+    }
+
+    @Test("populated form maps to an endpoint; empty api key stays nil")
+    func populatedMapsThrough() {
+        var f = EndpointForm()
+        f.baseUrl = "http://localhost:1234/v1"
+        f.model = "dans-pe-v1.3.0-24b-heresy@8bit"
+        let e = f.toEndpoint()
+        #expect(e?.baseUrl == "http://localhost:1234/v1")
+        #expect(e?.model == "dans-pe-v1.3.0-24b-heresy@8bit")
+        #expect(e?.apiKey == nil)
+
+        f.apiKey = "sk-123"
+        #expect(f.toEndpoint()?.apiKey == "sk-123")
+    }
+
+    @Test("whitespace is trimmed and blanks ignored")
+    func trimsWhitespace() {
+        var f = EndpointForm()
+        f.baseUrl = "  http://h/v1  "
+        f.model = " m "
+        f.apiKey = "   "
+        let e = f.toEndpoint()
+        #expect(e?.baseUrl == "http://h/v1")
+        #expect(e?.model == "m")
+        #expect(e?.apiKey == nil)
+    }
+
+    @Test("registry round-trips through the form bundle")
+    func registryRoundTrip() {
+        let registry = AIProviderRegistry(
+            promptOptimization: AIProviderEndpoint(baseUrl: "http://localhost:1234/v1", model: "dans-pe-v1.3.0-24b-heresy@8bit"),
+            vision: AIProviderEndpoint(baseUrl: "http://localhost:1235/v1", model: "moondream", apiKey: "k")
+        )
+        let bundle = ProviderFormBundle(registry)
+        #expect(bundle.prompt.model == "dans-pe-v1.3.0-24b-heresy@8bit")
+        #expect(bundle.vision.apiKey == "k")
+        #expect(bundle.captioning.baseUrl.isEmpty)
+
+        let back = bundle.toRegistry()
+        #expect(back == registry)
+        #expect(back.captioning == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-07-02-P7-ui-port-spec.md
+++ b/docs/superpowers/specs/2026-07-02-P7-ui-port-spec.md
@@ -1,0 +1,88 @@
+# P7 — Electron → SwiftUI UI Port (spec)
+
+**Date:** 2026-07-02
+**Parent:** `2026-07-02-imageservice-into-comfybox-decomposition.md` (P7)
+**Status:** Draft spec — planning the full UI port before building (Todd: "plan the full UI port first").
+**Goal:** Replace the Coffee Shop image service's Electron/React UI (~7,800 LOC, 9 sidebar views) with native SwiftUI in **ComfyBoxDesktop**, so the Electron app can be retired. **Improve, don't clone** — LoRA management, prompt management, and DAM get real UX upgrades, not 1:1 ports. Build **view-by-view**, gated on backend availability (some views' backends already ship; others wait on P3/P4/P5).
+
+---
+
+## Design stance
+
+Native macOS app, not a re-skinned webview. Reference `frontend-design` at implementation time. Principles:
+- SwiftUI `NavigationSplitView` shell with a sidebar (mirrors the Electron sidebar), `@Observable` state via `EngineService` + `DAMStore`.
+- Talks to the warm server over HTTP (`WarmServerClient`/`EngineService`), plus the **local DAM** (SQLite) for assets. No pipeline linkage.
+- Match platform idioms (toolbars, inspectors, `Table`, drag-and-drop, quicklook) rather than reproducing web layouts.
+- All new view logic covered by model-free Swift Testing (the existing 89-test desktop suite is the pattern; no server/model needed).
+
+---
+
+## View inventory & mapping
+
+| Electron view (LOC) | Existing SwiftUI | Action | Backend | Gate |
+|---|---|---|---|---|
+| **Dashboard** (496) | — (missing) | **New** — status, queue summary, live progress (uses the new `current_job_id`/`progress_percent`), recent renders, provider/health tiles | `/health`, `/v1/models`, DAM | **Now** |
+| **Gallery** (1429) | `GalleryView`, `AssetDetailView`, `ComparisonGridView` | **Upgrade** (DAM area) | DAM (local) | **Now** |
+| **Queue** (149) | `QueuePanel` | **Upgrade** — determinate progress, cancel/reorder | `/v1/queue`, `/health` | **Now** (dual-lane after P2) |
+| **Presets** (264) | `PresetView`, `PresetManager`, `PresetForm` | **Upgrade** | local + `/v1/presets` | **Now** (local); server presets after **P3** |
+| **Characters** (327) | `CharacterLibraryView` | **Upgrade** | `/v1/characters` | **P3** (route absent today) |
+| **Models & LoRAs** (591) | `ModelSelector`, `LoRAPicker` | **Upgrade** (LoRA area) + fold in native bake/save/depth | `/v1/models`, `/v1/loras*` | **Now** (bake/depth after those native ops land) |
+| **mflux Tools** (631) | — | **Drop** — Python retired; native bake/save/depth resurface inside Models & LoRAs | — | — |
+| **Server** (423) | — (missing) | **New** — model pool load/activate/unload, server status, shutdown, logs | `/v1/model/*`, `/health`, `/v1/shutdown` | **Now** |
+| **Config** (1146) | `SettingsView` | **Upgrade** — full config incl. **AI-provider registry** editor | `/v1/config`, `/v1/providers/status` | **Now** (routes deployed in P0) |
+
+Components → SwiftUI equivalents: `JobSubmitForm`→`GenerationView` (exists), `JobCard`/`StatusBadge`→list cells, `LoraImportDialog`→LoRA import sheet, `BakeDialog`→bake sheet (native op), `PresetForm`→preset editor, `ImmichStatus`→DAM export (P5), `Sidebar`→`NavigationSplitView` sidebar.
+
+---
+
+## The three "improve, don't clone" areas
+
+**1. LoRA management** (upgrade `LoRAPicker`/`ModelSelector` → a real manager).
+- Browse/search/filter the LoRA library (backed by in-tree `LoRALibrary`/`LoRAScanner`/`LoRACompatibility`).
+- Multi-LoRA stack with live scale sliders incl. **negative/slider LoRAs** (per the MCP scale change), compatibility + quarantine badges, trigger words, import + metadata edit.
+- Fold in native **bake/save/quantize/depth** actions (the surviving mflux-tools functions).
+
+**2. Prompt management** (new surface, not just a text field).
+- Prompt history, reusable snippets/wildcards, per-preset prompt+negative.
+- Inline **prompt optimization** via the configurable provider (P0 registry → P4 `/v1/enhance`) with before/after preview.
+- Prompt metadata surfaced from the DAM (reuse a render's exact prompt/seed).
+
+**3. DAM functions** (upgrade `GalleryView`/`AssetDetailView`).
+- Folders, robust FTS search over prompt/seed/model, rating/favorite/tags, compare, sidecar metadata for app-generated images (the remediation already fixed the FTS-dup + annotation-loss bugs).
+- Immich export + status (**P5**).
+
+---
+
+## Build order (interleaved with backend phases)
+
+**UI-Now (backends already shipped):** Config/provider-registry Settings panel → Server view → Dashboard → Queue upgrade → Models&LoRAs (LoRA manager) → Gallery/DAM upgrade → Presets (local).
+- **First increment: the AI-provider Settings panel** — small, exercises the deployed `/v1/config` + `/v1/providers/status`, establishes the port pattern, closes P0's deferred UI item.
+
+**UI-Gated (wait on backend phase):**
+- Characters → after **P3**.
+- Prompt-optimization inline UI → after **P4** (`/v1/enhance`); the provider *config* is already editable now.
+- DAM Immich export, media `/v1/assets*` unification → after **P5**.
+- Dual-lane Queue affordances → after **P2**.
+
+**Retire:** delete the Electron renderer + main process once the UI-Now set + P3/P4/P5-gated views reach parity (**P8**).
+
+---
+
+## Shared infrastructure to add
+- `EngineService`: config get/put (`/v1/config`), provider status, model-pool ops, server control — extend the existing client.
+- A small `ConfigStore` (`@Observable`) wrapping `ComfyBoxServerConfig` fetched from `/v1/config` for the Settings UI.
+- Sidebar-driven `NavigationSplitView` shell replacing the current 4-tab layout; preserve existing views as destinations.
+
+## Acceptance (per view)
+- Renders from live server/DAM data; no hardcoded ports/paths (uses `AppConfig`/`/v1/config`).
+- Errors surfaced to the UI (not swallowed — the remediation's lesson).
+- Model-free Swift Testing for view models/state; no server/weights in tests.
+- The Electron view it replaces is verified redundant before P8 deletion.
+
+## Decisions (confirmed)
+1. **Shell:** full sidebar `NavigationSplitView` (matches Electron, scales to 9+ destinations).
+2. **Prompt management:** inspector panel on Generate + a history sheet.
+3. **First increment:** the AI-provider Settings panel.
+
+## Governing principle: parity proof, then expansion (Todd)
+For **every** ported view: first build to **parity** with the Electron original and prove it (the SwiftUI view does what the web view did against live data), **then** layer the "improve, don't clone" expansions. Parity is the checkpoint that de-risks each port before investing in enhancements; don't start an Electron view's deletion (P8) until its SwiftUI replacement has passed parity.


### PR DESCRIPTION
Second UI-port increment (P7). Adds two new sidebar destinations, **ported to parity** from the Electron UI and bound to live `EngineService` state. Verified against the running server on 7870.

## Dashboard
Connection + active model, live status tiles (rendering/pending/renders/uptime/memory/last-render), a render-progress bar driven by the `current_job_id`/`progress_percent` telemetry, and a recent-renders strip from the DAM.

## Server
Server status + **model-pool control** — activate/unload loaded models and load from the catalog (Z-Image Turbo/Q8/Q4/Base, Flux 2 Klein 4B/9B/Base), each with family·quant·VRAM and per-row busy/error state.

Sidebar reordered with Dashboard first (⌘1–⌘6); shared `StatTile`.

## Verification
- `ComfyBoxDesktopTests`: 94/94.
- Launched the built app against the live server; both views render real data (screenshots shared with the reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)