### PR TITLE
Backend: creative/info layer (characters, presets, content-modes, stats, audit)

### DIFF
--- a/Sources/ZImage/Server/AuditLog.swift
+++ b/Sources/ZImage/Server/AuditLog.swift
@@ -1,0 +1,161 @@
+// AuditLog.swift — Append-only JSONL audit trail (~/.comfybox/audit-log.jsonl).
+//
+// Records notable server events (generation submitted/completed/failed, model
+// load/unload, config change) so the desktop UI can surface an activity history.
+// Ported for parity with the Coffee Shop image service audit log
+// (src/service.ts `appendAuditLog` / `getAuditLog`): one JSON object per line,
+// appended synchronously, read back most-recent-first with a limit.
+//
+// Writes are serialized on a private queue so concurrent `append` calls from the
+// server's request handlers never interleave partial lines in the file.
+
+import Foundation
+
+/// The category of an audited event. A wrapper over a string (rather than a closed
+/// enum) so new event kinds decode cleanly on older builds — the schema can grow
+/// without breaking existing `audit-log.jsonl` files.
+public struct AuditKind: RawRepresentable, Codable, Equatable, Hashable, Sendable, ExpressibleByStringLiteral {
+  public let rawValue: String
+
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public init(_ rawValue: String) { self.rawValue = rawValue }
+  public init(stringLiteral value: String) { self.rawValue = value }
+
+  public init(from decoder: Decoder) throws {
+    rawValue = try decoder.singleValueContainer().decode(String.self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.singleValueContainer()
+    try c.encode(rawValue)
+  }
+
+  // Well-known kinds. Callers may also construct arbitrary kinds via string literal.
+  public static let generationSubmitted: AuditKind = "generation.submitted"
+  public static let generationCompleted: AuditKind = "generation.completed"
+  public static let generationFailed: AuditKind = "generation.failed"
+  public static let generationCancelled: AuditKind = "generation.cancelled"
+  public static let modelLoad: AuditKind = "model.load"
+  public static let modelUnload: AuditKind = "model.unload"
+  public static let configChange: AuditKind = "config.change"
+}
+
+/// One line of the audit log.
+public struct AuditEntry: Codable, Equatable, Sendable {
+  /// When the event occurred.
+  public var timestamp: Date
+  /// What kind of event this is.
+  public var kind: AuditKind
+  /// Human-readable description of the event.
+  public var message: String
+  /// Optional structured detail (e.g. `["jobId": "abc", "durationMs": "1234"]`).
+  public var metadata: [String: String]?
+
+  public init(
+    timestamp: Date = Date(),
+    kind: AuditKind,
+    message: String,
+    metadata: [String: String]? = nil
+  ) {
+    self.timestamp = timestamp
+    self.kind = kind
+    self.message = message
+    self.metadata = metadata
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case timestamp, kind, message, metadata
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    timestamp = try c.decodeIfPresent(Date.self, forKey: .timestamp) ?? Date(timeIntervalSince1970: 0)
+    kind = try c.decodeIfPresent(AuditKind.self, forKey: .kind) ?? AuditKind("unknown")
+    message = try c.decodeIfPresent(String.self, forKey: .message) ?? ""
+    metadata = try c.decodeIfPresent([String: String].self, forKey: .metadata)
+  }
+}
+
+/// Append-only JSONL audit log. Thread-safe: all file mutations run on a private
+/// serial queue so appends never interleave.
+public final class AuditLog: @unchecked Sendable {
+  /// `~/.comfybox/audit-log.jsonl`.
+  public static func defaultPath() -> URL {
+    ComfyBoxServerConfig.homeDirectory().appendingPathComponent(".comfybox/audit-log.jsonl")
+  }
+
+  private let path: URL
+  private let fileManager: FileManager
+  private let queue = DispatchQueue(label: "com.comfybox.audit-log")
+
+  private static func makeEncoder() -> JSONEncoder {
+    let e = JSONEncoder()
+    e.dateEncodingStrategy = .iso8601
+    e.outputFormatting = [.sortedKeys] // single line — no .prettyPrinted
+    return e
+  }
+
+  private static func makeDecoder() -> JSONDecoder {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .iso8601
+    return d
+  }
+
+  public init(path: URL = AuditLog.defaultPath(), fileManager: FileManager = .default) {
+    self.path = path
+    self.fileManager = fileManager
+  }
+
+  /// Append one event to the log. Serialized against other appends. Failures to
+  /// write are swallowed — audit logging must never crash the server or a request.
+  public func append(_ entry: AuditEntry) {
+    queue.sync {
+      guard let line = try? Self.makeEncoder().encode(entry) else { return }
+      var data = line
+      data.append(0x0A) // '\n'
+
+      let dir = path.deletingLastPathComponent()
+      try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+
+      if let handle = try? FileHandle(forWritingTo: path) {
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+      } else {
+        // File doesn't exist yet — create it with this first line.
+        try? data.write(to: path, options: .atomic)
+      }
+    }
+  }
+
+  /// Convenience: build and append an entry in one call.
+  public func append(kind: AuditKind, message: String, metadata: [String: String]? = nil) {
+    append(AuditEntry(kind: kind, message: message, metadata: metadata))
+  }
+
+  /// Return up to `limit` most-recent entries, newest first. Malformed lines are
+  /// skipped. Returns an empty array if the log does not yet exist.
+  public func recent(limit: Int = 100) -> [AuditEntry] {
+    queue.sync {
+      guard limit > 0,
+            fileManager.fileExists(atPath: path.path),
+            let text = try? String(contentsOf: path, encoding: .utf8) else {
+        return []
+      }
+      let decoder = Self.makeDecoder()
+      let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+      var result: [AuditEntry] = []
+      result.reserveCapacity(min(limit, lines.count))
+      // Walk from the end (most recent) backwards until we have `limit` entries.
+      for line in lines.reversed() {
+        guard let data = line.data(using: .utf8),
+              let entry = try? decoder.decode(AuditEntry.self, from: data) else {
+          continue
+        }
+        result.append(entry)
+        if result.count >= limit { break }
+      }
+      return result
+    }
+  }
+}

--- a/Sources/ZImage/Server/CharacterStore.swift
+++ b/Sources/ZImage/Server/CharacterStore.swift
@@ -1,0 +1,272 @@
+// CharacterStore.swift — Character registry with JSON persistence (~/.comfybox/characters.json).
+//
+// Swift port of the Coffee Shop image service `src/character-registry.ts`, extended to a
+// feature-complete creative-layer model. A CharacterEntry carries a stable identity plus the
+// render-shaping data the desktop app needs: tiered descriptions gated by content mode,
+// default LoRAs (filename + scale), a reusable prompt snippet, trigger words, a negative
+// prompt, and tags.
+//
+// (Named `CharacterEntry`, matching the TS interface, rather than `Character` — a plain
+// `Character` type would collide with the Swift standard library's `Character` and become
+// ambiguous in modules that import ZImage.)
+//
+// Persistence mirrors the ComfyBoxServerConfig house style: Codable with a tolerant
+// `init(from:)` so partial / older files load with sensible defaults, and an atomic write
+// under the ~/.comfybox home.
+//
+// On-disk format — coexistence note: the file `~/.comfybox/characters.json` is *already
+// read* by the legacy `CharacterLoader` (Telegram bot) as an object keyed by lowercased
+// name, whose values decode as `{ base, banana, avocado }` (base non-optional). To avoid a
+// regression, CharacterStore writes the same object-keyed-by-name shape and always emits a
+// `base` tier (falling back to `description`), so CharacterLoader keeps parsing the file.
+// The richer CharacterEntry fields (id, defaultLoras, promptSnippet, …) are extra keys the
+// legacy decoder ignores. Loading is tolerant of that legacy shape, this superset shape, and
+// a plain JSON array.
+
+import Foundation
+
+/// A reference to a LoRA adapter applied by default for a character.
+///
+/// Mirrors the image-service `LoraReference` (`{ filename, scale }`). `filename` may be a
+/// bare filename, a library id, or an absolute path — the render pipeline resolves it.
+public struct CharacterLoraReference: Codable, Equatable, Sendable {
+  public var filename: String
+  public var scale: Double
+
+  public init(filename: String, scale: Double = 1.0) {
+    self.filename = filename
+    self.scale = scale
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    filename = try c.decodeIfPresent(String.self, forKey: .filename) ?? ""
+    scale = try c.decodeIfPresent(Double.self, forKey: .scale) ?? 1.0
+  }
+}
+
+/// A named character preset. Tiered description fields (`base` / `banana` / `avocado`) let a
+/// single character render safely across content modes: explicit anatomy in `avocado` never
+/// leaks into a neutral (SFW) render.
+///
+/// The flat `description` field is kept for backward compatibility with legacy / runtime-
+/// registered characters that predate the tiered fields; when `base` is present it takes
+/// precedence for assembly (see ``resolvedDescription(for:)``).
+public struct CharacterEntry: Codable, Equatable, Sendable, Identifiable {
+  /// Stable identity. Defaults to a slug of `name` when not supplied.
+  public var id: String
+  public var name: String
+
+  /// Flat description (legacy / fallback). Also used when no tiered `base` is present.
+  public var description: String
+
+  /// SFW physical appearance — always included when assembling a description.
+  public var base: String?
+  /// Suggestive additions — appended in banana + avocado modes.
+  public var banana: String?
+  /// Explicit additions — appended in avocado mode only.
+  public var avocado: String?
+
+  /// LoRAs applied by default when rendering this character.
+  public var defaultLoras: [CharacterLoraReference]
+  /// A reusable prompt fragment injected when this character is selected.
+  public var promptSnippet: String?
+  /// Negative-prompt additions specific to this character.
+  public var negativePrompt: String?
+  /// LoRA trigger words to place early in the prompt (image-service parity).
+  public var triggerWords: String?
+  /// Freeform tags for filtering / grouping.
+  public var tags: [String]
+
+  /// Epoch-millisecond timestamps (parity with image-service StudioProject style).
+  public var createdAt: Int64
+  public var updatedAt: Int64
+
+  public init(
+    id: String? = nil,
+    name: String,
+    description: String = "",
+    base: String? = nil,
+    banana: String? = nil,
+    avocado: String? = nil,
+    defaultLoras: [CharacterLoraReference] = [],
+    promptSnippet: String? = nil,
+    negativePrompt: String? = nil,
+    triggerWords: String? = nil,
+    tags: [String] = [],
+    createdAt: Int64? = nil,
+    updatedAt: Int64? = nil
+  ) {
+    let now = CharacterEntry.nowMillis()
+    self.id = id ?? CharacterEntry.slug(name)
+    self.name = name
+    self.description = description
+    self.base = base
+    self.banana = banana
+    self.avocado = avocado
+    self.defaultLoras = defaultLoras
+    self.promptSnippet = promptSnippet
+    self.negativePrompt = negativePrompt
+    self.triggerWords = triggerWords
+    self.tags = tags
+    self.createdAt = createdAt ?? now
+    self.updatedAt = updatedAt ?? now
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, name, description, base, banana, avocado
+    case defaultLoras, promptSnippet, negativePrompt, triggerWords, tags
+    case createdAt, updatedAt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let name = try c.decodeIfPresent(String.self, forKey: .name) ?? ""
+    self.name = name
+    self.id = try c.decodeIfPresent(String.self, forKey: .id) ?? CharacterEntry.slug(name)
+    self.description = try c.decodeIfPresent(String.self, forKey: .description) ?? ""
+    self.base = try c.decodeIfPresent(String.self, forKey: .base)
+    self.banana = try c.decodeIfPresent(String.self, forKey: .banana)
+    self.avocado = try c.decodeIfPresent(String.self, forKey: .avocado)
+    self.defaultLoras = try c.decodeIfPresent([CharacterLoraReference].self, forKey: .defaultLoras) ?? []
+    self.promptSnippet = try c.decodeIfPresent(String.self, forKey: .promptSnippet)
+    self.negativePrompt = try c.decodeIfPresent(String.self, forKey: .negativePrompt)
+    self.triggerWords = try c.decodeIfPresent(String.self, forKey: .triggerWords)
+    self.tags = try c.decodeIfPresent([String].self, forKey: .tags) ?? []
+    let now = CharacterEntry.nowMillis()
+    self.createdAt = try c.decodeIfPresent(Int64.self, forKey: .createdAt) ?? now
+    self.updatedAt = try c.decodeIfPresent(Int64.self, forKey: .updatedAt) ?? now
+  }
+
+  /// Assemble the effective description for a content mode.
+  ///
+  /// When tiered fields are present, builds `base` (+ `banana` in banana/avocado)
+  /// (+ `avocado` in avocado). When absent, returns the flat `description`.
+  public func resolvedDescription(for mode: ContentModeManager.Mode = .neutral) -> String {
+    guard let base, !base.isEmpty else { return description }
+    var parts = [base]
+    if (mode == .banana || mode == .avocado), let banana, !banana.isEmpty { parts.append(banana) }
+    if mode == .avocado, let avocado, !avocado.isEmpty { parts.append(avocado) }
+    return parts.joined(separator: " ")
+  }
+
+  // MARK: - Helpers
+
+  static func nowMillis() -> Int64 { Int64(Date().timeIntervalSince1970 * 1000) }
+
+  /// Lowercase, hyphenated slug of a name, safe as a filename-free identifier.
+  static func slug(_ name: String) -> String {
+    let lowered = name.lowercased()
+    var out = ""
+    var lastDash = false
+    for ch in lowered {
+      if ch.isLetter || ch.isNumber {
+        out.append(ch)
+        lastDash = false
+      } else if !lastDash && !out.isEmpty {
+        out.append("-")
+        lastDash = true
+      }
+    }
+    while out.hasSuffix("-") { out.removeLast() }
+    return out.isEmpty ? "character" : out
+  }
+}
+
+/// Persistent, serialized character registry backed by `~/.comfybox/characters.json`.
+///
+/// Isolated as an actor so concurrent server routes can list / mutate without data races.
+/// Lookups are case-insensitive on `id` (parity with the TS registry's lowercased keys).
+public actor CharacterStore {
+  private let path: URL
+  private var characters: [String: CharacterEntry] = [:] // key: id.lowercased()
+
+  /// `~/.comfybox/characters.json`.
+  public static func defaultPath() -> URL {
+    URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+      .appendingPathComponent(".comfybox/characters.json")
+  }
+
+  public init(path: URL = CharacterStore.defaultPath()) {
+    self.path = path
+    load()
+  }
+
+  // MARK: - Load / Save
+
+  private func load() {
+    guard let data = try? Data(contentsOf: path), !data.isEmpty else { return }
+    let decoder = JSONDecoder()
+    // Primary / legacy / superset format: object keyed by (lowercased) name.
+    if let object = try? decoder.decode([String: CharacterEntry].self, from: data) {
+      var loaded: [String: CharacterEntry] = [:]
+      for (key, value) in object {
+        // Backfill id/name from the map key when the value omitted them
+        // (legacy CharacterLoader files carry only base/banana/avocado).
+        var entry = value
+        if entry.name.isEmpty { entry.name = key }
+        if entry.id.isEmpty || entry.id == "character" { entry.id = CharacterEntry.slug(entry.name) }
+        loaded[entry.id.lowercased()] = entry
+      }
+      characters = loaded
+      return
+    }
+    // Tolerant fallback: a plain JSON array of characters.
+    if let list = try? decoder.decode([CharacterEntry].self, from: data) {
+      characters = Dictionary(list.map { ($0.id.lowercased(), $0) }, uniquingKeysWith: { _, new in new })
+    }
+  }
+
+  private func persist() {
+    let dir = path.deletingLastPathComponent()
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    // Object keyed by lowercased name, matching the legacy CharacterLoader read format.
+    var object: [String: CharacterEntry] = [:]
+    for character in characters.values {
+      var entry = character
+      // Guarantee a non-empty `base` tier so the legacy CharacterLoader — whose
+      // TieredCharacterDescription.base is non-optional — can still parse the file.
+      if entry.base == nil || entry.base?.isEmpty == true { entry.base = entry.description }
+      object[character.name.lowercased()] = entry
+    }
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    guard let data = try? encoder.encode(object) else { return }
+    try? data.write(to: path, options: .atomic)
+  }
+
+  // MARK: - CRUD
+
+  /// All characters, sorted by name (case-insensitive).
+  public func list() -> [CharacterEntry] {
+    characters.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+  }
+
+  /// Fetch a character by id (case-insensitive). Returns nil if absent.
+  public func get(_ id: String) -> CharacterEntry? {
+    characters[id.lowercased()]
+  }
+
+  /// Insert or update a character, then persist. `updatedAt` is refreshed; `createdAt` is
+  /// preserved from any existing entry with the same id. Returns the stored character.
+  @discardableResult
+  public func upsert(_ character: CharacterEntry) -> CharacterEntry {
+    var entry = character
+    let key = entry.id.lowercased()
+    if let existing = characters[key] {
+      entry.createdAt = existing.createdAt
+    }
+    entry.updatedAt = CharacterEntry.nowMillis()
+    characters[key] = entry
+    persist()
+    return entry
+  }
+
+  /// Delete a character by id (case-insensitive). Returns true if a character was removed.
+  @discardableResult
+  public func delete(_ id: String) -> Bool {
+    let removed = characters.removeValue(forKey: id.lowercased()) != nil
+    if removed { persist() }
+    return removed
+  }
+}

--- a/Sources/ZImage/Server/ContentModeStore.swift
+++ b/Sources/ZImage/Server/ContentModeStore.swift
@@ -1,0 +1,416 @@
+// ContentModeStore.swift — Content-mode (NSFW scaling) registry for ComfyBox.
+//
+// Straight port of the Coffee Shop image service `src/content-mode.ts`. Three modes:
+//   - neutral (default)  — no scaling; auto-detects sensual/explicit intent from the prompt.
+//   - banana  (sensual)  — sensual / suggestive guidance boost + prompt hint.
+//   - avocado (explicit) — explicit / uncensored guidance boost + prompt hint.
+//
+// The store exposes the built-in modes, resolves a `ContentModeEffect` (guidance boost,
+// style variant, prompt hint) for a request, and `apply()`s a mode to a generation request —
+// returning the adjusted guidance plus prompt/negative additions the caller folds in.
+//
+// Per-mode config is persisted to `~/.comfybox/content-modes.json`; the built-in defaults
+// ship in-code so the file is optional and older/partial files load tolerantly.
+
+import Foundation
+
+/// The three content modes ("fruit modes"). Raw values are the wire/JSON tokens.
+public enum ContentMode: String, Codable, CaseIterable, Sendable {
+  case neutral
+  case banana
+  case avocado
+}
+
+/// Style intent the renderer uses to pick preset/LoRA variants.
+public enum ContentStyleVariant: String, Codable, Sendable {
+  case neutral
+  case sensual
+  case nsfw
+}
+
+/// Engine / model descriptor used to decide whether a guidance boost should apply.
+///
+/// CFG-distilled models (z-image-turbo, schnell, lightning) expect guidance ≈ 1.0 — pushing
+/// them above ~1.5 in bf16 produces NaN latents and a black PNG. For those we suppress the
+/// boost entirely; the explicit-content signal then comes from prompt hints + LoRAs, not CFG.
+public struct GuidanceContext: Equatable, Sendable {
+  public var engine: String?
+  public var mode: String?
+  public var model: String?
+  public var baseModel: String?
+
+  public init(engine: String? = nil, mode: String? = nil, model: String? = nil, baseModel: String? = nil) {
+    self.engine = engine
+    self.mode = mode
+    self.model = model
+    self.baseModel = baseModel
+  }
+}
+
+/// The resolved effect of a content mode on a single generation.
+public struct ContentModeEffect: Codable, Equatable, Sendable {
+  public var guidanceBoost: Double
+  public var styleVariant: ContentStyleVariant
+  public var promptHint: String?
+
+  public init(guidanceBoost: Double, styleVariant: ContentStyleVariant, promptHint: String? = nil) {
+    self.guidanceBoost = guidanceBoost
+    self.styleVariant = styleVariant
+    self.promptHint = promptHint
+  }
+}
+
+/// Persisted, editable definition of one content mode. Ships with built-in defaults; a
+/// `~/.comfybox/content-modes.json` file may override the boost/hint/negatives per mode.
+public struct ContentModeDefinition: Codable, Equatable, Sendable {
+  /// Which mode this defines.
+  public var mode: ContentMode
+  /// Human-facing name for UI listing.
+  public var label: String
+  /// Short description for UI listing.
+  public var summary: String
+  /// Guidance boost added to the base/preset guidance (suppressed for CFG-distilled models).
+  public var guidanceBoost: Double
+  /// Style intent handed to the renderer.
+  public var styleVariant: ContentStyleVariant
+  /// Prompt hint appended to the injected keywords (nil for neutral).
+  public var promptHint: String?
+  /// Extra negative-prompt terms folded in when this mode is active.
+  public var negativePromptAdditions: [String]
+
+  public init(
+    mode: ContentMode,
+    label: String,
+    summary: String,
+    guidanceBoost: Double,
+    styleVariant: ContentStyleVariant,
+    promptHint: String? = nil,
+    negativePromptAdditions: [String] = []
+  ) {
+    self.mode = mode
+    self.label = label
+    self.summary = summary
+    self.guidanceBoost = guidanceBoost
+    self.styleVariant = styleVariant
+    self.promptHint = promptHint
+    self.negativePromptAdditions = negativePromptAdditions
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case mode, label, summary, guidanceBoost, styleVariant, promptHint, negativePromptAdditions
+  }
+
+  /// Tolerant decode: a partial entry falls back to the matching built-in for any missing field.
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let mode = try c.decode(ContentMode.self, forKey: .mode)
+    let base = ContentModeDefinition.builtin(mode)
+    self.mode = mode
+    self.label = try c.decodeIfPresent(String.self, forKey: .label) ?? base.label
+    self.summary = try c.decodeIfPresent(String.self, forKey: .summary) ?? base.summary
+    self.guidanceBoost = try c.decodeIfPresent(Double.self, forKey: .guidanceBoost) ?? base.guidanceBoost
+    self.styleVariant = try c.decodeIfPresent(ContentStyleVariant.self, forKey: .styleVariant) ?? base.styleVariant
+    self.promptHint = try c.decodeIfPresent(String.self, forKey: .promptHint) ?? base.promptHint
+    self.negativePromptAdditions =
+      try c.decodeIfPresent([String].self, forKey: .negativePromptAdditions) ?? base.negativePromptAdditions
+  }
+
+  /// The shipped default definition for a mode.
+  public static func builtin(_ mode: ContentMode) -> ContentModeDefinition {
+    switch mode {
+    case .neutral:
+      return ContentModeDefinition(
+        mode: .neutral,
+        label: "Neutral",
+        summary: "Default. No NSFW scaling; sensual/explicit intent is auto-detected from the prompt.",
+        guidanceBoost: 0,
+        styleVariant: .neutral,
+        promptHint: nil,
+        negativePromptAdditions: []
+      )
+    case .banana:
+      return ContentModeDefinition(
+        mode: .banana,
+        label: "Banana",
+        summary: "Sensual / suggestive. Adds a mild guidance boost and intimate prompt hint.",
+        guidanceBoost: 1.5,
+        styleVariant: .sensual,
+        promptHint: "sensual, intimate, suggestive",
+        negativePromptAdditions: []
+      )
+    case .avocado:
+      return ContentModeDefinition(
+        mode: .avocado,
+        label: "Avocado",
+        summary: "Explicit / uncensored. Adds a stronger guidance boost and explicit prompt hint.",
+        guidanceBoost: 2.5,
+        styleVariant: .nsfw,
+        promptHint: "explicit, uncensored, anatomically detailed",
+        negativePromptAdditions: []
+      )
+    }
+  }
+}
+
+/// Input to ``ContentModeStore/apply(_:)``: the request fields the content mode touches.
+public struct ContentModeRequest: Equatable, Sendable {
+  /// Explicit mode; when nil/neutral, the prompt is auto-scanned.
+  public var mode: ContentMode?
+  /// The user prompt (used for auto-detection in neutral mode).
+  public var prompt: String?
+  /// The base/preset guidance, if the request or preset supplied one.
+  public var guidance: Double?
+  /// Engine/model descriptor for CFG-distillation suppression.
+  public var context: GuidanceContext
+
+  public init(
+    mode: ContentMode? = nil,
+    prompt: String? = nil,
+    guidance: Double? = nil,
+    context: GuidanceContext = GuidanceContext()
+  ) {
+    self.mode = mode
+    self.prompt = prompt
+    self.guidance = guidance
+    self.context = context
+  }
+}
+
+/// Result of applying a content mode: the resolved effect plus the concrete adjustments
+/// the caller folds into the outgoing generation request.
+public struct ContentModeResult: Equatable, Sendable {
+  /// The resolved effect (boost, style variant, hint).
+  public var effect: ContentModeEffect
+  /// The final guidance value, or nil when neither a base guidance nor a boost applies.
+  ///
+  /// Mirrors the image service: `base != nil ? base + boost : (boost > 0 ? 3.5 + boost : nil)`.
+  public var guidance: Double?
+  /// Prompt fragments to append to the injected keywords (the mode's prompt hint, if any).
+  public var promptAdditions: [String]
+  /// Extra negative-prompt terms to fold in for the active mode.
+  public var negativePromptAdditions: [String]
+
+  public init(
+    effect: ContentModeEffect,
+    guidance: Double?,
+    promptAdditions: [String],
+    negativePromptAdditions: [String]
+  ) {
+    self.effect = effect
+    self.guidance = guidance
+    self.promptAdditions = promptAdditions
+    self.negativePromptAdditions = negativePromptAdditions
+  }
+}
+
+/// Registry of content modes: lists them, resolves effects, and applies a mode to a request.
+///
+/// Value type mirroring ``ComfyBoxServerConfig``'s persistence style: Codable, tolerant decode,
+/// `~/.comfybox` home, atomic writes. Built-in defaults ship in-code so the JSON file is optional.
+public struct ContentModeStore: Codable, Equatable, Sendable {
+  /// All mode definitions, in canonical (neutral, banana, avocado) order.
+  public var modes: [ContentModeDefinition]
+
+  public init(modes: [ContentModeDefinition] = ContentModeStore.builtinModes()) {
+    self.modes = ContentModeStore.normalize(modes)
+  }
+
+  private enum CodingKeys: String, CodingKey { case modes }
+
+  /// Tolerant decode: a missing/partial `modes` array is backfilled with built-ins.
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let decoded = try c.decodeIfPresent([ContentModeDefinition].self, forKey: .modes) ?? []
+    self.modes = ContentModeStore.normalize(decoded)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(modes, forKey: .modes)
+  }
+
+  // MARK: - Built-ins & normalization
+
+  /// The three shipped mode definitions, in canonical order.
+  public static func builtinModes() -> [ContentModeDefinition] {
+    ContentMode.allCases.map { ContentModeDefinition.builtin($0) }
+  }
+
+  /// Ensure exactly one entry per mode, in canonical order; missing modes are added from
+  /// built-ins and duplicates collapse to the first seen (so a partial file still loads).
+  static func normalize(_ input: [ContentModeDefinition]) -> [ContentModeDefinition] {
+    var seen: [ContentMode: ContentModeDefinition] = [:]
+    for def in input where seen[def.mode] == nil {
+      seen[def.mode] = def
+    }
+    return ContentMode.allCases.map { seen[$0] ?? ContentModeDefinition.builtin($0) }
+  }
+
+  // MARK: - Listing & lookup
+
+  /// The available modes for UI listing (canonical order).
+  public func listModes() -> [ContentModeDefinition] { modes }
+
+  /// The definition for a specific mode (always present after normalization).
+  public func definition(for mode: ContentMode) -> ContentModeDefinition {
+    modes.first { $0.mode == mode } ?? ContentModeDefinition.builtin(mode)
+  }
+
+  // MARK: - CFG-distillation detection
+
+  /// True for any CFG-distilled model (turbo / schnell / lightning family). Those models
+  /// encode unconditional output during training and run at guidance ≈ 1.0 — adding a
+  /// content-mode boost yields NaN latents and a black PNG. Ported 1:1 from `isCfgDistilledModel`.
+  public func isCfgDistilledModel(_ ctx: GuidanceContext) -> Bool {
+    let tokens = [ctx.mode, ctx.model, ctx.baseModel]
+      .compactMap { $0 }
+      .filter { !$0.isEmpty }
+      .map { $0.lowercased() }
+    if tokens.contains(where: { $0.contains("turbo") || $0.contains("schnell") || $0.contains("lightning") }) {
+      return true
+    }
+    // z-image-turbo ships as engine=zimage + mode=z-image-turbo; guard on the engine alone
+    // so a missing mode still trips the check.
+    if ctx.engine == "zimage" && (ctx.mode == nil || ctx.mode!.lowercased().contains("turbo")) {
+      return true
+    }
+    return false
+  }
+
+  // MARK: - Effect resolution
+
+  /// Resolve the content-mode effect for a request. Ported 1:1 from `resolveContentMode`:
+  /// explicit banana/avocado use the mode definition (with boost suppressed for CFG-distilled
+  /// models); neutral/nil auto-detects sensual/explicit intent from the prompt.
+  public func resolveEffect(
+    mode: ContentMode?,
+    prompt: String? = nil,
+    context: GuidanceContext = GuidanceContext()
+  ) -> ContentModeEffect {
+    let suppressBoost = isCfgDistilledModel(context)
+
+    switch mode {
+    case .avocado:
+      let def = definition(for: .avocado)
+      return ContentModeEffect(
+        guidanceBoost: suppressBoost ? 0 : def.guidanceBoost,
+        styleVariant: def.styleVariant,
+        promptHint: def.promptHint
+      )
+    case .banana:
+      let def = definition(for: .banana)
+      return ContentModeEffect(
+        guidanceBoost: suppressBoost ? 0 : def.guidanceBoost,
+        styleVariant: def.styleVariant,
+        promptHint: def.promptHint
+      )
+    case .neutral, .none:
+      // Auto-detect from the prompt when the mode is neutral/undefined.
+      if let prompt, Self.nsfwPattern.matches(prompt) {
+        return ContentModeEffect(guidanceBoost: 0, styleVariant: .nsfw)
+      }
+      if let prompt, Self.sensualPattern.matches(prompt) {
+        return ContentModeEffect(guidanceBoost: 0, styleVariant: .sensual)
+      }
+      return ContentModeEffect(guidanceBoost: 0, styleVariant: .neutral)
+    }
+  }
+
+  // MARK: - Apply
+
+  /// Apply a content mode to a generation request, returning the adjusted guidance and the
+  /// prompt/negative additions to fold in. Guidance math mirrors the image service exactly.
+  public func apply(_ request: ContentModeRequest) -> ContentModeResult {
+    let effect = resolveEffect(mode: request.mode, prompt: request.prompt, context: request.context)
+
+    // base != nil ? base + boost : (boost > 0 ? 3.5 + boost : nil)
+    let guidance: Double?
+    if let base = request.guidance {
+      guidance = base + effect.guidanceBoost
+    } else if effect.guidanceBoost > 0 {
+      guidance = 3.5 + effect.guidanceBoost
+    } else {
+      guidance = nil
+    }
+
+    let promptAdditions = effect.promptHint.map { [$0] } ?? []
+
+    // Negative additions come from the resolved mode's definition (explicit modes). Neutral
+    // auto-detection carries no configured negatives.
+    let resolvedMode = request.mode ?? .neutral
+    let negativeAdditions: [String] =
+      (resolvedMode == .banana || resolvedMode == .avocado)
+      ? definition(for: resolvedMode).negativePromptAdditions
+      : []
+
+    return ContentModeResult(
+      effect: effect,
+      guidance: guidance,
+      promptAdditions: promptAdditions,
+      negativePromptAdditions: negativeAdditions
+    )
+  }
+
+  // MARK: - Auto-detect patterns
+
+  /// Explicit-intent detector. Ported from `NSFW_PROMPT_PATTERN`.
+  static let nsfwPattern = WordPattern(
+    #"\b(nsfw|explicit|erotic|sex(?:ual)?|fetish|masturbat|orgasm|cum|penis|vagina|nude|nudity|naked)\b"#
+  )
+  /// Sensual-intent detector. Ported from `SENSUAL_PROMPT_PATTERN`.
+  static let sensualPattern = WordPattern(
+    #"\b(sensual|boudoir|intimate|suggestive|lingerie|pinup|glamour|topless|bottomless|undress)\b"#
+  )
+
+  // MARK: - Paths & persistence
+
+  /// `~/.comfybox/content-modes.json`.
+  public static func defaultPath() -> URL {
+    ComfyBoxServerConfig.homeDirectory().appendingPathComponent(".comfybox/content-modes.json")
+  }
+
+  /// Load `~/.comfybox/content-modes.json`. If absent or unreadable, ship built-in defaults,
+  /// persist them, and return. Present-but-partial files load tolerantly (backfilled).
+  @discardableResult
+  public static func loadOrCreate(
+    at path: URL = ContentModeStore.defaultPath(),
+    fileManager: FileManager = .default
+  ) -> ContentModeStore {
+    if fileManager.fileExists(atPath: path.path),
+       let data = try? Data(contentsOf: path),
+       let store = try? JSONDecoder().decode(ContentModeStore.self, from: data) {
+      return store
+    }
+    let store = ContentModeStore()
+    try? store.save(to: path, fileManager: fileManager)
+    return store
+  }
+
+  public func save(to path: URL = ContentModeStore.defaultPath(), fileManager: FileManager = .default) throws {
+    let dir = path.deletingLastPathComponent()
+    try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(self)
+    try data.write(to: path, options: .atomic)
+  }
+}
+
+/// A small case-insensitive, word-boundary regex wrapper (compiled once, reused).
+///
+/// `@unchecked Sendable`: the wrapped `NSRegularExpression` is immutable after construction
+/// and documented thread-safe, so sharing the compiled static patterns across threads is safe.
+struct WordPattern: @unchecked Sendable {
+  private let regex: NSRegularExpression?
+
+  init(_ pattern: String) {
+    self.regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+  }
+
+  /// True if the pattern matches anywhere in `text`.
+  func matches(_ text: String) -> Bool {
+    guard let regex else { return false }
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+    return regex.firstMatch(in: text, options: [], range: range) != nil
+  }
+}

--- a/Sources/ZImage/Server/PresetStore.swift
+++ b/Sources/ZImage/Server/PresetStore.swift
@@ -1,0 +1,478 @@
+// PresetStore.swift — Generation presets, persisted to ~/.comfybox/presets.json.
+//
+// Straight port of the Coffee Shop image service's ImagePreset concept and preset
+// resolution (see coffeeshop-image-service: src/types.ts `ImagePreset`,
+// src/service.ts `resolveJobRequest`/`validatePreset`, src/config.ts `DEFAULT_PRESETS`).
+//
+// A preset is a reusable bundle of generation parameters (prompt bits, engine/model/mode,
+// steps, guidance, dimensions, LoRAs, …) keyed by id/name/description. `resolve(id)` merges
+// a preset onto system defaults to yield a fully-populated parameter set — the behavior the
+// Node service exposed at `/v1/presets/resolve`.
+//
+// Persistence mirrors ``ComfyBoxServerConfig``: JSON under ~/.comfybox, tolerant decode
+// (older/partial files load with defaults), atomic writes.
+
+import Foundation
+
+// MARK: - LoRA reference
+
+/// One LoRA a preset applies, by filename + scale. Port of `LoraReference` (types.ts).
+public struct LoraReference: Codable, Equatable, Sendable {
+  public var filename: String
+  public var scale: Double
+
+  public init(filename: String, scale: Double) {
+    self.filename = filename
+    self.scale = scale
+  }
+}
+
+// MARK: - Post-render upscale
+
+/// Optional post-render upscale config. When enabled, callers auto-chain an upscale job
+/// after the base render. Port of `ImagePreset.upscale` (types.ts).
+public struct PresetUpscale: Codable, Equatable, Sendable {
+  public var enabled: Bool
+  public var mode: String?   // "seedvr2" | "controlnet"
+  public var scale: Double?  // default 2
+
+  public init(enabled: Bool, mode: String? = nil, scale: Double? = nil) {
+    self.enabled = enabled
+    self.mode = mode
+    self.scale = scale
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+    mode = try c.decodeIfPresent(String.self, forKey: .mode)
+    scale = try c.decodeIfPresent(Double.self, forKey: .scale)
+  }
+}
+
+// MARK: - ImagePreset
+
+/// A named, reusable set of generation parameters. Port of `ImagePreset` (types.ts).
+///
+/// Decoding is tolerant: only `id`/`name` are truly needed to round-trip; every other field
+/// falls back to nil / empty so partial or older files load cleanly. Enum-like fields
+/// (`mediaKind`, `provider`, `engine`, `mode`, `model`) are kept as free-form strings for the
+/// same forward-compatibility reason the Node config used string unions.
+public struct ImagePreset: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var name: String
+  public var description: String
+
+  // Routing / engine selection.
+  public var mediaKind: String?   // "image" | "video"
+  public var provider: String?    // "local" | "replicate" | "auto"
+  public var engine: String?      // "mflux" | "zimage"
+  public var mode: String?        // MfluxExecutable (e.g. "z-image-turbo", "generate")
+  public var model: String?       // SupportedModel or custom
+  public var customModelPath: String?
+  public var baseModel: String?
+
+  // Prompt shaping.
+  public var prompt: String?
+  public var negativePrompt: String?
+  public var promptPrefix: String?
+  public var promptSuffix: String?
+  public var injectedKeywords: [String]?
+
+  // Numeric generation params.
+  public var steps: Int?
+  public var guidance: Double?
+  public var seed: Int?
+  public var width: Int?
+  public var height: Int?
+
+  // Adapters + scheduler + post-processing.
+  public var loras: [LoraReference]
+  public var scheduler: String?
+  public var upscale: PresetUpscale?
+
+  public init(
+    id: String,
+    name: String,
+    description: String = "",
+    mediaKind: String? = nil,
+    provider: String? = nil,
+    engine: String? = nil,
+    mode: String? = nil,
+    model: String? = nil,
+    customModelPath: String? = nil,
+    baseModel: String? = nil,
+    prompt: String? = nil,
+    negativePrompt: String? = nil,
+    promptPrefix: String? = nil,
+    promptSuffix: String? = nil,
+    injectedKeywords: [String]? = nil,
+    steps: Int? = nil,
+    guidance: Double? = nil,
+    seed: Int? = nil,
+    width: Int? = nil,
+    height: Int? = nil,
+    loras: [LoraReference] = [],
+    scheduler: String? = nil,
+    upscale: PresetUpscale? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.mediaKind = mediaKind
+    self.provider = provider
+    self.engine = engine
+    self.mode = mode
+    self.model = model
+    self.customModelPath = customModelPath
+    self.baseModel = baseModel
+    self.prompt = prompt
+    self.negativePrompt = negativePrompt
+    self.promptPrefix = promptPrefix
+    self.promptSuffix = promptSuffix
+    self.injectedKeywords = injectedKeywords
+    self.steps = steps
+    self.guidance = guidance
+    self.seed = seed
+    self.width = width
+    self.height = height
+    self.loras = loras
+    self.scheduler = scheduler
+    self.upscale = upscale
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, name, description
+    case mediaKind, provider, engine, mode, model, customModelPath, baseModel
+    case prompt, negativePrompt, promptPrefix, promptSuffix, injectedKeywords
+    case steps, guidance, seed, width, height
+    case loras, scheduler, upscale
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    id = try c.decodeIfPresent(String.self, forKey: .id) ?? ""
+    name = try c.decodeIfPresent(String.self, forKey: .name) ?? ""
+    description = try c.decodeIfPresent(String.self, forKey: .description) ?? ""
+    mediaKind = try c.decodeIfPresent(String.self, forKey: .mediaKind)
+    provider = try c.decodeIfPresent(String.self, forKey: .provider)
+    engine = try c.decodeIfPresent(String.self, forKey: .engine)
+    mode = try c.decodeIfPresent(String.self, forKey: .mode)
+    model = try c.decodeIfPresent(String.self, forKey: .model)
+    customModelPath = try c.decodeIfPresent(String.self, forKey: .customModelPath)
+    baseModel = try c.decodeIfPresent(String.self, forKey: .baseModel)
+    prompt = try c.decodeIfPresent(String.self, forKey: .prompt)
+    negativePrompt = try c.decodeIfPresent(String.self, forKey: .negativePrompt)
+    promptPrefix = try c.decodeIfPresent(String.self, forKey: .promptPrefix)
+    promptSuffix = try c.decodeIfPresent(String.self, forKey: .promptSuffix)
+    injectedKeywords = try c.decodeIfPresent([String].self, forKey: .injectedKeywords)
+    steps = try c.decodeIfPresent(Int.self, forKey: .steps)
+    guidance = try c.decodeIfPresent(Double.self, forKey: .guidance)
+    seed = try c.decodeIfPresent(Int.self, forKey: .seed)
+    width = try c.decodeIfPresent(Int.self, forKey: .width)
+    height = try c.decodeIfPresent(Int.self, forKey: .height)
+    // Tolerate a malformed `loras` value by treating it as empty rather than failing the decode.
+    loras = ((try? c.decodeIfPresent([LoraReference].self, forKey: .loras)) ?? nil) ?? []
+    scheduler = try c.decodeIfPresent(String.self, forKey: .scheduler)
+    upscale = try c.decodeIfPresent(PresetUpscale.self, forKey: .upscale)
+  }
+}
+
+// MARK: - Resolution defaults + result
+
+/// System defaults a preset is merged onto in ``PresetStore/resolve(_:)``.
+///
+/// Mirrors the fallback ladder in the Node `resolveJobRequest`: steps→4, width/height→512,
+/// provider→"local", engine→"mflux", mediaKind→"image".
+public struct PresetDefaults: Equatable, Sendable {
+  public var mediaKind: String
+  public var provider: String
+  public var engine: String
+  public var steps: Int
+  public var width: Int
+  public var height: Int
+  public var guidance: Double?
+
+  public init(
+    mediaKind: String = "image",
+    provider: String = "local",
+    engine: String = "mflux",
+    steps: Int = 4,
+    width: Int = 512,
+    height: Int = 512,
+    guidance: Double? = nil
+  ) {
+    self.mediaKind = mediaKind
+    self.provider = provider
+    self.engine = engine
+    self.steps = steps
+    self.width = width
+    self.height = height
+    self.guidance = guidance
+  }
+
+  public static let standard = PresetDefaults()
+}
+
+/// A fully-resolved parameter set: a preset merged onto ``PresetDefaults``. Every routing and
+/// numeric field callers need to launch a render is populated (nil only where genuinely
+/// optional, e.g. `seed`, `model`, `negativePrompt`).
+public struct ResolvedPreset: Codable, Equatable, Sendable {
+  public var id: String
+  public var name: String
+  public var description: String
+
+  public var mediaKind: String
+  public var provider: String
+  public var engine: String
+  public var mode: String?
+  public var model: String?
+  public var customModelPath: String?
+  public var baseModel: String?
+
+  public var prompt: String?
+  public var negativePrompt: String?
+  public var promptPrefix: String?
+  public var promptSuffix: String?
+  public var injectedKeywords: [String]
+
+  public var steps: Int
+  public var guidance: Double?
+  public var seed: Int?
+  public var width: Int
+  public var height: Int
+
+  public var loras: [LoraReference]
+  public var scheduler: String?
+  public var upscale: PresetUpscale?
+
+  public init(preset: ImagePreset, defaults: PresetDefaults = .standard) {
+    id = preset.id
+    name = preset.name
+    description = preset.description
+    mediaKind = preset.mediaKind ?? defaults.mediaKind
+    provider = preset.provider ?? defaults.provider
+    engine = preset.engine ?? defaults.engine
+    mode = preset.mode
+    model = preset.model
+    customModelPath = preset.customModelPath
+    baseModel = preset.baseModel
+    prompt = preset.prompt
+    negativePrompt = preset.negativePrompt
+    promptPrefix = preset.promptPrefix
+    promptSuffix = preset.promptSuffix
+    injectedKeywords = preset.injectedKeywords ?? []
+    steps = preset.steps ?? defaults.steps
+    guidance = preset.guidance ?? defaults.guidance
+    seed = preset.seed
+    width = preset.width ?? defaults.width
+    height = preset.height ?? defaults.height
+    loras = preset.loras
+    scheduler = preset.scheduler
+    upscale = preset.upscale
+  }
+}
+
+// MARK: - Errors
+
+public enum PresetStoreError: Error, Equatable, CustomStringConvertible {
+  case validation(String)
+  case notFound(String)
+
+  public var description: String {
+    switch self {
+    case .validation(let m): return "Preset validation failed: \(m)"
+    case .notFound(let id): return "Preset not found: \(id)"
+    }
+  }
+}
+
+// MARK: - PresetStore
+
+/// Persists generation presets to `~/.comfybox/presets.json` and resolves them against
+/// system defaults. Thread-safe: all access is guarded by an internal lock.
+public final class PresetStore: @unchecked Sendable {
+
+  private let path: URL
+  private let fileManager: FileManager
+  private let defaults: PresetDefaults
+  private let lock = NSLock()
+  private var presets: [ImagePreset]
+
+  /// On-disk envelope. Wrapping the array in an object leaves room for schema growth
+  /// (e.g. a future `version` or `presetMap`) without breaking older readers.
+  private struct PresetFile: Codable {
+    var presets: [ImagePreset]
+  }
+
+  /// `~/.comfybox/presets.json`.
+  public static func defaultPath() -> URL {
+    ComfyBoxServerConfig.homeDirectory().appendingPathComponent(".comfybox/presets.json")
+  }
+
+  /// Seed presets written on first run (file absent). Port of `DEFAULT_PRESETS` (config.ts).
+  public static let defaultPresets: [ImagePreset] = [
+    ImagePreset(
+      id: "zimage-chat",
+      name: "Z-Image Chat",
+      description: "Fast chat lane preset",
+      mediaKind: "image",
+      provider: "local",
+      engine: "zimage",
+      mode: "z-image-turbo",
+      model: "z-image-turbo",
+      steps: 8,
+      guidance: 1,
+      width: 512,
+      height: 512,
+      loras: []
+    ),
+    ImagePreset(
+      id: "schnell-hq",
+      name: "Schnell HQ",
+      description: "Higher-quality mflux preset",
+      mediaKind: "image",
+      provider: "local",
+      engine: "mflux",
+      mode: "generate",
+      model: "schnell",
+      steps: 4,
+      guidance: 3.5,
+      width: 1024,
+      height: 1024,
+      loras: []
+    ),
+  ]
+
+  /// Load presets from `path`. If the file is absent, seed ``defaultPresets`` and persist them.
+  /// A malformed/partial file loads tolerantly (recoverable entries survive; the rest default).
+  public init(
+    path: URL = PresetStore.defaultPath(),
+    defaults: PresetDefaults = .standard,
+    seedDefaults: Bool = true,
+    fileManager: FileManager = .default
+  ) {
+    self.path = path
+    self.defaults = defaults
+    self.fileManager = fileManager
+
+    if fileManager.fileExists(atPath: path.path), let data = try? Data(contentsOf: path) {
+      self.presets = PresetStore.decode(data)
+    } else if seedDefaults {
+      self.presets = PresetStore.defaultPresets
+      try? PresetStore.persist(self.presets, to: path, fileManager: fileManager)
+    } else {
+      self.presets = []
+    }
+  }
+
+  // MARK: Reads
+
+  /// All presets, in insertion order.
+  public func list() -> [ImagePreset] {
+    lock.lock(); defer { lock.unlock() }
+    return presets
+  }
+
+  /// The preset with `id`, or nil.
+  public func get(_ id: String) -> ImagePreset? {
+    lock.lock(); defer { lock.unlock() }
+    return presets.first { $0.id == id }
+  }
+
+  // MARK: Writes
+
+  /// Insert `preset`, or replace the existing one with the same id. Validates first; on success
+  /// the store is persisted atomically. Returns the (validated) stored preset.
+  @discardableResult
+  public func upsert(_ preset: ImagePreset) throws -> ImagePreset {
+    let validated = try PresetStore.validate(preset)
+    lock.lock(); defer { lock.unlock() }
+    if let idx = presets.firstIndex(where: { $0.id == validated.id }) {
+      presets[idx] = validated
+    } else {
+      presets.append(validated)
+    }
+    try PresetStore.persist(presets, to: path, fileManager: fileManager)
+    return validated
+  }
+
+  /// Delete the preset with `id`. Returns true if one was removed. Persists on change.
+  @discardableResult
+  public func delete(_ id: String) throws -> Bool {
+    lock.lock(); defer { lock.unlock() }
+    let before = presets.count
+    presets.removeAll { $0.id == id }
+    let changed = presets.count != before
+    if changed {
+      try PresetStore.persist(presets, to: path, fileManager: fileManager)
+    }
+    return changed
+  }
+
+  // MARK: Resolve
+
+  /// Merge the preset `id` onto the store's ``PresetDefaults`` and return the fully-populated
+  /// parameter set. Port of the `/v1/presets/resolve` behavior. Throws ``PresetStoreError/notFound(_:)``.
+  public func resolve(_ id: String) throws -> ResolvedPreset {
+    guard let preset = get(id) else { throw PresetStoreError.notFound(id) }
+    return ResolvedPreset(preset: preset, defaults: defaults)
+  }
+
+  /// Resolve an in-hand preset against the store's defaults without a lookup.
+  public func resolve(preset: ImagePreset) -> ResolvedPreset {
+    ResolvedPreset(preset: preset, defaults: defaults)
+  }
+
+  // MARK: - Validation
+
+  /// Port of `validatePreset` (service.ts): required non-empty `id`/`name`; when present,
+  /// `steps`/`width`/`height` must be positive integers, and every LoRA scale must be finite.
+  /// Kept lenient on the string enum fields (like the tolerant decode) — the client owns them.
+  static func validate(_ preset: ImagePreset) throws -> ImagePreset {
+    if preset.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      throw PresetStoreError.validation(#"required field "id" is missing or empty"#)
+    }
+    if preset.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      throw PresetStoreError.validation(#"required field "name" is missing or empty"#)
+    }
+    for (label, value) in [("steps", preset.steps), ("width", preset.width), ("height", preset.height)] {
+      if let v = value, v <= 0 {
+        throw PresetStoreError.validation("required field \"\(label)\" must be positive (got \(v))")
+      }
+    }
+    for (i, lora) in preset.loras.enumerated() {
+      if lora.filename.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        throw PresetStoreError.validation("loras[\(i)].filename is missing or empty")
+      }
+      if !lora.scale.isFinite {
+        throw PresetStoreError.validation("loras[\(i)].scale must be a finite number")
+      }
+    }
+    return preset
+  }
+
+  // MARK: - Persistence helpers
+
+  /// Tolerant decode: accepts the `{ "presets": [...] }` envelope or a bare `[...]` array,
+  /// and falls back to empty on unrecoverable input.
+  static func decode(_ data: Data) -> [ImagePreset] {
+    let decoder = JSONDecoder()
+    if let file = try? decoder.decode(PresetFile.self, from: data) {
+      return file.presets
+    }
+    if let array = try? decoder.decode([ImagePreset].self, from: data) {
+      return array
+    }
+    return []
+  }
+
+  static func persist(_ presets: [ImagePreset], to path: URL, fileManager: FileManager) throws {
+    let dir = path.deletingLastPathComponent()
+    try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(PresetFile(presets: presets))
+    try data.write(to: path, options: .atomic)
+  }
+}

--- a/Sources/ZImage/Server/StatsProvider.swift
+++ b/Sources/ZImage/Server/StatsProvider.swift
@@ -1,0 +1,341 @@
+// StatsProvider.swift — Server stats, process/system memory, and a provider-config
+// summary for the ComfyBox warm server.
+//
+// Swift port of the retiring Coffee Shop image service's `src/memory-guard.ts`
+// (memory pressure thresholds + RSS/free/total sampling) and `src/providers-status.ts`
+// (per-provider health/configuration report). This file owns only the *pure* data
+// gathering and formatting — no HTTP route wiring, no network I/O. A later Routes
+// agent surfaces `ServerStatsSnapshot` on an endpoint.
+//
+// The pure/live split keeps threshold and formatting logic unit-testable without
+// asserting on live machine memory:
+//   * `MemoryPressureThresholds.evaluate(...)` — pure classification
+//   * `StatsProvider.memoryStatus(processRssBytes:systemFreeBytes:systemTotalBytes:)` — pure conversion
+//   * `StatsProvider.snapshot(memory:uptimeSeconds:...)` — pure assembly
+//   * `MemoryProbe.*` / `StatsProvider.sampleMemoryStatus()` / `liveSnapshot(...)` — live sampling
+
+import Foundation
+
+// MARK: - Memory pressure
+
+/// Memory-pressure classification. Mirrors `MemoryStatus['pressureLevel']` in
+/// `memory-guard.ts` (`'normal' | 'warning' | 'critical'`).
+public enum MemoryPressureLevel: String, Codable, Sendable {
+  case normal
+  case warning
+  case critical
+}
+
+/// RSS / free-memory thresholds that classify memory pressure. Defaults mirror
+/// `DEFAULT_CONFIG` in `memory-guard.ts` (8 GB warn, 12 GB / 2 GB free critical).
+public struct MemoryPressureThresholds: Codable, Equatable, Sendable {
+  /// Process RSS (MB) at or above which pressure becomes `.warning`. Default 8192 (8 GB).
+  public var warningRssMb: Int
+  /// Process RSS (MB) at or above which pressure becomes `.critical`. Default 12288 (12 GB).
+  public var criticalRssMb: Int
+  /// System available memory (MB) at or below which pressure becomes `.critical`. Default 2048 (2 GB).
+  public var criticalFreeMb: Int
+
+  public init(warningRssMb: Int = 8192, criticalRssMb: Int = 12288, criticalFreeMb: Int = 2048) {
+    self.warningRssMb = warningRssMb
+    self.criticalRssMb = criticalRssMb
+    self.criticalFreeMb = criticalFreeMb
+  }
+
+  /// Default thresholds matching the Node image service.
+  public static let `default` = MemoryPressureThresholds()
+
+  /// Classify pressure from a process RSS and system-free reading (both in MB).
+  ///
+  /// Ordering matches `MemoryGuard.getStatus()`: critical wins over warning, and a
+  /// low free-memory reading forces critical even when RSS is modest.
+  public func evaluate(processRssMb: Int, systemFreeMb: Int) -> MemoryPressureLevel {
+    if processRssMb >= criticalRssMb || systemFreeMb <= criticalFreeMb {
+      return .critical
+    }
+    if processRssMb >= warningRssMb {
+      return .warning
+    }
+    return .normal
+  }
+}
+
+/// Snapshot of process + system memory. Mirrors `MemoryStatus` in `memory-guard.ts`.
+public struct MemoryStatus: Codable, Equatable, Sendable {
+  /// Resident process footprint in MB (`task_vm_info.phys_footprint`).
+  public var processRssMb: Int
+  /// System available memory in MB (free + inactive + speculative + purgeable pages).
+  public var systemFreeMb: Int
+  /// Total physical memory in MB.
+  public var systemTotalMb: Int
+  /// Derived pressure classification.
+  public var pressureLevel: MemoryPressureLevel
+
+  public init(processRssMb: Int, systemFreeMb: Int, systemTotalMb: Int, pressureLevel: MemoryPressureLevel) {
+    self.processRssMb = processRssMb
+    self.systemFreeMb = systemFreeMb
+    self.systemTotalMb = systemTotalMb
+    self.pressureLevel = pressureLevel
+  }
+}
+
+// MARK: - Providers summary
+
+/// Configuration state of one AI capability. This is a *config* summary — it reports
+/// whether a capability is wired up, not whether it is reachable right now (live
+/// reachability probes require async network I/O and belong to the Routes layer).
+public struct ProviderCapabilityStatus: Codable, Equatable, Sendable {
+  /// True when the capability has a usable endpoint / credential in config.
+  public var configured: Bool
+  /// Human-readable hint (endpoint model/url, or why it's unconfigured).
+  public var detail: String?
+
+  public init(configured: Bool, detail: String? = nil) {
+    self.configured = configured
+    self.detail = detail
+  }
+}
+
+/// Which ComfyBox capabilities are configured. Mirrors the per-provider shape of
+/// `ProviderStatusReport` in `providers-status.ts`, restricted to what is knowable
+/// from config alone.
+public struct ProvidersStatusSummary: Codable, Equatable, Sendable {
+  public var promptOptimization: ProviderCapabilityStatus
+  public var vision: ProviderCapabilityStatus
+  public var captioning: ProviderCapabilityStatus
+  public var replicate: ProviderCapabilityStatus
+
+  public init(
+    promptOptimization: ProviderCapabilityStatus,
+    vision: ProviderCapabilityStatus,
+    captioning: ProviderCapabilityStatus,
+    replicate: ProviderCapabilityStatus
+  ) {
+    self.promptOptimization = promptOptimization
+    self.vision = vision
+    self.captioning = captioning
+    self.replicate = replicate
+  }
+
+  /// Number of capabilities that are configured.
+  public var configuredCount: Int {
+    [promptOptimization, vision, captioning, replicate].reduce(0) { $0 + ($1.configured ? 1 : 0) }
+  }
+}
+
+/// Summarizes which capabilities in a ``ComfyBoxServerConfig`` are configured.
+public enum ProvidersStatusSummarizer {
+  /// Build a config-only provider summary.
+  public static func summarize(_ config: ComfyBoxServerConfig) -> ProvidersStatusSummary {
+    ProvidersStatusSummary(
+      promptOptimization: endpointStatus(config.providers.promptOptimization),
+      vision: endpointStatus(config.providers.vision),
+      captioning: endpointStatus(config.providers.captioning),
+      replicate: replicateStatus(config.replicate)
+    )
+  }
+
+  /// An OpenAI-compatible capability is configured when it has a non-empty base URL.
+  static func endpointStatus(_ endpoint: AIProviderEndpoint?) -> ProviderCapabilityStatus {
+    guard let endpoint,
+          !endpoint.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return ProviderCapabilityStatus(configured: false, detail: nil)
+    }
+    let model = endpoint.model.trimmingCharacters(in: .whitespacesAndNewlines)
+    let modelPart = model.isEmpty ? "?" : model
+    return ProviderCapabilityStatus(
+      configured: true,
+      detail: "model=\(modelPart) baseUrl=\(endpoint.baseUrl)"
+    )
+  }
+
+  /// Replicate is configured when an API key is present (mirrors the `not_configured`
+  /// branch of `checkReplicate` in `providers-status.ts`).
+  static func replicateStatus(_ replicate: ReplicateProviderConfig?) -> ProviderCapabilityStatus {
+    guard let replicate,
+          let apiKey = replicate.apiKey,
+          !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return ProviderCapabilityStatus(
+        configured: false,
+        detail: "replicate.apiKey is empty — set it in ~/.comfybox/config.json"
+      )
+    }
+    var bits = ["apiKey set"]
+    if let imageModel = replicate.imageModel, !imageModel.isEmpty { bits.append("imageModel=\(imageModel)") }
+    if let videoModel = replicate.videoModel, !videoModel.isEmpty { bits.append("videoModel=\(videoModel)") }
+    return ProviderCapabilityStatus(configured: true, detail: bits.joined(separator: " "))
+  }
+}
+
+// MARK: - Combined snapshot
+
+/// A complete stats snapshot for the server. Codable so a route can return it directly.
+public struct ServerStatsSnapshot: Codable, Equatable, Sendable {
+  public var uptimeSeconds: Int
+  /// Successful render count, when the caller tracks it.
+  public var renderCount: Int?
+  /// Failed render count, when the caller tracks it.
+  public var failedRenderCount: Int?
+  /// Queued/pending request count, when the caller tracks it.
+  public var pendingCount: Int?
+  public var memory: MemoryStatus
+  public var providers: ProvidersStatusSummary
+
+  public init(
+    uptimeSeconds: Int,
+    renderCount: Int? = nil,
+    failedRenderCount: Int? = nil,
+    pendingCount: Int? = nil,
+    memory: MemoryStatus,
+    providers: ProvidersStatusSummary
+  ) {
+    self.uptimeSeconds = uptimeSeconds
+    self.renderCount = renderCount
+    self.failedRenderCount = failedRenderCount
+    self.pendingCount = pendingCount
+    self.memory = memory
+    self.providers = providers
+  }
+}
+
+// MARK: - Provider
+
+/// Gathers server stats: process/system memory, uptime, render counts, and a
+/// provider-config summary. Pure builders are separated from live samplers so the
+/// classification and formatting logic can be unit-tested deterministically.
+public struct StatsProvider: Sendable {
+  public var thresholds: MemoryPressureThresholds
+
+  public init(thresholds: MemoryPressureThresholds = .default) {
+    self.thresholds = thresholds
+  }
+
+  // MARK: Pure builders
+
+  /// Convert raw byte readings into a classified ``MemoryStatus``. Pure — no sampling.
+  public func memoryStatus(
+    processRssBytes: UInt64,
+    systemFreeBytes: UInt64,
+    systemTotalBytes: UInt64
+  ) -> MemoryStatus {
+    let bytesPerMb: UInt64 = 1024 * 1024
+    let processRssMb = Int(processRssBytes / bytesPerMb)
+    let systemFreeMb = Int(systemFreeBytes / bytesPerMb)
+    let systemTotalMb = Int(systemTotalBytes / bytesPerMb)
+    return MemoryStatus(
+      processRssMb: processRssMb,
+      systemFreeMb: systemFreeMb,
+      systemTotalMb: systemTotalMb,
+      pressureLevel: thresholds.evaluate(processRssMb: processRssMb, systemFreeMb: systemFreeMb)
+    )
+  }
+
+  /// Assemble a full snapshot from an already-sampled ``MemoryStatus``. Pure — no sampling.
+  public func snapshot(
+    memory: MemoryStatus,
+    uptimeSeconds: Int,
+    renderCount: Int? = nil,
+    failedRenderCount: Int? = nil,
+    pendingCount: Int? = nil,
+    config: ComfyBoxServerConfig
+  ) -> ServerStatsSnapshot {
+    ServerStatsSnapshot(
+      uptimeSeconds: max(0, uptimeSeconds),
+      renderCount: renderCount,
+      failedRenderCount: failedRenderCount,
+      pendingCount: pendingCount,
+      memory: memory,
+      providers: ProvidersStatusSummarizer.summarize(config)
+    )
+  }
+
+  /// Whole-number uptime seconds from a start time. Pure.
+  public static func uptimeSeconds(startTime: Date, now: Date = Date()) -> Int {
+    max(0, Int(now.timeIntervalSince(startTime)))
+  }
+
+  // MARK: Live samplers
+
+  /// Sample process + system memory right now and classify it.
+  public func sampleMemoryStatus() -> MemoryStatus {
+    memoryStatus(
+      processRssBytes: MemoryProbe.processFootprintBytes(),
+      systemFreeBytes: MemoryProbe.systemAvailableMemoryBytes(),
+      systemTotalBytes: MemoryProbe.systemTotalMemoryBytes()
+    )
+  }
+
+  /// Sample everything live and assemble a snapshot.
+  public func liveSnapshot(
+    startTime: Date,
+    now: Date = Date(),
+    renderCount: Int? = nil,
+    failedRenderCount: Int? = nil,
+    pendingCount: Int? = nil,
+    config: ComfyBoxServerConfig
+  ) -> ServerStatsSnapshot {
+    snapshot(
+      memory: sampleMemoryStatus(),
+      uptimeSeconds: StatsProvider.uptimeSeconds(startTime: startTime, now: now),
+      renderCount: renderCount,
+      failedRenderCount: failedRenderCount,
+      pendingCount: pendingCount,
+      config: config
+    )
+  }
+}
+
+// MARK: - Low-level memory probes
+
+/// Mach-level memory readings. Kept separate from the pure logic so tests never
+/// depend on live machine state.
+public enum MemoryProbe {
+  /// Resident process footprint in bytes (`task_vm_info.phys_footprint`), matching
+  /// the probe WarmServer already uses. Returns 0 on failure.
+  public static func processFootprintBytes() -> UInt64 {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout.size(ofValue: info) / MemoryLayout<natural_t>.size)
+    let result = withUnsafeMutablePointer(to: &info) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+        task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), rebound, &count)
+      }
+    }
+    guard result == KERN_SUCCESS else { return 0 }
+    return info.phys_footprint
+  }
+
+  /// System *available* memory in bytes: free + inactive + purgeable pages. Mirrors
+  /// `getAvailableMemoryBytes()` in `memory-guard.ts` (which parses `vm_stat` and sums
+  /// free + inactive + speculative + purgeable) but reads
+  /// `host_statistics64(HOST_VM_INFO64)` directly. NOTE: unlike the `vm_stat` CLI,
+  /// `host_statistics64`'s `free_count` already includes speculative pages (see
+  /// `vm_statistics.h`), so speculative is intentionally not added again here — that
+  /// keeps this total equal to the Node figure without double-counting. On macOS a
+  /// "free only" reading wildly under-reports with a warm ~20 GB model resident,
+  /// because the kernel keeps everything else as reclaimable inactive cache.
+  /// Returns 0 on failure.
+  public static func systemAvailableMemoryBytes() -> UInt64 {
+    var stats = vm_statistics64_data_t()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size
+    )
+    let hostPort = mach_host_self()
+    let result = withUnsafeMutablePointer(to: &stats) { pointer in
+      pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+        host_statistics64(hostPort, HOST_VM_INFO64, rebound, &count)
+      }
+    }
+    guard result == KERN_SUCCESS else { return 0 }
+    let pageSize = UInt64(vm_kernel_page_size)
+    let available =
+      UInt64(stats.free_count)
+      + UInt64(stats.inactive_count)
+      + UInt64(stats.purgeable_count)
+    return available * pageSize
+  }
+
+  /// Total physical memory in bytes.
+  public static func systemTotalMemoryBytes() -> UInt64 {
+    ProcessInfo.processInfo.physicalMemory
+  }
+}

--- a/Sources/ZImage/Server/WarmServer.swift
+++ b/Sources/ZImage/Server/WarmServer.swift
@@ -157,6 +157,27 @@ public final class WarmServer {
   /// Default upscale models directory path — ESRGAN weights are stored here.
   private static let upscaleModelsDirectoryPath = ("~/bin/zimage/upscale_models" as NSString).expandingTildeInPath
 
+  // MARK: - Creative-layer stores
+  //
+  // Feature parity with the Coffee Shop image service's creative subsystems. Each persists
+  // to a JSON file under ~/.comfybox/ (characters.json, presets.json, content-modes.json,
+  // audit-log.jsonl). Constructed eagerly so the first request has warm data; they are cheap
+  // (small JSON loads) and thread-safe internally (CharacterStore is an actor; PresetStore /
+  // AuditLog guard with a lock / serial queue; ContentModeStore is a value type).
+
+  /// Character registry (~/.comfybox/characters.json).
+  let characterStore = CharacterStore()
+  /// Generation presets (~/.comfybox/presets.json). Seeds defaults on first run.
+  let presetStore = PresetStore()
+  /// Content-mode definitions (~/.comfybox/content-modes.json). Built-ins ship in-code.
+  let contentModeStore = ContentModeStore.loadOrCreate()
+  /// Append-only audit trail (~/.comfybox/audit-log.jsonl).
+  let auditLog = AuditLog()
+  /// Server stats + memory-pressure sampler (pure logic; live probes isolated).
+  private let statsProvider = StatsProvider()
+  /// Server start time, for the /v1/stats uptime figure.
+  private let serverStartTime = Date()
+
   public init(
     configuration: WarmServerConfiguration,
     host: String = "127.0.0.1",
@@ -813,16 +834,249 @@ public final class WarmServer {
         return .error(response(for: error))
       }
 
+    // MARK: - Creative Layer: Characters
+    // Character registry parity with the image service. Path-parameter routes follow the
+    // /v1/loras/ hasPrefix pattern.
+
+    case ("GET", "/v1/characters"):
+      return await listCharactersResponse()
+
+    case ("POST", "/v1/characters"), ("PUT", "/v1/characters"):
+      return await upsertCharacterResponse(body: request.body)
+
+    case ("GET", _) where request.path.hasPrefix("/v1/characters/"):
+      return await getCharacterResponse(rawId: String(request.path.dropFirst("/v1/characters/".count)))
+
+    case ("DELETE", _) where request.path.hasPrefix("/v1/characters/"):
+      return await deleteCharacterResponse(rawId: String(request.path.dropFirst("/v1/characters/".count)))
+
+    // MARK: - Creative Layer: Presets
+
+    case ("GET", "/v1/presets"):
+      return presetsListResponse()
+
+    case ("POST", "/v1/presets/resolve"):
+      // Match before the generic /v1/presets/ prefix routes below.
+      return resolvePresetResponse(body: request.body)
+
+    case ("POST", "/v1/presets"), ("PUT", "/v1/presets"):
+      return upsertPresetResponse(body: request.body)
+
+    case ("GET", _) where request.path.hasPrefix("/v1/presets/"):
+      return getPresetResponse(rawId: String(request.path.dropFirst("/v1/presets/".count)))
+
+    case ("DELETE", _) where request.path.hasPrefix("/v1/presets/"):
+      return deletePresetResponse(rawId: String(request.path.dropFirst("/v1/presets/".count)))
+
+    // MARK: - Creative Layer: Content modes
+
+    case ("GET", "/v1/content-modes"):
+      return contentModesResponse()
+
+    // MARK: - Creative Layer: Stats / memory
+
+    case ("GET", "/v1/stats"):
+      return await statsResponse()
+
+    case ("GET", "/v1/memory"):
+      return memoryResponse()
+
+    // MARK: - Creative Layer: Audit log
+
+    case ("GET", "/v1/audit-log"):
+      return auditLogResponse(query: request.queryParameters)
+
     default:
       if ["/v1/generate", "/v1/lora/swap", "/v1/shutdown", "/health",
           "/v1/model/load", "/v1/model/activate", "/v1/model/pool", "/v1/model/unload",
-          "/v1/loras", "/v1/loras/scan", "/v1/video/generate", "/v1/upscale"
+          "/v1/loras", "/v1/loras/scan", "/v1/video/generate", "/v1/upscale",
+          "/v1/characters", "/v1/presets", "/v1/presets/resolve",
+          "/v1/content-modes", "/v1/stats", "/v1/memory", "/v1/audit-log"
       ].contains(request.path) || request.path.hasPrefix("/v1/loras/")
-         || request.path.hasPrefix("/v1/video/status/") {
+         || request.path.hasPrefix("/v1/video/status/")
+         || request.path.hasPrefix("/v1/characters/")
+         || request.path.hasPrefix("/v1/presets/") {
         return .error(.error(status: 405, message: "Method not allowed"))
       }
       return .error(.error(status: 404, message: "Not found"))
     }
+  }
+
+  // MARK: - Creative-layer route handlers
+  //
+  // These back the /v1/characters, /v1/presets, /v1/content-modes, /v1/stats, /v1/memory,
+  // and /v1/audit-log routes above. Kept as small private methods so the main route switch
+  // stays readable. Responses use the same helpers as the rest of the server:
+  // `RoutedResponse.json(status:payload:)` (snake_case JSON) and `.error(.error(...))`.
+
+  /// Small `{ success, id, deleted }` payload for DELETE responses.
+  private struct DeleteResult: Encodable {
+    let success: Bool
+    let id: String
+    let deleted: Bool
+  }
+
+  /// Validate + percent-decode a single path-parameter id (rejects empty / nested paths),
+  /// matching the guard the /v1/loras/{id} routes use.
+  private static func pathIdComponent(_ raw: String) -> String? {
+    let decoded = raw.removingPercentEncoding ?? raw
+    guard !decoded.isEmpty, !decoded.contains("/") else { return nil }
+    return decoded
+  }
+
+  // Characters ---------------------------------------------------------------
+
+  private func listCharactersResponse() async -> RoutedResponse {
+    .json(status: 200, payload: await characterStore.list())
+  }
+
+  private func getCharacterResponse(rawId: String) async -> RoutedResponse {
+    guard let id = Self.pathIdComponent(rawId) else {
+      return .error(.error(status: 400, message: "Invalid character id"))
+    }
+    guard let character = await characterStore.get(id) else {
+      return .error(.error(status: 404, message: "Character not found: \(id)"))
+    }
+    return .json(status: 200, payload: character)
+  }
+
+  private func upsertCharacterResponse(body: Data) async -> RoutedResponse {
+    do {
+      let character = try decode(CharacterEntry.self, from: body)
+      guard !character.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return .error(.error(status: 400, message: "Character 'name' is required"))
+      }
+      let saved = await characterStore.upsert(character)
+      auditLog.append(
+        kind: "character.upsert",
+        message: "Upserted character \(saved.id)",
+        metadata: ["id": saved.id, "name": saved.name]
+      )
+      return .json(status: 200, payload: saved)
+    } catch {
+      return .error(.error(status: 400, message: "Invalid character payload: \(error.localizedDescription)"))
+    }
+  }
+
+  private func deleteCharacterResponse(rawId: String) async -> RoutedResponse {
+    guard let id = Self.pathIdComponent(rawId) else {
+      return .error(.error(status: 400, message: "Invalid character id"))
+    }
+    let deleted = await characterStore.delete(id)
+    if deleted {
+      auditLog.append(kind: "character.delete", message: "Deleted character \(id)", metadata: ["id": id])
+    }
+    return .json(status: deleted ? 200 : 404, payload: DeleteResult(success: deleted, id: id, deleted: deleted))
+  }
+
+  // Presets ------------------------------------------------------------------
+
+  private func presetsListResponse() -> RoutedResponse {
+    .json(status: 200, payload: presetStore.list())
+  }
+
+  private func getPresetResponse(rawId: String) -> RoutedResponse {
+    guard let id = Self.pathIdComponent(rawId) else {
+      return .error(.error(status: 400, message: "Invalid preset id"))
+    }
+    guard let preset = presetStore.get(id) else {
+      return .error(.error(status: 404, message: "Preset not found: \(id)"))
+    }
+    return .json(status: 200, payload: preset)
+  }
+
+  private func upsertPresetResponse(body: Data) -> RoutedResponse {
+    do {
+      let preset = try decode(ImagePreset.self, from: body)
+      let saved = try presetStore.upsert(preset)
+      auditLog.append(kind: "preset.upsert", message: "Upserted preset \(saved.id)", metadata: ["id": saved.id])
+      return .json(status: 200, payload: saved)
+    } catch let error as PresetStoreError {
+      return presetErrorResponse(error)
+    } catch {
+      return .error(.error(status: 400, message: "Invalid preset payload: \(error.localizedDescription)"))
+    }
+  }
+
+  private func deletePresetResponse(rawId: String) -> RoutedResponse {
+    guard let id = Self.pathIdComponent(rawId) else {
+      return .error(.error(status: 400, message: "Invalid preset id"))
+    }
+    do {
+      let deleted = try presetStore.delete(id)
+      if deleted {
+        auditLog.append(kind: "preset.delete", message: "Deleted preset \(id)", metadata: ["id": id])
+      }
+      return .json(status: deleted ? 200 : 404, payload: DeleteResult(success: deleted, id: id, deleted: deleted))
+    } catch {
+      return .error(.error(status: 500, message: "Failed to delete preset: \(error.localizedDescription)"))
+    }
+  }
+
+  private func resolvePresetResponse(body: Data) -> RoutedResponse {
+    struct ResolveRequest: Decodable { let id: String }
+    do {
+      let request = try decode(ResolveRequest.self, from: body)
+      let resolved = try presetStore.resolve(request.id)
+      return .json(status: 200, payload: resolved)
+    } catch let error as PresetStoreError {
+      return presetErrorResponse(error)
+    } catch {
+      return .error(.error(status: 400, message: #"Invalid resolve request (expected {"id": ...}): \#(error.localizedDescription)"#))
+    }
+  }
+
+  /// Map a ``PresetStoreError`` to the right HTTP status: validation -> 400, notFound -> 404.
+  private func presetErrorResponse(_ error: PresetStoreError) -> RoutedResponse {
+    switch error {
+    case .validation(let message):
+      return .error(.error(status: 400, message: message))
+    case .notFound(let id):
+      return .error(.error(status: 404, message: "Preset not found: \(id)"))
+    }
+  }
+
+  // Content modes ------------------------------------------------------------
+
+  private func contentModesResponse() -> RoutedResponse {
+    .json(status: 200, payload: contentModeStore.listModes())
+  }
+
+  // Stats / memory -----------------------------------------------------------
+
+  private func statsResponse() async -> RoutedResponse {
+    let queue = await coordinator.queueStatus()
+    let config = ComfyBoxServerConfig.loadOrMigrate()
+    let snapshot = statsProvider.snapshot(
+      memory: statsProvider.sampleMemoryStatus(),
+      uptimeSeconds: StatsProvider.uptimeSeconds(startTime: serverStartTime),
+      renderCount: queue.renderCount,
+      failedRenderCount: queue.failedCount,
+      pendingCount: queue.pendingCount,
+      config: config
+    )
+    return .json(status: 200, payload: snapshot)
+  }
+
+  private func memoryResponse() -> RoutedResponse {
+    .json(status: 200, payload: statsProvider.sampleMemoryStatus())
+  }
+
+  // Audit log ----------------------------------------------------------------
+
+  private func auditLogResponse(query: [String: String]) -> RoutedResponse {
+    let limit = query["limit"].flatMap { Int($0) } ?? 100
+    let entries = auditLog.recent(limit: max(0, limit))
+    // Custom encoder: ISO8601 timestamps (matching the on-disk JSONL). No snake_case
+    // conversion — AuditEntry keys are already flat single words, and converting would
+    // also mangle arbitrary `metadata` dictionary keys.
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(entries) else {
+      return .error(.error(status: 500, message: "Failed to serialize audit log"))
+    }
+    return .json(.rawJSON(status: 200, data: data))
   }
 
 

--- a/Tests/ZImageTests/Server/AuditLogTests.swift
+++ b/Tests/ZImageTests/Server/AuditLogTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import ZImage
+
+final class AuditLogTests: XCTestCase {
+
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-audit-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+  }
+
+  private func makeLog(file: String = "audit-log.jsonl") -> (AuditLog, URL) {
+    let path = tempDir.appendingPathComponent(file)
+    return (AuditLog(path: path), path)
+  }
+
+  // MARK: - Basic append + read back
+
+  func testAppendThenRecentReturnsEntry() {
+    let (log, path) = makeLog()
+    log.append(kind: .generationSubmitted, message: "job started", metadata: ["jobId": "abc"])
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+    let entries = log.recent()
+    XCTAssertEqual(entries.count, 1)
+    XCTAssertEqual(entries[0].kind, .generationSubmitted)
+    XCTAssertEqual(entries[0].message, "job started")
+    XCTAssertEqual(entries[0].metadata?["jobId"], "abc")
+  }
+
+  func testRecentOnMissingFileReturnsEmpty() {
+    let (log, _) = makeLog(file: "does-not-exist.jsonl")
+    XCTAssertTrue(log.recent().isEmpty)
+  }
+
+  // MARK: - Ordering (newest first)
+
+  func testRecentReturnsNewestFirst() {
+    let (log, _) = makeLog()
+    log.append(kind: .generationSubmitted, message: "first")
+    log.append(kind: .generationCompleted, message: "second")
+    log.append(kind: .modelUnload, message: "third")
+
+    let entries = log.recent()
+    XCTAssertEqual(entries.map(\.message), ["third", "second", "first"])
+    XCTAssertEqual(entries.first?.kind, .modelUnload)
+  }
+
+  // MARK: - Limit
+
+  func testRecentRespectsLimit() {
+    let (log, _) = makeLog()
+    for i in 0..<10 {
+      log.append(kind: .configChange, message: "event-\(i)")
+    }
+
+    let entries = log.recent(limit: 3)
+    XCTAssertEqual(entries.count, 3)
+    // Newest first: event-9, event-8, event-7
+    XCTAssertEqual(entries.map(\.message), ["event-9", "event-8", "event-7"])
+  }
+
+  func testRecentLimitLargerThanCountReturnsAll() {
+    let (log, _) = makeLog()
+    log.append(kind: .modelLoad, message: "only")
+    XCTAssertEqual(log.recent(limit: 100).count, 1)
+  }
+
+  func testRecentZeroLimitReturnsEmpty() {
+    let (log, _) = makeLog()
+    log.append(kind: .modelLoad, message: "x")
+    XCTAssertTrue(log.recent(limit: 0).isEmpty)
+  }
+
+  // MARK: - Persistence is append-only across instances
+
+  func testAppendIsPersistentAcrossInstances() {
+    let path = tempDir.appendingPathComponent("shared.jsonl")
+    let first = AuditLog(path: path)
+    first.append(kind: .generationSubmitted, message: "a")
+
+    let second = AuditLog(path: path)
+    second.append(kind: .generationCompleted, message: "b")
+
+    let entries = AuditLog(path: path).recent()
+    XCTAssertEqual(entries.map(\.message), ["b", "a"])
+  }
+
+  // MARK: - Malformed lines are skipped
+
+  func testMalformedLinesAreSkipped() throws {
+    let path = tempDir.appendingPathComponent("mixed.jsonl")
+    let log = AuditLog(path: path)
+    log.append(kind: .generationSubmitted, message: "valid")
+    // Corrupt the file by appending a junk line.
+    let handle = try FileHandle(forWritingTo: path)
+    try handle.seekToEnd()
+    try handle.write(contentsOf: Data("not json\n".utf8))
+    try handle.close()
+
+    let entries = log.recent()
+    XCTAssertEqual(entries.count, 1)
+    XCTAssertEqual(entries[0].message, "valid")
+  }
+
+  // MARK: - Codable round-trip
+
+  func testAuditEntryRoundTrip() throws {
+    let entry = AuditEntry(
+      timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+      kind: .modelLoad,
+      message: "loaded z-image-turbo",
+      metadata: ["path": "/models/z"]
+    )
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(entry)
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(AuditEntry.self, from: data)
+    XCTAssertEqual(decoded, entry)
+  }
+
+  func testUnknownKindDecodesToRawValue() throws {
+    let json = Data(#"{ "kind": "future.event", "message": "hi", "timestamp": "2023-11-14T22:13:20Z" }"#.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(AuditEntry.self, from: json)
+    XCTAssertEqual(decoded.kind, AuditKind("future.event"))
+    XCTAssertNil(decoded.metadata)
+  }
+
+  // MARK: - Concurrent appends serialize cleanly (no interleaved/partial lines)
+
+  func testConcurrentAppendsProduceWellFormedLines() {
+    let (log, _) = makeLog(file: "concurrent.jsonl")
+    let count = 200
+    DispatchQueue.concurrentPerform(iterations: count) { i in
+      log.append(kind: .generationCompleted, message: "msg-\(i)")
+    }
+    let entries = log.recent(limit: count + 10)
+    XCTAssertEqual(entries.count, count)
+    // Every line decoded (no corruption) and messages are unique across the set.
+    XCTAssertEqual(Set(entries.map(\.message)).count, count)
+  }
+}

--- a/Tests/ZImageTests/Server/CharacterStoreTests.swift
+++ b/Tests/ZImageTests/Server/CharacterStoreTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import ZImage
+
+final class CharacterStoreTests: XCTestCase {
+
+  private func makeTempPath() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-character-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("characters.json")
+  }
+
+  private func sampleCharacter() -> CharacterEntry {
+    CharacterEntry(
+      name: "Nova Starling",
+      description: "A confident astronaut.",
+      base: "A confident astronaut in a white flight suit.",
+      banana: "Suit unzipped to the waist.",
+      avocado: "Fully explicit anatomy detail.",
+      defaultLoras: [CharacterLoraReference(filename: "nova.safetensors", scale: 0.8)],
+      promptSnippet: "cinematic lighting, 85mm",
+      negativePrompt: "cartoon, blurry",
+      triggerWords: "novastar",
+      tags: ["scifi", "portrait"]
+    )
+  }
+
+  // MARK: - Model behavior
+
+  func testSlugGeneratedFromName() {
+    XCTAssertEqual(CharacterEntry.slug("Nova Starling"), "nova-starling")
+    XCTAssertEqual(CharacterEntry.slug("  Multi   Space!! "), "multi-space")
+    XCTAssertEqual(CharacterEntry.slug("###"), "character")
+  }
+
+  func testResolvedDescriptionGatedByContentMode() {
+    let c = sampleCharacter()
+    XCTAssertEqual(c.resolvedDescription(for: .neutral), "A confident astronaut in a white flight suit.")
+    XCTAssertEqual(
+      c.resolvedDescription(for: .banana),
+      "A confident astronaut in a white flight suit. Suit unzipped to the waist."
+    )
+    XCTAssertEqual(
+      c.resolvedDescription(for: .avocado),
+      "A confident astronaut in a white flight suit. Suit unzipped to the waist. Fully explicit anatomy detail."
+    )
+  }
+
+  func testResolvedDescriptionFallsBackToFlatWhenNoTiers() {
+    let c = CharacterEntry(name: "Legacy", description: "flat only")
+    XCTAssertEqual(c.resolvedDescription(for: .avocado), "flat only")
+  }
+
+  // MARK: - CRUD
+
+  func testUpsertGetListDelete() async throws {
+    let path = try makeTempPath()
+    let store = CharacterStore(path: path)
+
+    let initial = await store.list()
+    XCTAssertTrue(initial.isEmpty)
+
+    let stored = await store.upsert(sampleCharacter())
+    XCTAssertEqual(stored.id, "nova-starling")
+
+    // get is case-insensitive on id
+    let fetched = await store.get("NOVA-STARLING")
+    XCTAssertEqual(fetched?.name, "Nova Starling")
+    XCTAssertEqual(fetched?.defaultLoras.first?.scale, 0.8)
+
+    let afterInsert = await store.list()
+    XCTAssertEqual(afterInsert.count, 1)
+
+    let deleted = await store.delete("nova-starling")
+    XCTAssertTrue(deleted)
+    let goneAfterDelete = await store.get("nova-starling")
+    XCTAssertNil(goneAfterDelete)
+    let deleteAgain = await store.delete("nova-starling")
+    XCTAssertFalse(deleteAgain)
+    let afterDelete = await store.list()
+    XCTAssertTrue(afterDelete.isEmpty)
+  }
+
+  func testUpsertUpdatesExistingAndPreservesCreatedAt() async throws {
+    let path = try makeTempPath()
+    let store = CharacterStore(path: path)
+
+    let first = await store.upsert(
+      CharacterEntry(id: "hero", name: "Hero", description: "v1", createdAt: 1000, updatedAt: 1000)
+    )
+    XCTAssertEqual(first.createdAt, 1000)
+
+    // A second upsert with the same id must keep createdAt but refresh updatedAt.
+    let second = await store.upsert(CharacterEntry(id: "hero", name: "Hero", description: "v2"))
+    XCTAssertEqual(second.createdAt, 1000)
+    XCTAssertGreaterThanOrEqual(second.updatedAt, 1000)
+    let list = await store.list()
+    XCTAssertEqual(list.count, 1)
+    let hero = await store.get("hero")
+    XCTAssertEqual(hero?.description, "v2")
+  }
+
+  // MARK: - Persistence round-trip
+
+  func testPersistenceRoundTripAcrossInstances() async throws {
+    let path = try makeTempPath()
+
+    let store1 = CharacterStore(path: path)
+    await store1.upsert(sampleCharacter())
+    await store1.upsert(CharacterEntry(name: "Aria Vale", description: "a bard", tags: ["fantasy"]))
+
+    // A fresh instance reads the persisted file.
+    let store2 = CharacterStore(path: path)
+    let list = await store2.list()
+    XCTAssertEqual(list.count, 2)
+    XCTAssertEqual(list.map(\.name), ["Aria Vale", "Nova Starling"]) // name-sorted
+
+    let nova = await store2.get("nova-starling")
+    XCTAssertEqual(nova?.triggerWords, "novastar")
+    XCTAssertEqual(nova?.avocado, "Fully explicit anatomy detail.")
+    XCTAssertEqual(nova?.defaultLoras.first?.filename, "nova.safetensors")
+    XCTAssertEqual(nova?.tags, ["scifi", "portrait"])
+  }
+
+  func testPersistedFileIsNameKeyedObjectOnDisk() async throws {
+    let path = try makeTempPath()
+    let store = CharacterStore(path: path)
+    await store.upsert(sampleCharacter())
+
+    // Persisted as an object keyed by lowercased name (legacy CharacterLoader read format).
+    let data = try Data(contentsOf: path)
+    let decoded = try JSONDecoder().decode([String: CharacterEntry].self, from: data)
+    XCTAssertEqual(decoded.count, 1)
+    XCTAssertEqual(decoded["nova starling"]?.id, "nova-starling")
+  }
+
+  /// Coexistence guard: the legacy CharacterLoader (Telegram bot) must still parse a file
+  /// written by CharacterStore, including a character that had no explicit `base` tier.
+  func testLegacyCharacterLoaderCanReadStoreOutput() async throws {
+    let path = try makeTempPath()
+    let store = CharacterStore(path: path)
+    await store.upsert(sampleCharacter())
+    await store.upsert(CharacterEntry(name: "Flatly", description: "just a flat description"))
+
+    let loader = CharacterLoader(configPath: path.path)
+    XCTAssertTrue(loader.has("nova starling"))
+    // Tiered assembly still works through the legacy loader.
+    XCTAssertEqual(
+      loader.description(for: "nova starling", mode: .banana),
+      "A confident astronaut in a white flight suit. Suit unzipped to the waist."
+    )
+    // Flat-only character got a `base` backfill so the loader (non-optional base) parses it.
+    XCTAssertEqual(loader.description(for: "flatly", mode: .neutral), "just a flat description")
+  }
+
+  // MARK: - Tolerant decode
+
+  func testTolerantDecodeOfPartialCharacterJSON() throws {
+    // Only a name; everything else should default (empty arrays, nil optionals, timestamps).
+    let json = Data(#"{ "name": "Sparse" }"#.utf8)
+    let c = try JSONDecoder().decode(CharacterEntry.self, from: json)
+    XCTAssertEqual(c.name, "Sparse")
+    XCTAssertEqual(c.id, "sparse") // slug backfilled from name
+    XCTAssertEqual(c.description, "")
+    XCTAssertTrue(c.defaultLoras.isEmpty)
+    XCTAssertTrue(c.tags.isEmpty)
+    XCTAssertNil(c.base)
+    XCTAssertGreaterThan(c.createdAt, 0)
+  }
+
+  func testTolerantDecodeOfLegacyNameKeyedObject() async throws {
+    // Legacy TS character-registry format: object keyed by name, values omit id.
+    let path = try makeTempPath()
+    let legacy = #"""
+    {
+      "Nova Starling": { "name": "Nova Starling", "description": "legacy flat", "tags": ["scifi"] }
+    }
+    """#
+    try Data(legacy.utf8).write(to: path)
+
+    let store = CharacterStore(path: path)
+    let list = await store.list()
+    XCTAssertEqual(list.count, 1)
+    let nova = await store.get("nova-starling")
+    XCTAssertEqual(nova?.description, "legacy flat")
+    XCTAssertEqual(nova?.tags, ["scifi"])
+  }
+
+  func testLoraReferenceTolerantDecodeDefaultsScale() throws {
+    let json = Data(#"{ "filename": "x.safetensors" }"#.utf8)
+    let ref = try JSONDecoder().decode(CharacterLoraReference.self, from: json)
+    XCTAssertEqual(ref.filename, "x.safetensors")
+    XCTAssertEqual(ref.scale, 1.0)
+  }
+}

--- a/Tests/ZImageTests/Server/ContentModeTests.swift
+++ b/Tests/ZImageTests/Server/ContentModeTests.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import ZImage
+
+final class ContentModeTests: XCTestCase {
+
+  private func makeTempPath() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-content-modes-tests-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent("content-modes.json")
+  }
+
+  // MARK: - Listing
+
+  func testListModesReturnsThreeBuiltinsInCanonicalOrder() {
+    let store = ContentModeStore()
+    let modes = store.listModes()
+    XCTAssertEqual(modes.map { $0.mode }, [.neutral, .banana, .avocado])
+    XCTAssertEqual(modes.map { $0.label }, ["Neutral", "Banana", "Avocado"])
+  }
+
+  func testBuiltinDefaults() {
+    let store = ContentModeStore()
+    XCTAssertEqual(store.definition(for: .neutral).guidanceBoost, 0)
+    XCTAssertEqual(store.definition(for: .neutral).styleVariant, .neutral)
+    XCTAssertNil(store.definition(for: .neutral).promptHint)
+
+    XCTAssertEqual(store.definition(for: .banana).guidanceBoost, 1.5)
+    XCTAssertEqual(store.definition(for: .banana).styleVariant, .sensual)
+    XCTAssertEqual(store.definition(for: .banana).promptHint, "sensual, intimate, suggestive")
+
+    XCTAssertEqual(store.definition(for: .avocado).guidanceBoost, 2.5)
+    XCTAssertEqual(store.definition(for: .avocado).styleVariant, .nsfw)
+    XCTAssertEqual(store.definition(for: .avocado).promptHint, "explicit, uncensored, anatomically detailed")
+  }
+
+  // MARK: - Effect resolution (parity with resolveContentMode)
+
+  func testResolveAvocado() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: .avocado)
+    XCTAssertEqual(e.guidanceBoost, 2.5)
+    XCTAssertEqual(e.styleVariant, .nsfw)
+    XCTAssertEqual(e.promptHint, "explicit, uncensored, anatomically detailed")
+  }
+
+  func testResolveBanana() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: .banana)
+    XCTAssertEqual(e.guidanceBoost, 1.5)
+    XCTAssertEqual(e.styleVariant, .sensual)
+    XCTAssertEqual(e.promptHint, "sensual, intimate, suggestive")
+  }
+
+  func testResolveNeutralPlain() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: .neutral, prompt: "a cat on a windowsill")
+    XCTAssertEqual(e.guidanceBoost, 0)
+    XCTAssertEqual(e.styleVariant, .neutral)
+    XCTAssertNil(e.promptHint)
+  }
+
+  func testResolveNilModeIsNeutral() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: nil, prompt: "landscape at dawn")
+    XCTAssertEqual(e.styleVariant, .neutral)
+    XCTAssertEqual(e.guidanceBoost, 0)
+  }
+
+  // MARK: - Auto-detection from prompt
+
+  func testNeutralAutoDetectsNsfwPrompt() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: .neutral, prompt: "an explicit erotic scene")
+    XCTAssertEqual(e.styleVariant, .nsfw)
+    XCTAssertEqual(e.guidanceBoost, 0, "auto-detection never boosts guidance")
+    XCTAssertNil(e.promptHint)
+  }
+
+  func testNeutralAutoDetectsSensualPrompt() {
+    let store = ContentModeStore()
+    let e = store.resolveEffect(mode: .neutral, prompt: "a tasteful boudoir portrait in lingerie")
+    XCTAssertEqual(e.styleVariant, .sensual)
+    XCTAssertEqual(e.guidanceBoost, 0)
+  }
+
+  func testNsfwPatternTakesPrecedenceOverSensual() {
+    let store = ContentModeStore()
+    // Prompt matches both patterns; NSFW is checked first.
+    let e = store.resolveEffect(mode: .neutral, prompt: "sensual explicit boudoir")
+    XCTAssertEqual(e.styleVariant, .nsfw)
+  }
+
+  func testAutoDetectIsCaseInsensitive() {
+    let store = ContentModeStore()
+    XCTAssertEqual(store.resolveEffect(mode: .neutral, prompt: "NSFW content").styleVariant, .nsfw)
+    XCTAssertEqual(store.resolveEffect(mode: .neutral, prompt: "NUDE study").styleVariant, .nsfw)
+  }
+
+  func testWordBoundaryAvoidsFalsePositives() {
+    let store = ContentModeStore()
+    // "nude" must not match inside "denude"? "denude" contains "nude" but not on a word boundary.
+    XCTAssertEqual(store.resolveEffect(mode: .neutral, prompt: "prenatal denuded rocks").styleVariant, .neutral)
+  }
+
+  // MARK: - CFG-distilled suppression
+
+  func testCfgDistilledSuppressesBoostForAvocado() {
+    let store = ContentModeStore()
+    let ctx = GuidanceContext(model: "z-image-turbo")
+    let e = store.resolveEffect(mode: .avocado, context: ctx)
+    XCTAssertEqual(e.guidanceBoost, 0, "turbo model suppresses the boost")
+    XCTAssertEqual(e.styleVariant, .nsfw, "style variant + hint survive suppression")
+    XCTAssertEqual(e.promptHint, "explicit, uncensored, anatomically detailed")
+  }
+
+  func testCfgDistilledSuppressesBananaBoost() {
+    let store = ContentModeStore()
+    let ctx = GuidanceContext(baseModel: "schnell")
+    XCTAssertEqual(store.resolveEffect(mode: .banana, context: ctx).guidanceBoost, 0)
+  }
+
+  func testIsCfgDistilledDetection() {
+    let store = ContentModeStore()
+    XCTAssertTrue(store.isCfgDistilledModel(GuidanceContext(model: "some-turbo-model")))
+    XCTAssertTrue(store.isCfgDistilledModel(GuidanceContext(baseModel: "flux-schnell")))
+    XCTAssertTrue(store.isCfgDistilledModel(GuidanceContext(mode: "lightning-4step")))
+    // engine=zimage with no mode trips the check.
+    XCTAssertTrue(store.isCfgDistilledModel(GuidanceContext(engine: "zimage")))
+    XCTAssertTrue(store.isCfgDistilledModel(GuidanceContext(engine: "zimage", mode: "z-image-turbo")))
+    // engine=zimage but an explicit non-turbo mode is NOT distilled.
+    XCTAssertFalse(store.isCfgDistilledModel(GuidanceContext(engine: "zimage", mode: "dev")))
+    // Nothing distilled here.
+    XCTAssertFalse(store.isCfgDistilledModel(GuidanceContext(model: "flux-dev")))
+    XCTAssertFalse(store.isCfgDistilledModel(GuidanceContext()))
+  }
+
+  // MARK: - apply() guidance math + additions
+
+  func testApplyWithBaseGuidanceAddsBoost() {
+    let store = ContentModeStore()
+    let result = store.apply(ContentModeRequest(mode: .avocado, guidance: 4.0))
+    XCTAssertEqual(result.guidance, 6.5)  // 4.0 + 2.5
+    XCTAssertEqual(result.promptAdditions, ["explicit, uncensored, anatomically detailed"])
+  }
+
+  func testApplyWithoutBaseGuidanceUsesFallbackWhenBoosted() {
+    let store = ContentModeStore()
+    let result = store.apply(ContentModeRequest(mode: .banana))
+    XCTAssertEqual(result.guidance, 5.0)  // 3.5 + 1.5
+    XCTAssertEqual(result.promptAdditions, ["sensual, intimate, suggestive"])
+  }
+
+  func testApplyNeutralWithoutBoostYieldsNilGuidance() {
+    let store = ContentModeStore()
+    let result = store.apply(ContentModeRequest(mode: .neutral, prompt: "a quiet forest"))
+    XCTAssertNil(result.guidance)
+    XCTAssertTrue(result.promptAdditions.isEmpty)
+    XCTAssertTrue(result.negativePromptAdditions.isEmpty)
+  }
+
+  func testApplyNeutralPreservesBaseGuidance() {
+    let store = ContentModeStore()
+    let result = store.apply(ContentModeRequest(mode: .neutral, prompt: "a lake", guidance: 3.0))
+    XCTAssertEqual(result.guidance, 3.0)  // 3.0 + 0
+  }
+
+  func testApplySuppressedBoostKeepsBaseGuidance() {
+    let store = ContentModeStore()
+    // turbo model: boost suppressed, so guidance stays at the base value.
+    let result = store.apply(ContentModeRequest(
+      mode: .avocado, guidance: 1.0, context: GuidanceContext(model: "z-image-turbo")))
+    XCTAssertEqual(result.guidance, 1.0)
+    XCTAssertEqual(result.effect.styleVariant, .nsfw)
+    XCTAssertEqual(result.promptAdditions, ["explicit, uncensored, anatomically detailed"])
+  }
+
+  func testApplySuppressedBoostNoBaseGivesNilGuidance() {
+    let store = ContentModeStore()
+    // No base guidance and boost suppressed → nil (fallback only fires when boost > 0).
+    let result = store.apply(ContentModeRequest(
+      mode: .avocado, context: GuidanceContext(engine: "zimage")))
+    XCTAssertNil(result.guidance)
+  }
+
+  func testApplyFoldsInConfiguredNegativeAdditions() throws {
+    var store = ContentModeStore()
+    // Configure a negative addition for avocado.
+    if let idx = store.modes.firstIndex(where: { $0.mode == .avocado }) {
+      store.modes[idx].negativePromptAdditions = ["blurry", "deformed"]
+    }
+    let result = store.apply(ContentModeRequest(mode: .avocado, guidance: 4.0))
+    XCTAssertEqual(result.negativePromptAdditions, ["blurry", "deformed"])
+  }
+
+  // MARK: - Persistence
+
+  func testLoadOrCreateWritesDefaultsWhenAbsent() {
+    let path = makeTempPath()
+    defer { try? FileManager.default.removeItem(at: path.deletingLastPathComponent()) }
+    XCTAssertFalse(FileManager.default.fileExists(atPath: path.path))
+    let store = ContentModeStore.loadOrCreate(at: path)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+    XCTAssertEqual(store.listModes().map { $0.mode }, [.neutral, .banana, .avocado])
+  }
+
+  func testSaveThenLoadRoundTrip() throws {
+    let path = makeTempPath()
+    defer { try? FileManager.default.removeItem(at: path.deletingLastPathComponent()) }
+    var store = ContentModeStore()
+    if let idx = store.modes.firstIndex(where: { $0.mode == .banana }) {
+      store.modes[idx].guidanceBoost = 2.0
+      store.modes[idx].negativePromptAdditions = ["watermark"]
+    }
+    try store.save(to: path)
+    let loaded = ContentModeStore.loadOrCreate(at: path)
+    XCTAssertEqual(loaded.definition(for: .banana).guidanceBoost, 2.0)
+    XCTAssertEqual(loaded.definition(for: .banana).negativePromptAdditions, ["watermark"])
+  }
+
+  func testTolerantDecodeBackfillsMissingModes() throws {
+    // A file with only avocado defined should backfill neutral + banana from built-ins.
+    let json = #"{"modes":[{"mode":"avocado","guidanceBoost":9.0}]}"#
+    let store = try JSONDecoder().decode(ContentModeStore.self, from: Data(json.utf8))
+    XCTAssertEqual(store.listModes().map { $0.mode }, [.neutral, .banana, .avocado])
+    XCTAssertEqual(store.definition(for: .avocado).guidanceBoost, 9.0)
+    // Missing fields backfilled from builtin avocado.
+    XCTAssertEqual(store.definition(for: .avocado).styleVariant, .nsfw)
+    // Backfilled modes keep builtin defaults.
+    XCTAssertEqual(store.definition(for: .banana).guidanceBoost, 1.5)
+  }
+
+  func testTolerantDecodeEmptyGivesAllBuiltins() throws {
+    let store = try JSONDecoder().decode(ContentModeStore.self, from: Data("{}".utf8))
+    XCTAssertEqual(store.listModes().count, 3)
+  }
+
+  func testDuplicateModesCollapseToFirst() throws {
+    let json = #"{"modes":[{"mode":"banana","guidanceBoost":1.0},{"mode":"banana","guidanceBoost":9.0}]}"#
+    let store = try JSONDecoder().decode(ContentModeStore.self, from: Data(json.utf8))
+    XCTAssertEqual(store.definition(for: .banana).guidanceBoost, 1.0)
+  }
+}

--- a/Tests/ZImageTests/Server/PresetStoreTests.swift
+++ b/Tests/ZImageTests/Server/PresetStoreTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import ZImage
+
+final class PresetStoreTests: XCTestCase {
+
+  private func makeTempPath() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("comfybox-preset-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("presets.json")
+  }
+
+  private func sample(id: String = "portrait", name: String = "Portrait") -> ImagePreset {
+    ImagePreset(
+      id: id,
+      name: name,
+      description: "A portrait preset",
+      mediaKind: "image",
+      provider: "local",
+      engine: "zimage",
+      mode: "z-image-turbo",
+      model: "z-image-turbo",
+      prompt: "a person",
+      negativePrompt: "cropped",
+      injectedKeywords: ["cinematic"],
+      steps: 9,
+      guidance: 1.0,
+      seed: 42,
+      width: 1280,
+      height: 1280,
+      loras: [LoraReference(filename: "moody.safetensors", scale: 0.8)],
+      scheduler: "euler"
+    )
+  }
+
+  // MARK: - Seeding / defaults
+
+  func testFirstRunSeedsDefaultPresetsAndPersists() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path)
+    let ids = store.list().map(\.id)
+    XCTAssertEqual(ids, ["zimage-chat", "schnell-hq"])
+    // The seed was written to disk, so a fresh store over the same file sees the same data.
+    let reopened = PresetStore(path: path)
+    XCTAssertEqual(reopened.list().map(\.id), ids)
+  }
+
+  func testSeedDefaultsCanBeDisabled() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path, seedDefaults: false)
+    XCTAssertTrue(store.list().isEmpty)
+  }
+
+  // MARK: - CRUD
+
+  func testUpsertInsertAndReplace() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path, seedDefaults: false)
+
+    let inserted = try store.upsert(sample())
+    XCTAssertEqual(inserted.id, "portrait")
+    XCTAssertEqual(store.list().count, 1)
+    XCTAssertEqual(store.get("portrait")?.name, "Portrait")
+
+    // Same id → replace, not append.
+    var edited = sample()
+    edited.name = "Portrait v2"
+    edited.steps = 12
+    try store.upsert(edited)
+    XCTAssertEqual(store.list().count, 1)
+    XCTAssertEqual(store.get("portrait")?.name, "Portrait v2")
+    XCTAssertEqual(store.get("portrait")?.steps, 12)
+  }
+
+  func testGetMissingReturnsNil() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    XCTAssertNil(store.get("nope"))
+  }
+
+  func testDeleteRemovesAndReportsChange() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path, seedDefaults: false)
+    try store.upsert(sample())
+
+    XCTAssertTrue(try store.delete("portrait"))
+    XCTAssertNil(store.get("portrait"))
+    XCTAssertFalse(try store.delete("portrait")) // second delete is a no-op
+
+    // Deletion persisted.
+    XCTAssertTrue(PresetStore(path: path, seedDefaults: false).list().isEmpty)
+  }
+
+  // MARK: - Validation
+
+  func testUpsertRejectsEmptyId() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    XCTAssertThrowsError(try store.upsert(ImagePreset(id: "  ", name: "X"))) { error in
+      XCTAssertEqual(error as? PresetStoreError, .validation(#"required field "id" is missing or empty"#))
+    }
+  }
+
+  func testUpsertRejectsNonPositiveDimension() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    var bad = sample()
+    bad.width = 0
+    XCTAssertThrowsError(try store.upsert(bad))
+  }
+
+  func testUpsertRejectsEmptyLoraFilename() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    var bad = sample()
+    bad.loras = [LoraReference(filename: "", scale: 0.5)]
+    XCTAssertThrowsError(try store.upsert(bad))
+  }
+
+  // MARK: - Resolve / merge
+
+  func testResolveMergesPresetOntoDefaults() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path, seedDefaults: false)
+    // Sparse preset: only a couple of fields set; the rest must come from defaults.
+    try store.upsert(ImagePreset(id: "sparse", name: "Sparse", engine: "mflux", steps: 20))
+
+    let resolved = try store.resolve("sparse")
+    XCTAssertEqual(resolved.steps, 20)          // from preset
+    XCTAssertEqual(resolved.width, 512)         // from defaults
+    XCTAssertEqual(resolved.height, 512)        // from defaults
+    XCTAssertEqual(resolved.provider, "local")  // from defaults
+    XCTAssertEqual(resolved.engine, "mflux")    // from preset
+    XCTAssertEqual(resolved.mediaKind, "image") // from defaults
+    XCTAssertEqual(resolved.injectedKeywords, [])
+    XCTAssertNil(resolved.seed)
+  }
+
+  func testResolvePrefersPresetValuesOverDefaults() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    try store.upsert(sample())
+    let resolved = try store.resolve("portrait")
+    XCTAssertEqual(resolved.steps, 9)
+    XCTAssertEqual(resolved.width, 1280)
+    XCTAssertEqual(resolved.height, 1280)
+    XCTAssertEqual(resolved.guidance, 1.0)
+    XCTAssertEqual(resolved.seed, 42)
+    XCTAssertEqual(resolved.model, "z-image-turbo")
+    XCTAssertEqual(resolved.injectedKeywords, ["cinematic"])
+    XCTAssertEqual(resolved.loras, [LoraReference(filename: "moody.safetensors", scale: 0.8)])
+    XCTAssertEqual(resolved.scheduler, "euler")
+  }
+
+  func testResolveHonorsCustomDefaults() throws {
+    let path = try makeTempPath()
+    let custom = PresetDefaults(provider: "replicate", engine: "mflux", steps: 30, width: 1024, height: 1536, guidance: 3.5)
+    let store = PresetStore(path: path, defaults: custom, seedDefaults: false)
+    try store.upsert(ImagePreset(id: "bare", name: "Bare"))
+    let resolved = try store.resolve("bare")
+    XCTAssertEqual(resolved.steps, 30)
+    XCTAssertEqual(resolved.width, 1024)
+    XCTAssertEqual(resolved.height, 1536)
+    XCTAssertEqual(resolved.provider, "replicate")
+    XCTAssertEqual(resolved.guidance, 3.5)
+  }
+
+  func testResolveMissingThrowsNotFound() throws {
+    let store = PresetStore(path: try makeTempPath(), seedDefaults: false)
+    XCTAssertThrowsError(try store.resolve("ghost")) { error in
+      XCTAssertEqual(error as? PresetStoreError, .notFound("ghost"))
+    }
+  }
+
+  // MARK: - Round-trip / tolerant decode
+
+  func testPresetCodableRoundTrip() throws {
+    let original = sample()
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ImagePreset.self, from: data)
+    XCTAssertEqual(original, decoded)
+  }
+
+  func testStoreRoundTripThroughDisk() throws {
+    let path = try makeTempPath()
+    let store = PresetStore(path: path, seedDefaults: false)
+    try store.upsert(sample(id: "a", name: "A"))
+    try store.upsert(sample(id: "b", name: "B"))
+
+    let reopened = PresetStore(path: path, seedDefaults: false)
+    XCTAssertEqual(reopened.list(), store.list())
+  }
+
+  func testTolerantDecodeOfPartialPreset() throws {
+    // Only id + name present; everything else must default without throwing.
+    let json = Data(#"{ "id": "min", "name": "Minimal" }"#.utf8)
+    let preset = try JSONDecoder().decode(ImagePreset.self, from: json)
+    XCTAssertEqual(preset.id, "min")
+    XCTAssertEqual(preset.description, "")
+    XCTAssertNil(preset.steps)
+    XCTAssertEqual(preset.loras, [])
+    // Resolving a bare preset yields the full default parameter set.
+    let resolved = ResolvedPreset(preset: preset)
+    XCTAssertEqual(resolved.steps, 4)
+    XCTAssertEqual(resolved.width, 512)
+  }
+
+  func testDecodeAcceptsBareArrayEnvelope() throws {
+    let path = try makeTempPath()
+    // Write a legacy bare-array file (no { presets: ... } wrapper).
+    let bare = try JSONEncoder().encode([sample(id: "legacy", name: "Legacy")])
+    try FileManager.default.createDirectory(at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try bare.write(to: path)
+
+    let store = PresetStore(path: path, seedDefaults: false)
+    XCTAssertEqual(store.list().map(\.id), ["legacy"])
+  }
+
+  func testDecodeGarbageFallsBackToEmpty() {
+    XCTAssertTrue(PresetStore.decode(Data("not json".utf8)).isEmpty)
+  }
+}

--- a/Tests/ZImageTests/Server/StatsProviderTests.swift
+++ b/Tests/ZImageTests/Server/StatsProviderTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+@testable import ZImage
+
+/// Unit tests for the pure formatting / threshold / summary logic in
+/// ``StatsProvider``. Deliberately does not assert on live machine memory —
+/// only the deterministic conversions and classifications are exercised.
+final class StatsProviderTests: XCTestCase {
+
+  // MARK: - Memory pressure thresholds
+
+  func testDefaultThresholdsMatchNodeImageService() {
+    let t = MemoryPressureThresholds.default
+    XCTAssertEqual(t.warningRssMb, 8192)
+    XCTAssertEqual(t.criticalRssMb, 12288)
+    XCTAssertEqual(t.criticalFreeMb, 2048)
+  }
+
+  func testEvaluateNormalWhenLowRssAndAmpleFree() {
+    let t = MemoryPressureThresholds.default
+    XCTAssertEqual(t.evaluate(processRssMb: 4096, systemFreeMb: 32768), .normal)
+  }
+
+  func testEvaluateWarningAtRssBoundary() {
+    let t = MemoryPressureThresholds.default
+    // Just below the warning threshold stays normal.
+    XCTAssertEqual(t.evaluate(processRssMb: 8191, systemFreeMb: 32768), .normal)
+    // At the warning threshold becomes warning.
+    XCTAssertEqual(t.evaluate(processRssMb: 8192, systemFreeMb: 32768), .warning)
+  }
+
+  func testEvaluateCriticalAtRssBoundary() {
+    let t = MemoryPressureThresholds.default
+    // Just below the critical RSS threshold is still only warning.
+    XCTAssertEqual(t.evaluate(processRssMb: 12287, systemFreeMb: 32768), .warning)
+    // At the critical RSS threshold becomes critical.
+    XCTAssertEqual(t.evaluate(processRssMb: 12288, systemFreeMb: 32768), .critical)
+  }
+
+  func testEvaluateCriticalWhenFreeMemoryLowEvenWithModestRss() {
+    let t = MemoryPressureThresholds.default
+    // Low free memory forces critical even though RSS is comfortable.
+    XCTAssertEqual(t.evaluate(processRssMb: 1024, systemFreeMb: 2048), .critical)
+    // One MB above the free threshold is not critical from free alone.
+    XCTAssertEqual(t.evaluate(processRssMb: 1024, systemFreeMb: 2049), .normal)
+  }
+
+  func testEvaluateCriticalWinsOverWarning() {
+    let t = MemoryPressureThresholds.default
+    // RSS in warning range but free memory critical → critical.
+    XCTAssertEqual(t.evaluate(processRssMb: 9000, systemFreeMb: 100), .critical)
+  }
+
+  func testCustomThresholds() {
+    let t = MemoryPressureThresholds(warningRssMb: 1000, criticalRssMb: 2000, criticalFreeMb: 500)
+    XCTAssertEqual(t.evaluate(processRssMb: 999, systemFreeMb: 10000), .normal)
+    XCTAssertEqual(t.evaluate(processRssMb: 1000, systemFreeMb: 10000), .warning)
+    XCTAssertEqual(t.evaluate(processRssMb: 2000, systemFreeMb: 10000), .critical)
+    XCTAssertEqual(t.evaluate(processRssMb: 0, systemFreeMb: 500), .critical)
+  }
+
+  // MARK: - Byte → MB conversion
+
+  func testMemoryStatusConvertsBytesToMegabytes() {
+    let provider = StatsProvider()
+    let mb: UInt64 = 1024 * 1024
+    let status = provider.memoryStatus(
+      processRssBytes: 4096 * mb,
+      systemFreeBytes: 32768 * mb,
+      systemTotalBytes: 65536 * mb
+    )
+    XCTAssertEqual(status.processRssMb, 4096)
+    XCTAssertEqual(status.systemFreeMb, 32768)
+    XCTAssertEqual(status.systemTotalMb, 65536)
+    XCTAssertEqual(status.pressureLevel, .normal)
+  }
+
+  func testMemoryStatusTruncatesSubMegabyteBytes() {
+    let provider = StatsProvider()
+    // 1.5 MB truncates to 1 MB.
+    let status = provider.memoryStatus(
+      processRssBytes: UInt64(1.5 * 1024 * 1024),
+      systemFreeBytes: 0,
+      systemTotalBytes: 0
+    )
+    XCTAssertEqual(status.processRssMb, 1)
+  }
+
+  func testMemoryStatusAppliesThresholdClassification() {
+    let provider = StatsProvider(thresholds: .default)
+    let mb: UInt64 = 1024 * 1024
+    let status = provider.memoryStatus(
+      processRssBytes: 13000 * mb,
+      systemFreeBytes: 32768 * mb,
+      systemTotalBytes: 65536 * mb
+    )
+    XCTAssertEqual(status.pressureLevel, .critical)
+  }
+
+  // MARK: - Uptime
+
+  func testUptimeSecondsWholeNumber() {
+    let start = Date(timeIntervalSince1970: 1000)
+    let now = Date(timeIntervalSince1970: 1042)
+    XCTAssertEqual(StatsProvider.uptimeSeconds(startTime: start, now: now), 42)
+  }
+
+  func testUptimeSecondsNeverNegative() {
+    let start = Date(timeIntervalSince1970: 2000)
+    let now = Date(timeIntervalSince1970: 1000)
+    XCTAssertEqual(StatsProvider.uptimeSeconds(startTime: start, now: now), 0)
+  }
+
+  func testSnapshotClampsNegativeUptime() {
+    let provider = StatsProvider()
+    let memory = MemoryStatus(processRssMb: 100, systemFreeMb: 100, systemTotalMb: 100, pressureLevel: .normal)
+    let snapshot = provider.snapshot(memory: memory, uptimeSeconds: -5, config: ComfyBoxServerConfig())
+    XCTAssertEqual(snapshot.uptimeSeconds, 0)
+  }
+
+  // MARK: - Provider summary
+
+  func testDefaultConfigConfiguresOnlyPromptOptimization() {
+    let summary = ProvidersStatusSummarizer.summarize(ComfyBoxServerConfig())
+    XCTAssertTrue(summary.promptOptimization.configured)
+    XCTAssertFalse(summary.vision.configured)
+    XCTAssertFalse(summary.captioning.configured)
+    XCTAssertFalse(summary.replicate.configured)
+    XCTAssertEqual(summary.configuredCount, 1)
+    // Detail surfaces the model + base URL for a configured endpoint.
+    XCTAssertEqual(
+      summary.promptOptimization.detail,
+      "model=dans-pe-v1.3.0-24b-heresy@8bit baseUrl=http://localhost:1234/v1"
+    )
+  }
+
+  func testUnconfiguredEndpointHasNilDetail() {
+    let summary = ProvidersStatusSummarizer.summarize(ComfyBoxServerConfig())
+    XCTAssertNil(summary.vision.detail)
+  }
+
+  func testAllCapabilitiesConfigured() {
+    var config = ComfyBoxServerConfig()
+    config.providers.vision = AIProviderEndpoint(baseUrl: "http://localhost:1235/v1", model: "moondream")
+    config.providers.captioning = AIProviderEndpoint(baseUrl: "http://localhost:1236/v1", model: "florence")
+    config.replicate = ReplicateProviderConfig(apiKey: "secret", imageModel: "black-forest-labs/flux", videoModel: "kwaivgi/kling")
+
+    let summary = ProvidersStatusSummarizer.summarize(config)
+    XCTAssertTrue(summary.promptOptimization.configured)
+    XCTAssertTrue(summary.vision.configured)
+    XCTAssertTrue(summary.captioning.configured)
+    XCTAssertTrue(summary.replicate.configured)
+    XCTAssertEqual(summary.configuredCount, 4)
+    XCTAssertEqual(summary.replicate.detail, "apiKey set imageModel=black-forest-labs/flux videoModel=kwaivgi/kling")
+  }
+
+  func testReplicateWithEmptyKeyIsUnconfigured() {
+    var config = ComfyBoxServerConfig()
+    config.replicate = ReplicateProviderConfig(apiKey: "   ")
+    let summary = ProvidersStatusSummarizer.summarize(config)
+    XCTAssertFalse(summary.replicate.configured)
+    XCTAssertNotNil(summary.replicate.detail)
+  }
+
+  func testReplicateConfiguredWithKeyOnly() {
+    var config = ComfyBoxServerConfig()
+    config.replicate = ReplicateProviderConfig(apiKey: "secret")
+    let summary = ProvidersStatusSummarizer.summarize(config)
+    XCTAssertTrue(summary.replicate.configured)
+    XCTAssertEqual(summary.replicate.detail, "apiKey set")
+  }
+
+  func testEndpointWithBlankBaseUrlIsUnconfigured() {
+    var config = ComfyBoxServerConfig()
+    config.providers.vision = AIProviderEndpoint(baseUrl: "   ", model: "moondream")
+    let summary = ProvidersStatusSummarizer.summarize(config)
+    XCTAssertFalse(summary.vision.configured)
+  }
+
+  func testEndpointWithEmptyModelShowsQuestionMark() {
+    var config = ComfyBoxServerConfig()
+    config.providers.vision = AIProviderEndpoint(baseUrl: "http://localhost:9/v1", model: "")
+    let summary = ProvidersStatusSummarizer.summarize(config)
+    XCTAssertTrue(summary.vision.configured)
+    XCTAssertEqual(summary.vision.detail, "model=? baseUrl=http://localhost:9/v1")
+  }
+
+  // MARK: - Snapshot assembly & Codable
+
+  func testSnapshotCarriesRenderCountsAndProviders() {
+    let provider = StatsProvider()
+    let memory = MemoryStatus(processRssMb: 500, systemFreeMb: 40000, systemTotalMb: 65536, pressureLevel: .normal)
+    let snapshot = provider.snapshot(
+      memory: memory,
+      uptimeSeconds: 120,
+      renderCount: 7,
+      failedRenderCount: 1,
+      pendingCount: 2,
+      config: ComfyBoxServerConfig()
+    )
+    XCTAssertEqual(snapshot.uptimeSeconds, 120)
+    XCTAssertEqual(snapshot.renderCount, 7)
+    XCTAssertEqual(snapshot.failedRenderCount, 1)
+    XCTAssertEqual(snapshot.pendingCount, 2)
+    XCTAssertEqual(snapshot.memory, memory)
+    XCTAssertEqual(snapshot.providers.configuredCount, 1)
+  }
+
+  func testSnapshotCodableRoundTrip() throws {
+    let provider = StatsProvider()
+    let memory = MemoryStatus(processRssMb: 9000, systemFreeMb: 3000, systemTotalMb: 65536, pressureLevel: .warning)
+    let snapshot = provider.snapshot(
+      memory: memory,
+      uptimeSeconds: 300,
+      renderCount: 42,
+      config: ComfyBoxServerConfig()
+    )
+    let data = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(ServerStatsSnapshot.self, from: data)
+    XCTAssertEqual(snapshot, decoded)
+  }
+
+  func testMemoryPressureLevelEncodesAsRawString() throws {
+    let data = try JSONEncoder().encode(MemoryPressureLevel.critical)
+    XCTAssertEqual(String(data: data, encoding: .utf8), "\"critical\"")
+  }
+}


### PR DESCRIPTION
Builds the ComfyBox Swift API the Electron UI depends on — the first backend wave toward full UI parity. Ported from the Coffee Shop image service; the SwiftUI client will consume these next.

## Routes added
- `GET/POST/PUT/DELETE /v1/characters(/{id})` — CharacterStore (actor), `~/.comfybox/characters.json`
- `GET/POST/PUT/DELETE /v1/presets(/{id})` + `POST /v1/presets/resolve` — PresetStore
- `GET /v1/content-modes` — neutral/banana/avocado, guidance boost + prompt hints + neutral-mode auto-detect
- `GET /v1/stats`, `GET /v1/memory` — RSS/pressure/uptime
- `GET /v1/audit-log` — append-only JSONL

## Verification
- 88 store tests pass (CharacterStore, PresetStore, ContentMode, StatsProvider, AuditLog).
- ComfyBox CLI builds.

Built via a multi-agent workflow (one store per agent) then route-wired and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)