### PR TITLE
Kira tab: tiered scheduler UI, editors, world map, taste verdicts

### DIFF
--- a/Sources/ComfyBoxDesktop/AppContentGate.swift
+++ b/Sources/ComfyBoxDesktop/AppContentGate.swift
@@ -51,6 +51,10 @@ public extension View {
     }
 }
 
+// Explicitly MainActor (Kimi review 2026-07-27): body already runs on the main
+// actor via SwiftUI, but the annotation makes the @Environment(AppContentGate)
+// read provably safe when the package moves to Swift 6 language mode.
+@MainActor
 struct ContentGateModifier: ViewModifier {
     @Environment(AppContentGate.self) private var gate
     let cornerRadius: CGFloat
@@ -100,6 +104,7 @@ public struct GatedText: View {
 /// would advertise hidden content to anyone who opens the app (Todd
 /// 2026-07-18). Revealing is a hidden keyboard shortcut only, handled at the
 /// app level. This just shows a quiet lock so nothing mature is on screen.
+@MainActor
 public struct ContentHiddenWall: View {
     private let note: String
 
@@ -115,6 +120,13 @@ public struct ContentHiddenWall: View {
             Text("Locked")
                 .font(.headline)
                 .foregroundStyle(.secondary)
+            // The note was accepted-but-dropped (Kimi review 2026-07-27).
+            // Rendered quietly: callers pass neutral copy, never a content tease.
+            if !note.isEmpty {
+                Text(note)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(40)

--- a/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
+++ b/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
@@ -83,6 +83,10 @@ public struct KiraStateSnapshot: Equatable, Sendable {
     public var worldPresent: Bool
     public var fetchedAt: Date
 
+    /// Deliberate (Kimi review 2026-07-27 asked): `scores` is a tuple array, so
+    /// Equatable can't be synthesized. fetchedAt is stamped fresh (Date()) on
+    /// every parse, so two distinct fetches never compare equal — this is a
+    /// cheap identity check, not a content diff.
     public static func == (lhs: KiraStateSnapshot, rhs: KiraStateSnapshot) -> Bool {
         lhs.fetchedAt == rhs.fetchedAt
     }
@@ -525,6 +529,11 @@ public final class KiraClient {
             stateError = nil
         } else if state == nil {
             stateError = "GET /v1/kira/state unavailable"
+        } else {
+            // Keep the last snapshot on screen but SAY it's stale (Kimi review
+            // 2026-07-27) — the card's relative fetchedAt stops advancing and
+            // this line explains why.
+            stateError = "state refresh failed — showing last snapshot"
         }
         if let data = await schedulerData {
             scheduler = KiraSchedulerStatus.parse(data)
@@ -532,6 +541,8 @@ public final class KiraClient {
         if let data = await modeData,
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             contentMode = json["mode"] as? String
+            // Absent/empty allow-list keeps the previous value ON PURPOSE — a
+            // transiently malformed payload must not blank the mode picker.
             allowedModes = json["allowed"] as? [String] ?? allowedModes
         }
         if let data = await mediaData,
@@ -683,8 +694,9 @@ public final class KiraClient {
     /// server-side). Live: the scheduler re-reads policy every cycle, so
     /// edits take effect on the next tick without a daemon restart.
     public func updateSchedulerPolicy(_ changes: [String: Any]) async {
+        // perform() already refreshes the dashboard on success (Kimi review
+        // 2026-07-27: this used to call refreshDashboard() a second time).
         await perform("v1/kira/content-scheduler/policy", method: "PUT", body: changes)
-        await refreshDashboard()
     }
 
     // MARK: - Editors (Todd 2026-07-27): character / Her Now / lorebook

--- a/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
+++ b/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
@@ -148,6 +148,112 @@ public struct KiraSchedulerStatus: Equatable, Sendable {
     }
 }
 
+/// `GET/PUT /v1/kira/character` (A6) — Kira's tiered image-prompt description.
+/// Fully editable from the tab; the daemon persists an override file and
+/// re-registers live. Empty strings mean "tier not set" and are dropped from
+/// the PUT payload.
+public struct KiraCharacterDescription: Equatable, Sendable {
+    public static let regionKeys = ["face", "upperBody", "lowerBody", "back", "handsFeet", "hair"]
+
+    public var base: String = ""
+    public var banana: String = ""
+    public var avocado: String = ""
+    public var regions: [String: String] = [:]
+    public var bananaRegion: String = ""
+    public var avocadoRegion: String = ""
+    /// Comma-joined in the editor; sent as an array.
+    public var preserveAnchors: [String] = []
+    public var avocadoAnchor: String = ""
+
+    public static func parse(_ dict: [String: Any]) -> KiraCharacterDescription {
+        var d = KiraCharacterDescription()
+        d.base = dict["base"] as? String ?? ""
+        d.banana = dict["banana"] as? String ?? ""
+        d.avocado = dict["avocado"] as? String ?? ""
+        if let regions = dict["regions"] as? [String: Any] {
+            for key in Self.regionKeys {
+                if let v = regions[key] as? String { d.regions[key] = v }
+            }
+        }
+        d.bananaRegion = dict["bananaRegion"] as? String ?? ""
+        d.avocadoRegion = dict["avocadoRegion"] as? String ?? ""
+        d.preserveAnchors = dict["preserveAnchors"] as? [String] ?? []
+        d.avocadoAnchor = dict["avocadoAnchor"] as? String ?? ""
+        return d
+    }
+
+    /// PUT body — empties dropped so the daemon's normalizer stays authoritative.
+    public func payload() -> [String: Any] {
+        var out: [String: Any] = ["base": base]
+        if !banana.isEmpty { out["banana"] = banana }
+        if !avocado.isEmpty { out["avocado"] = avocado }
+        let regionValues = regions.filter { !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        if !regionValues.isEmpty { out["regions"] = regionValues }
+        if !bananaRegion.isEmpty { out["bananaRegion"] = bananaRegion }
+        if !avocadoRegion.isEmpty { out["avocadoRegion"] = avocadoRegion }
+        let anchors = preserveAnchors.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+        if !anchors.isEmpty { out["preserveAnchors"] = anchors }
+        if !avocadoAnchor.isEmpty { out["avocadoAnchor"] = avocadoAnchor }
+        return out
+    }
+}
+
+/// `GET/PUT /v1/kira/state/now` (A7) — raw mood numbers + labels + arcPhase override.
+public struct KiraNowState: Equatable, Sendable {
+    public var valence: Double
+    public var energy: Double
+    public var moodLabel: String
+    public var energyLabel: String
+    /// The persisted operator override; empty = derived phases active.
+    public var arcPhase: String
+
+    public static func parse(_ json: [String: Any]) -> KiraNowState? {
+        guard let mood = json["mood"] as? [String: Any],
+              let valence = (mood["valence"] as? NSNumber)?.doubleValue,
+              let energy = (mood["energy"] as? NSNumber)?.doubleValue else { return nil }
+        let labels = json["labels"] as? [String: Any]
+        return KiraNowState(
+            valence: valence,
+            energy: energy,
+            moodLabel: labels?["mood"] as? String ?? "",
+            energyLabel: labels?["energy"] as? String ?? "",
+            arcPhase: json["arcPhase"] as? String ?? "")
+    }
+}
+
+/// `GET /v1/lorebook/entries` — the daemon's lorebook (canonical facts injected
+/// into her context by keyword match; pinned entries always ride along).
+public struct KiraLorebookEntry: Identifiable, Equatable, Sendable {
+    public var id: String
+    public var title: String
+    public var enabled: Bool
+    public var pinned: Bool
+    public var keywords: [String]
+    public var content: String
+
+    public static func parse(_ dict: [String: Any]) -> KiraLorebookEntry? {
+        guard let id = dict["id"] as? String, let title = dict["title"] as? String else { return nil }
+        return KiraLorebookEntry(
+            id: id,
+            title: title,
+            enabled: dict["enabled"] as? Bool ?? true,
+            pinned: dict["pinned"] as? Bool ?? false,
+            keywords: dict["keywords"] as? [String] ?? [],
+            content: dict["content"] as? String ?? "")
+    }
+
+    public func payload() -> [String: Any] {
+        [
+            "id": id,
+            "title": title,
+            "enabled": enabled,
+            "pinned": pinned,
+            "keywords": keywords,
+            "content": content,
+        ]
+    }
+}
+
 /// Structured `GET /v1/kira/compute` read model (C1). The daemon proxies three
 /// ComfyBox MCP tools; each nested value arrives as a JSON *string*, so parsing
 /// unwraps them tolerantly (string → parse, object → use, absent → nil).
@@ -281,6 +387,14 @@ public final class KiraClient {
     /// In-flight control action (pause/resume/mode) — disables the controls.
     public private(set) var actionInFlight = false
     public private(set) var actionError: String?
+
+    // Editor read models (Todd 2026-07-27): character description, Her Now
+    // raw numbers, lorebook. Refreshed with the dashboard poll and after writes.
+    public private(set) var character: KiraCharacterDescription?
+    /// 'override' when an operator edit is active, 'default' otherwise.
+    public private(set) var characterSource: String?
+    public private(set) var nowState: KiraNowState?
+    public private(set) var lorebookEntries: [KiraLorebookEntry] = []
 
     private var pollTask: Task<Void, Never>?
     private var dashboardTask: Task<Void, Never>?
@@ -439,6 +553,33 @@ public final class KiraClient {
                 suggestionKinds = kinds
             }
         }
+
+        await refreshEditors()
+    }
+
+    /// Editor read models (A6/A7 + lorebook) — small payloads, refreshed with
+    /// the dashboard poll so writes from any surface converge without a
+    /// dedicated cadence.
+    public func refreshEditors() async {
+        async let characterData = fetch("v1/kira/character")
+        async let nowData = fetch("v1/kira/state/now")
+        async let lorebookData = fetch("v1/lorebook/entries")
+
+        if let data = await characterData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let dict = json["character"] as? [String: Any] {
+            character = KiraCharacterDescription.parse(dict)
+            characterSource = json["source"] as? String
+        }
+        if let data = await nowData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            nowState = KiraNowState.parse(json)
+        }
+        if let data = await lorebookData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let items = json["entries"] as? [[String: Any]] {
+            lorebookEntries = items.compactMap(KiraLorebookEntry.parse)
+        }
     }
 
     /// Drop an idea in the box — Kira picks it up on her next content cycle.
@@ -544,5 +685,46 @@ public final class KiraClient {
     public func updateSchedulerPolicy(_ changes: [String: Any]) async {
         await perform("v1/kira/content-scheduler/policy", method: "PUT", body: changes)
         await refreshDashboard()
+    }
+
+    // MARK: - Editors (Todd 2026-07-27): character / Her Now / lorebook
+
+    /// A6: persist the edited description — live for the very next render.
+    public func saveCharacter(_ desc: KiraCharacterDescription) async {
+        await perform("v1/kira/character", method: "PUT", body: desc.payload())
+    }
+
+    /// A6: drop the override, reverting to the code-canonical description.
+    public func resetCharacter() async {
+        await perform("v1/kira/character", method: "DELETE")
+    }
+
+    /// A7: pin current mood valence/energy (decays back to baseline normally).
+    public func saveMood(valence: Double, energy: Double) async {
+        await perform("v1/kira/state/now", method: "PUT",
+                      body: ["valence": valence, "energy": energy])
+    }
+
+    /// A7: set (or clear, with nil) the persistent arcPhase override.
+    public func saveArcPhase(_ phase: String?) async {
+        let value: Any = phase.map { $0 as Any } ?? NSNull()
+        await perform("v1/kira/state/now", method: "PUT", body: ["arcPhase": value])
+    }
+
+    /// Lorebook upsert: entries with a fresh id go through POST (create), the
+    /// rest through PUT (update). The daemon persists to the vault lorebook.
+    public func addLorebookEntry(title: String, keywords: [String], content: String, pinned: Bool) async {
+        await perform("v1/lorebook/entry", method: "POST", body: [
+            "title": title, "keywords": keywords, "content": content,
+            "pinned": pinned, "enabled": true,
+        ])
+    }
+
+    public func updateLorebookEntry(_ entry: KiraLorebookEntry) async {
+        await perform("v1/lorebook/entry/\(entry.id)", method: "PUT", body: entry.payload())
+    }
+
+    public func deleteLorebookEntry(_ id: String) async {
+        await perform("v1/lorebook/entry/\(id)", method: "DELETE")
     }
 }

--- a/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
+++ b/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
@@ -133,12 +133,22 @@ public struct KiraSchedulerStatus: Equatable, Sendable {
     /// concrete window otherwise — absent also renders as 24/7 for old daemons).
     public var activeHoursStart: String?
     public var activeHoursEnd: String?
+    /// Tiered scheduler v2: per-tier schedule + pacing, keyed by tier name.
+    /// A tier absent from the map is scheduled off.
+    public var tiers: [String: KiraTierConfig] = [:]
 
     public static func parse(_ data: Data) -> KiraSchedulerStatus? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let paused = json["paused"] as? Bool else { return nil }
         let config = json["config"] as? [String: Any]
         let hours = config?["activeHours"] as? [String: Any]
+        var tiers: [String: KiraTierConfig] = [:]
+        if let rawTiers = config?["tiers"] as? [String: Any] {
+            for (key, value) in rawTiers {
+                guard let dict = value as? [String: Any] else { continue }
+                tiers[key] = KiraTierConfig.parse(dict)
+            }
+        }
         return KiraSchedulerStatus(
             paused: paused,
             enabled: config?["enabled"] as? Bool ?? false,
@@ -148,7 +158,63 @@ public struct KiraSchedulerStatus: Equatable, Sendable {
             videoMode: config?["videoMode"] as? String,
             unlimitedImages: config?["unlimitedImages"] as? Bool ?? false,
             activeHoursStart: hours?["start"] as? String,
-            activeHoursEnd: hours?["end"] as? String)
+            activeHoursEnd: hours?["end"] as? String,
+            tiers: tiers)
+    }
+}
+
+/// One tier's schedule + pacing (tiered scheduler v2). nil window = 24/7.
+public struct KiraTierConfig: Equatable, Sendable {
+    public var activeHoursStart: String?
+    public var activeHoursEnd: String?
+    public var imageCount: Int
+    public var unlimitedImages: Bool
+    public var videoCount: Int
+
+    public static func parse(_ dict: [String: Any]) -> KiraTierConfig {
+        let hours = dict["activeHours"] as? [String: Any]
+        return KiraTierConfig(
+            activeHoursStart: hours?["start"] as? String,
+            activeHoursEnd: hours?["end"] as? String,
+            imageCount: (dict["imageCount"] as? NSNumber)?.intValue ?? 2,
+            unlimitedImages: dict["unlimitedImages"] as? Bool ?? false,
+            videoCount: (dict["videoCount"] as? NSNumber)?.intValue ?? 1)
+    }
+
+    /// PUT payload fragment. The tiers PUT is a FULL REPLACEMENT server-side,
+    /// and every tier must carry the activeHours key (null = 24/7).
+    public func payload(isNeutral: Bool) -> [String: Any] {
+        var out: [String: Any] = [:]
+        if let start = activeHoursStart, let end = activeHoursEnd {
+            out["activeHours"] = ["start": start, "end": end]
+        } else {
+            out["activeHours"] = NSNull()
+        }
+        out["imageCount"] = imageCount
+        out["unlimitedImages"] = unlimitedImages
+        if !isNeutral { out["videoCount"] = videoCount }
+        return out
+    }
+}
+
+/// `GET/PUT /v1/kira/stream-mode` — who steers the 24/7 stream.
+/// Precedence: todd override > Kira's choice > schedule.
+public struct KiraStreamStatus: Equatable, Sendable {
+    /// nil exactly when schedule-driven and no tier window is open.
+    public var effectiveMode: String?
+    public var source: String
+    public var todd: String?
+    public var kira: String?
+    public var openTiers: [String]
+
+    public static func parse(_ json: [String: Any]) -> KiraStreamStatus? {
+        guard let source = json["source"] as? String else { return nil }
+        return KiraStreamStatus(
+            effectiveMode: json["effectiveMode"] as? String,
+            source: source,
+            todd: json["todd"] as? String,
+            kira: json["kira"] as? String,
+            openTiers: json["openTiers"] as? [String] ?? [])
     }
 }
 
@@ -399,6 +465,8 @@ public final class KiraClient {
     public private(set) var characterSource: String?
     public private(set) var nowState: KiraNowState?
     public private(set) var lorebookEntries: [KiraLorebookEntry] = []
+    /// Tiered scheduler v2: who steers the 24/7 stream right now.
+    public private(set) var streamStatus: KiraStreamStatus?
 
     private var pollTask: Task<Void, Never>?
     private var dashboardTask: Task<Void, Never>?
@@ -575,6 +643,7 @@ public final class KiraClient {
         async let characterData = fetch("v1/kira/character")
         async let nowData = fetch("v1/kira/state/now")
         async let lorebookData = fetch("v1/lorebook/entries")
+        async let streamData = fetch("v1/kira/stream-mode")
 
         if let data = await characterData,
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -591,13 +660,20 @@ public final class KiraClient {
            let items = json["entries"] as? [[String: Any]] {
             lorebookEntries = items.compactMap(KiraLorebookEntry.parse)
         }
+        if let data = await streamData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            streamStatus = KiraStreamStatus.parse(json)
+        }
     }
 
     /// Drop an idea in the box — Kira picks it up on her next content cycle.
-    public func addSuggestion(kind: String, text: String) async {
+    /// An optional tier tag holds the idea for a cycle of that tier.
+    public func addSuggestion(kind: String, text: String, tier: String? = nil) async {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        await perform("v1/kira/suggestions", method: "POST", body: ["kind": kind, "text": trimmed])
+        var body: [String: Any] = ["kind": kind, "text": trimmed]
+        if let tier { body["tier"] = tier }
+        await perform("v1/kira/suggestions", method: "POST", body: body)
     }
 
     public func deleteSuggestion(_ id: String) async {
@@ -697,6 +773,22 @@ public final class KiraClient {
         // perform() already refreshes the dashboard on success (Kimi review
         // 2026-07-27: this used to call refreshDashboard() a second time).
         await perform("v1/kira/content-scheduler/policy", method: "PUT", body: changes)
+    }
+
+    /// Tiered scheduler v2: replace the whole tiers map (server semantics —
+    /// a tier omitted from the payload is scheduled off).
+    public func updateSchedulerTiers(_ tiers: [String: KiraTierConfig]) async {
+        var payload: [String: Any] = [:]
+        for (mode, tier) in tiers {
+            payload[mode] = tier.payload(isNeutral: mode == "neutral")
+        }
+        await perform("v1/kira/content-scheduler/policy", method: "PUT", body: ["tiers": payload])
+    }
+
+    /// Tiered scheduler v2: set/clear the owner's sticky stream override.
+    public func setStreamOverride(_ mode: String?) async {
+        await perform("v1/kira/stream-mode", method: "PUT",
+                      body: ["todd": mode.map { $0 as Any } ?? NSNull()])
     }
 
     // MARK: - Editors (Todd 2026-07-27): character / Her Now / lorebook

--- a/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
+++ b/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
@@ -394,6 +394,39 @@ public struct KiraMediaItem: Identifiable, Equatable, Sendable {
     public var mtimeMs: Double
 }
 
+/// World-map entity (`/v1/kira/world`, Todd 2026-07-29): her people AND
+/// places in one bounded store — kinds friend/pet/person/place, with the
+/// map-specific `relation` ("her Tita") and `where` ("above Barkada Brew").
+public struct KiraWorldEntity: Identifiable, Equatable, Sendable {
+    public var id: String { name.lowercased() }
+    public var name: String
+    public var kind: String
+    public var persona: String
+    public var relation: String
+    public var location: String   // wire field `where` (Swift keyword)
+    public var facts: [String]
+
+    public var isPlace: Bool { kind == "place" }
+
+    public static func parse(_ item: [String: Any]) -> KiraWorldEntity? {
+        guard let name = item["name"] as? String, !name.isEmpty else { return nil }
+        return KiraWorldEntity(
+            name: name,
+            kind: item["kind"] as? String ?? "friend",
+            persona: item["persona"] as? String ?? "",
+            relation: item["relation"] as? String ?? "",
+            location: item["where"] as? String ?? "",
+            facts: item["facts"] as? [String] ?? [])
+    }
+
+    public func payload() -> [String: Any] {
+        var out: [String: Any] = ["name": name, "kind": kind, "persona": persona, "facts": facts]
+        if !relation.isEmpty { out["relation"] = relation }
+        if !location.isEmpty { out["where"] = location }
+        return out
+    }
+}
+
 /// Suggestion-box entry (`/v1/kira/suggestions`). Kinds: image/video seed one
 /// render (consumed FIFO), session themes one cycle (consumed), arc is sticky
 /// context until removed.
@@ -467,6 +500,10 @@ public final class KiraClient {
     public private(set) var lorebookEntries: [KiraLorebookEntry] = []
     /// Tiered scheduler v2: who steers the 24/7 stream right now.
     public private(set) var streamStatus: KiraStreamStatus?
+    /// World map (Todd 2026-07-29): her people + places, editable.
+    public private(set) var world: [KiraWorldEntity] = []
+    /// Per-path taste verdicts sent this app run (for immediate ❤️/😐 feedback).
+    public private(set) var tasteSent: [String: String] = [:]
 
     private var pollTask: Task<Void, Never>?
     private var dashboardTask: Task<Void, Never>?
@@ -644,6 +681,13 @@ public final class KiraClient {
         async let nowData = fetch("v1/kira/state/now")
         async let lorebookData = fetch("v1/lorebook/entries")
         async let streamData = fetch("v1/kira/stream-mode")
+        async let worldData = fetch("v1/kira/world")
+
+        if let data = await worldData,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let items = json["entities"] as? [[String: Any]] {
+            world = items.compactMap(KiraWorldEntity.parse)
+        }
 
         if let data = await characterData,
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -830,5 +874,24 @@ public final class KiraClient {
 
     public func deleteLorebookEntry(_ id: String) async {
         await perform("v1/lorebook/entry/\(id)", method: "DELETE")
+    }
+
+    // MARK: - World map (Todd 2026-07-29)
+
+    /// PUT is a FULL replacement — the daemon caps/validates and the next
+    /// refresh reads back exactly what it kept.
+    public func saveWorld(_ entities: [KiraWorldEntity]) async {
+        await perform("v1/kira/world", method: "PUT",
+                      body: ["entities": entities.map { $0.payload() }])
+        await refreshEditors()
+    }
+
+    // MARK: - Taste (Inner Loop F3)
+
+    /// ❤️/😐 on a rendered item — feeds her draw-weighting taste store.
+    public func sendTaste(path: String, verdict: String) async {
+        await perform("v1/kira/taste", method: "POST",
+                      body: ["path": path, "verdict": verdict])
+        tasteSent[path] = verdict
     }
 }

--- a/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
+++ b/Sources/ComfyBoxDesktop/Kira/KiraClient.swift
@@ -124,11 +124,17 @@ public struct KiraSchedulerStatus: Equatable, Sendable {
     /// Unlimited-within-cycle images: renders chain until the cycle window
     /// closes; imageCount is ignored while true.
     public var unlimitedImages: Bool
+    /// Content-creation window "HH:MM" (server-local; start > end wraps
+    /// midnight). nil = 24/7 (the daemon serves explicit null for 24/7 and a
+    /// concrete window otherwise — absent also renders as 24/7 for old daemons).
+    public var activeHoursStart: String?
+    public var activeHoursEnd: String?
 
     public static func parse(_ data: Data) -> KiraSchedulerStatus? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let paused = json["paused"] as? Bool else { return nil }
         let config = json["config"] as? [String: Any]
+        let hours = config?["activeHours"] as? [String: Any]
         return KiraSchedulerStatus(
             paused: paused,
             enabled: config?["enabled"] as? Bool ?? false,
@@ -136,7 +142,9 @@ public struct KiraSchedulerStatus: Equatable, Sendable {
             imageCount: (config?["imageCount"] as? NSNumber)?.intValue,
             videoCount: (config?["videoCount"] as? NSNumber)?.intValue,
             videoMode: config?["videoMode"] as? String,
-            unlimitedImages: config?["unlimitedImages"] as? Bool ?? false)
+            unlimitedImages: config?["unlimitedImages"] as? Bool ?? false,
+            activeHoursStart: hours?["start"] as? String,
+            activeHoursEnd: hours?["end"] as? String)
     }
 }
 

--- a/Sources/ComfyBoxDesktop/Views/KiraEditorsView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraEditorsView.swift
@@ -282,3 +282,111 @@ struct KiraLorebookCard: View {
         }
     }
 }
+
+// MARK: - World map (Todd 2026-07-29)
+
+/// Her people + places (`/v1/kira/world`) — the persisted map that rides every
+/// turn's state block. Full-replacement PUT: edit drafts locally, Apply saves
+/// the whole map; the daemon caps/validates and the next poll reads back what
+/// it kept. Kira edits the same store live via her `update_world` tool, so
+/// Revert also picks up anything she added since the drafts loaded.
+struct KiraWorldMapCard: View {
+    @Bindable var client: KiraClient
+    @State private var draft: [KiraWorldEntity] = []
+    @State private var loadedFor: [KiraWorldEntity]?
+    @State private var newName = ""
+    @State private var newKind = "place"
+
+    private static let kinds = ["friend", "person", "pet", "place"]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            section("People", entities: draft.filter { !$0.isPlace })
+            section("Places", entities: draft.filter { $0.isPlace })
+            HStack(spacing: 8) {
+                TextField("new entry name", text: $newName)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 180)
+                Picker("", selection: $newKind) {
+                    ForEach(Self.kinds, id: \.self) { Text($0) }
+                }
+                .frame(width: 90)
+                Button("Add") {
+                    let name = newName.trimmingCharacters(in: .whitespaces)
+                    guard !name.isEmpty,
+                          !draft.contains(where: { $0.name.lowercased() == name.lowercased() })
+                    else { return }
+                    draft.append(KiraWorldEntity(
+                        name: name, kind: newKind, persona: "",
+                        relation: "", location: "", facts: []))
+                    newName = ""
+                }
+                .disabled(newName.trimmingCharacters(in: .whitespaces).isEmpty)
+                Spacer()
+                Button("Revert") { draft = client.world; loadedFor = client.world }
+                    .disabled(draft == client.world)
+                Button("Apply") { Task { await client.saveWorld(draft) } }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(draft == client.world || client.actionInFlight)
+            }
+            Text("She maintains this map herself with update_world — Revert pulls in anything she added. Deleting here sticks: seeds never resurrect.")
+                .font(.caption2).foregroundStyle(.tertiary)
+        }
+        .onAppear { syncDrafts() }
+        .onChange(of: client.world) { syncDrafts() }
+    }
+
+    /// Load drafts from the live map, but never clobber unsaved local edits
+    /// (same guard pattern as the character card's loadedFor).
+    private func syncDrafts() {
+        guard loadedFor != client.world else { return }
+        if draft == (loadedFor ?? []) { draft = client.world }
+        loadedFor = client.world
+    }
+
+    @ViewBuilder private func section(_ title: String, entities: [KiraWorldEntity]) -> some View {
+        if !entities.isEmpty {
+            Text(title).font(.caption).bold().foregroundStyle(.secondary)
+            ForEach(entities) { entity in
+                row(entity)
+            }
+        }
+    }
+
+    @ViewBuilder private func row(_ entity: KiraWorldEntity) -> some View {
+        if let idx = draft.firstIndex(where: { $0.id == entity.id }) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(draft[idx].name).font(.callout).bold()
+                    Text(draft[idx].kind)
+                        .font(.caption2)
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(.quaternary, in: Capsule())
+                    Spacer()
+                    Button(role: .destructive) {
+                        draft.remove(at: idx)
+                    } label: { Image(systemName: "trash") }
+                        .buttonStyle(.borderless)
+                        .help("Remove from her map (Apply to persist — the deletion sticks)")
+                }
+                TextField("persona — short sketch", text: $draft[idx].persona)
+                    .textFieldStyle(.roundedBorder).font(.caption)
+                if draft[idx].isPlace {
+                    TextField("where — e.g. above Barkada Brew", text: $draft[idx].location)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                } else {
+                    TextField("relation — how they stand to her", text: $draft[idx].relation)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                }
+                if !draft[idx].facts.isEmpty {
+                    Text(draft[idx].facts.joined(separator: " · "))
+                        .font(.caption2).foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                        .help("Facts accumulate from her update_world calls")
+                }
+            }
+            .padding(6)
+            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 6))
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/KiraEditorsView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraEditorsView.swift
@@ -1,0 +1,284 @@
+// KiraEditorsView.swift — editable Kira-tab surfaces (Todd 2026-07-27):
+//
+//  - HerNowEditor:       pin mood valence/energy + set/clear the arcPhase
+//                        override (PUT /v1/kira/state/now).
+//  - KiraCharacterCard:  the tiered image-prompt description, fully editable
+//                        (PUT/DELETE /v1/kira/character; override-aware).
+//  - KiraLorebookCard:   canonical facts injected into her context by keyword
+//                        match (existing /v1/lorebook/* CRUD on the daemon).
+//
+// All three are THIN CLIENTS of the daemon API, same as the rest of the tab —
+// no state of their own beyond edit drafts.
+
+import SwiftUI
+
+// MARK: - Her Now editor
+
+struct HerNowEditor: View {
+    @Bindable var client: KiraClient
+    @State private var valence: Double = 0
+    @State private var energy: Double = 0
+    @State private var arcPhaseDraft: String = ""
+    @State private var loadedFor: KiraNowState?
+
+    var body: some View {
+        if let now = client.nowState {
+            VStack(alignment: .leading, spacing: 6) {
+                Divider()
+                Text("Adjust — pins her current mood; it drifts back to baseline on the normal half-life.")
+                    .font(.caption2).foregroundStyle(.tertiary)
+                HStack(spacing: 10) {
+                    Text("valence").font(.caption).foregroundStyle(.secondary)
+                    Slider(value: $valence, in: -1...1, step: 0.05).frame(width: 140)
+                    Text(String(format: "%+.2f", valence)).font(.caption.monospacedDigit())
+                    Text("energy").font(.caption).foregroundStyle(.secondary)
+                    Slider(value: $energy, in: -1...1, step: 0.05).frame(width: 140)
+                    Text(String(format: "%+.2f", energy)).font(.caption.monospacedDigit())
+                    Button("Set mood") {
+                        Task { await client.saveMood(valence: valence, energy: energy) }
+                    }
+                    .disabled(client.actionInFlight)
+                }
+                HStack(spacing: 8) {
+                    Text("arc phase").font(.caption).foregroundStyle(.secondary)
+                    TextField("override (empty = derived)", text: $arcPhaseDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 260)
+                        .onSubmit { saveArcPhase() }
+                    Button("Set") { saveArcPhase() }
+                        .disabled(client.actionInFlight)
+                    if !now.arcPhase.isEmpty {
+                        Button("Clear override") {
+                            Task { await client.saveArcPhase(nil) }
+                        }
+                        .disabled(client.actionInFlight)
+                    }
+                }
+            }
+            .onAppear { syncDrafts(now) }
+            .onChange(of: client.nowState) { _, updated in
+                if let updated { syncDrafts(updated) }
+            }
+        }
+    }
+
+    private func saveArcPhase() {
+        let trimmed = arcPhaseDraft.trimmingCharacters(in: .whitespaces)
+        Task { await client.saveArcPhase(trimmed.isEmpty ? nil : trimmed) }
+    }
+
+    /// Re-seed drafts only when the server state actually changed — otherwise
+    /// the 5s dashboard poll would stomp in-progress slider drags.
+    private func syncDrafts(_ now: KiraNowState) {
+        guard loadedFor != now else { return }
+        loadedFor = now
+        valence = now.valence
+        energy = now.energy
+        arcPhaseDraft = now.arcPhase
+    }
+}
+
+// MARK: - Character description editor
+
+struct KiraCharacterCard: View {
+    @Bindable var client: KiraClient
+    @State private var draft = KiraCharacterDescription()
+    @State private var loadedFor: KiraCharacterDescription?
+    @State private var anchorsDraft: String = ""
+
+    var body: some View {
+        if client.character != nil {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(client.characterSource == "override"
+                         ? "Edited (override active — the code default is preserved)"
+                         : "Canonical code default")
+                        .font(.caption2).foregroundStyle(.tertiary)
+                    Spacer()
+                    if client.characterSource == "override" {
+                        Button("Revert to default") {
+                            Task { await client.resetCharacter() }
+                        }
+                        .disabled(client.actionInFlight)
+                    }
+                }
+                editor("Base (identity anchors — always injected)", text: $draft.base, height: 70)
+                ForEach(KiraCharacterDescription.regionKeys, id: \.self) { key in
+                    editor("Region: \(key)", text: regionBinding(key), height: 44)
+                }
+                editor("Banana tier (suggestive additions)", text: $draft.banana, height: 36)
+                editor("Avocado tier (explicit additions)", text: $draft.avocado, height: 36)
+                HStack(spacing: 8) {
+                    Text("preserve anchors").font(.caption).foregroundStyle(.secondary)
+                    TextField("comma-separated phrases the optimizer must keep", text: $anchorsDraft)
+                        .textFieldStyle(.roundedBorder)
+                }
+                HStack(spacing: 8) {
+                    Text("avocado anchor").font(.caption).foregroundStyle(.secondary)
+                    TextField("canonical explicit-anatomy phrase", text: $draft.avocadoAnchor)
+                        .textFieldStyle(.roundedBorder)
+                }
+                HStack {
+                    Text("Writing guidelines: concrete visuals only, 30–60 words, no garments, light facial detail (face consistency is the LoRA's job).")
+                        .font(.caption2).foregroundStyle(.tertiary)
+                    Spacer()
+                    Button("Save") {
+                        var out = draft
+                        out.preserveAnchors = anchorsDraft
+                            .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                            .filter { !$0.isEmpty }
+                        Task { await client.saveCharacter(out) }
+                    }
+                    .keyboardShortcut("s", modifiers: [.command])
+                    .disabled(client.actionInFlight
+                              || draft.base.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .contentGated()   // description text is tiered; gate like other Kira surfaces
+            .onAppear { syncDraft() }
+            .onChange(of: client.character) { _, _ in syncDraft() }
+        } else {
+            Text("character description unavailable (daemon predates A6?)")
+                .font(.caption).foregroundStyle(.tertiary)
+        }
+    }
+
+    private func regionBinding(_ key: String) -> Binding<String> {
+        Binding(
+            get: { draft.regions[key] ?? "" },
+            set: { draft.regions[key] = $0 })
+    }
+
+    private func editor(_ label: String, text: Binding<String>, height: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            TextEditor(text: text)
+                .font(.caption)
+                .frame(height: height)
+                .overlay(RoundedRectangle(cornerRadius: 4).stroke(.quaternary))
+        }
+    }
+
+    private func syncDraft() {
+        guard let server = client.character, loadedFor != server else { return }
+        loadedFor = server
+        draft = server
+        anchorsDraft = server.preserveAnchors.joined(separator: ", ")
+    }
+}
+
+// MARK: - Lorebook editor
+
+struct KiraLorebookCard: View {
+    @Bindable var client: KiraClient
+    @State private var editingID: String?
+    @State private var draft = KiraLorebookEntry(id: "", title: "", enabled: true,
+                                                 pinned: false, keywords: [], content: "")
+    @State private var keywordsDraft: String = ""
+    @State private var adding = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Canonical facts injected into her context by keyword match; pinned entries always ride along.")
+                .font(.caption2).foregroundStyle(.tertiary)
+
+            ForEach(client.lorebookEntries) { entry in
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Toggle("", isOn: Binding(
+                            get: { entry.enabled },
+                            set: { on in
+                                var e = entry; e.enabled = on
+                                Task { await client.updateLorebookEntry(e) }
+                            }))
+                            .toggleStyle(.checkbox).labelsHidden()
+                            .help(entry.enabled ? "enabled" : "disabled")
+                        Text(entry.title).font(.caption.bold())
+                        if entry.pinned {
+                            Image(systemName: "pin.fill").font(.caption2).foregroundStyle(.orange)
+                        }
+                        Spacer()
+                        Button(editingID == entry.id ? "Close" : "Edit") {
+                            if editingID == entry.id {
+                                editingID = nil
+                            } else {
+                                editingID = entry.id
+                                draft = entry
+                                keywordsDraft = entry.keywords.joined(separator: ", ")
+                                adding = false
+                            }
+                        }
+                        .font(.caption)
+                        Button(role: .destructive) {
+                            Task { await client.deleteLorebookEntry(entry.id) }
+                        } label: { Image(systemName: "trash") }
+                            .font(.caption)
+                            .disabled(client.actionInFlight)
+                    }
+                    if editingID != entry.id {
+                        Text(entry.content).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+                    }
+                    if editingID == entry.id {
+                        entryEditor(isNew: false)
+                    }
+                }
+                .padding(6)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary.opacity(0.3)))
+            }
+
+            if adding {
+                entryEditor(isNew: true)
+                    .padding(6)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary.opacity(0.3)))
+            } else {
+                Button {
+                    adding = true
+                    editingID = nil
+                    draft = KiraLorebookEntry(id: "", title: "", enabled: true,
+                                              pinned: false, keywords: [], content: "")
+                    keywordsDraft = ""
+                } label: {
+                    Label("Add entry", systemImage: "plus")
+                }
+                .font(.caption)
+            }
+        }
+        .contentGated()
+    }
+
+    @ViewBuilder private func entryEditor(isNew: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            TextField("Title", text: $draft.title).textFieldStyle(.roundedBorder)
+            TextField("Keywords (comma-separated)", text: $keywordsDraft).textFieldStyle(.roundedBorder)
+            TextEditor(text: $draft.content)
+                .font(.caption)
+                .frame(height: 70)
+                .overlay(RoundedRectangle(cornerRadius: 4).stroke(.quaternary))
+            HStack {
+                Toggle("Pinned (always injected)", isOn: $draft.pinned)
+                    .toggleStyle(.checkbox).font(.caption)
+                Spacer()
+                Button(isNew ? "Add" : "Save") {
+                    let keywords = keywordsDraft
+                        .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                        .filter { !$0.isEmpty }
+                    if isNew {
+                        Task {
+                            await client.addLorebookEntry(
+                                title: draft.title, keywords: keywords,
+                                content: draft.content, pinned: draft.pinned)
+                        }
+                        adding = false
+                    } else {
+                        var e = draft; e.keywords = keywords
+                        Task { await client.updateLorebookEntry(e) }
+                        editingID = nil
+                    }
+                }
+                .disabled(client.actionInFlight
+                          || draft.title.trimmingCharacters(in: .whitespaces).isEmpty
+                          || draft.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+}

--- a/Sources/ComfyBoxDesktop/Views/KiraView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraView.swift
@@ -43,6 +43,9 @@ struct KiraView: View {
                     foldable("Lorebook", systemImage: "book.closed", "lorebook") {
                         KiraLorebookCard(client: client)
                     }
+                    foldable("World map", systemImage: "map", "world") {
+                        KiraWorldMapCard(client: client)
+                    }
                     foldable("Suggestion box", systemImage: "lightbulb", "suggest") { suggestionBody }
                     foldable("Compute", systemImage: "memorychip", "compute") { computeBody }
                     foldable("Recent output", systemImage: "photo.stack", "recent") { recentOutputBody }
@@ -745,6 +748,28 @@ private struct KiraMediaThumb: View {
         }
         .frame(width: 84, height: 96)
         .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(alignment: .bottomTrailing) {
+            // Taste verdicts (Inner Loop F3): ❤️/😐 feed her draw-weighting
+            // store via POST /v1/kira/taste — she renders more of what lands.
+            if let sent = client.tasteSent[item.path] {
+                Text(sent == "up" ? "❤️" : "😐")
+                    .font(.caption2)
+                    .padding(3)
+                    .background(.black.opacity(0.45), in: Capsule())
+                    .padding(3)
+            } else {
+                HStack(spacing: 2) {
+                    Button { Task { await client.sendTaste(path: item.path, verdict: "up") } }
+                        label: { Text("❤️").font(.caption2) }
+                    Button { Task { await client.sendTaste(path: item.path, verdict: "down") } }
+                        label: { Text("😐").font(.caption2) }
+                }
+                .buttonStyle(.borderless)
+                .padding(2)
+                .background(.black.opacity(0.45), in: Capsule())
+                .padding(3)
+            }
+        }
         .help((item.path as NSString).lastPathComponent)
         .task {
             guard image == nil, item.kind == "image" else { return }

--- a/Sources/ComfyBoxDesktop/Views/KiraView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraView.swift
@@ -15,6 +15,7 @@ struct KiraView: View {
     @State private var portDraft: String = ""
     @State private var suggestionDraft: String = ""
     @State private var suggestionKind: String = "image"
+    @State private var suggestionTier: String = "any"
     /// Which cards are expanded. Empty by default → every card starts collapsed
     /// on launch (Todd 2026-07-17). Expansion is per-session, not persisted.
     @State private var expandedCards: Set<String> = []
@@ -289,71 +290,37 @@ struct KiraView: View {
                     Text(cadenceLine(scheduler))
                         .font(.caption).foregroundStyle(.secondary)
                 }
-                // Editable pacing (Todd 2026-07-20) — live: the scheduler
-                // re-reads policy each cycle, so changes apply next tick.
-                HStack(spacing: 14) {
-                    Stepper(
-                        "Images: \(scheduler.unlimitedImages ? "∞" : String(scheduler.imageCount ?? 2))",
-                        onIncrement: {
-                            Task { await client.updateSchedulerPolicy(["imageCount": (scheduler.imageCount ?? 2) + 1]) }
-                        },
-                        onDecrement: {
-                            Task { await client.updateSchedulerPolicy(["imageCount": max(0, (scheduler.imageCount ?? 2) - 1)]) }
-                        })
-                        .disabled(client.actionInFlight || scheduler.unlimitedImages)
-                    Toggle("Unlimited (fit cycle)", isOn: Binding(
-                        get: { scheduler.unlimitedImages },
-                        set: { on in Task { await client.updateSchedulerPolicy(["unlimitedImages": on]) } }))
-                        .toggleStyle(.checkbox)
-                        .disabled(client.actionInFlight)
-                        .help("Keep rendering images for the whole cycle — throughput adapts to render times; the queue never carries into the next cycle.")
-                    Stepper(
-                        "Videos: \(scheduler.videoCount ?? 1)",
-                        onIncrement: {
-                            Task { await client.updateSchedulerPolicy(["videoCount": (scheduler.videoCount ?? 1) + 1]) }
-                        },
-                        onDecrement: {
-                            Task { await client.updateSchedulerPolicy(["videoCount": max(0, (scheduler.videoCount ?? 1) - 1)]) }
-                        })
-                        .disabled(client.actionInFlight)
-                }
-                .font(.caption)
-                // Content-creation window (Todd 2026-07-27) — server-local time;
-                // the scheduler skips cycles outside it and the unlimited chain
-                // stops at the edge. Off = 24/7 (activeHours null server-side).
-                HStack(spacing: 10) {
-                    Toggle("Active hours", isOn: Binding(
-                        get: { scheduler.activeHoursStart != nil },
-                        set: { on in
-                            Task {
-                                await client.updateSchedulerPolicy(
-                                    ["activeHours": on
-                                        ? ["start": "20:00", "end": "08:00"]
-                                        : NSNull()])
-                            }
-                        }))
-                        .toggleStyle(.checkbox)
-                        .disabled(client.actionInFlight)
-                        .help("Restrict content creation to a time window (server-local). Overnight windows wrap midnight. Off = 24/7.")
-                    if scheduler.activeHoursStart != nil {
-                        Picker("from", selection: windowHourBinding(scheduler, isStart: true)) {
-                            ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
+                // Stream steering (tiered scheduler v2, Todd 2026-07-27):
+                // precedence = your override > Kira's choice > schedule.
+                if let stream = client.streamStatus {
+                    HStack(spacing: 10) {
+                        Text("Stream:").font(.caption).foregroundStyle(.secondary)
+                        Text(streamSummary(stream)).font(.caption)
+                        Picker("", selection: Binding(
+                            get: { stream.todd ?? "auto" },
+                            set: { v in Task { await client.setStreamOverride(v == "auto" ? nil : v) } })) {
+                            Text("Auto").tag("auto")
+                            ForEach(Self.tierOrder, id: \.self) { Text(modeEmoji($0)).tag($0) }
                         }
-                        .frame(width: 110)
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .frame(maxWidth: 240)
                         .disabled(client.actionInFlight)
-                        Picker("to", selection: windowHourBinding(scheduler, isStart: false)) {
-                            ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
-                        }
-                        .frame(width: 110)
-                        .disabled(client.actionInFlight)
+                        .help("Your sticky override — pins every cycle to a tier, all hours, until Auto. Kira's own choice and the schedule take over when cleared.")
                     }
                 }
-                .font(.caption)
+                // Per-tier schedule + pacing. Editing writes the FULL tiers
+                // map (server replaces; an unchecked tier is scheduled off).
+                ForEach(Self.tierOrder, id: \.self) { mode in
+                    tierRow(mode, scheduler: scheduler)
+                }
+                Text("Overlapping windows are fine — the most explicit open tier wins. Kira can pick any tier herself; /stream overrides from Telegram.")
+                    .font(.caption2).foregroundStyle(.tertiary)
             } else {
                 Text("scheduler status unavailable").font(.caption).foregroundStyle(.tertiary)
             }
             if !client.allowedModes.isEmpty {
-                Picker("Mode", selection: Binding(
+                Picker("Chat mode", selection: Binding(
                     get: { client.contentMode ?? "" },
                     set: { mode in Task { await client.setContentMode(mode) } })) {
                     ForEach(client.allowedModes, id: \.self) { mode in
@@ -361,9 +328,9 @@ struct KiraView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .frame(maxWidth: 260)
+                .frame(maxWidth: 300)
                 .disabled(client.actionInFlight)
-                .help("Content mode — allowlisted server-side; reflected across surfaces")
+                .help("Conversation register only — the 24/7 stream is driven by the tier schedule above, not this picker.")
             }
         }
     }
@@ -379,6 +346,13 @@ struct KiraView: View {
             }
             .labelsHidden()
             .frame(width: 110)
+            Picker("", selection: $suggestionTier) {
+                Text("any").tag("any")
+                ForEach(Self.tierOrder, id: \.self) { Text(modeEmoji($0)).tag($0) }
+            }
+            .labelsHidden()
+            .frame(width: 76)
+            .help("Optional tier tag — the idea waits for a cycle of that tier (an apple-tagged arc themes only apple cycles). \"any\" = next cycle regardless.")
             TextField("e.g. golden hour on the balcony in the red dress", text: $suggestionDraft)
                 .textFieldStyle(.roundedBorder)
                 .onSubmit { submitSuggestion() }
@@ -412,7 +386,10 @@ struct KiraView: View {
     private func submitSuggestion() {
         let text = suggestionDraft
         suggestionDraft = ""
-        Task { await client.addSuggestion(kind: suggestionKind, text: text) }
+        // "any" = untagged (consumed by whatever tier's cycle runs next);
+        // a tier tag holds the idea for that tier's window.
+        let tier = suggestionTier == "any" ? nil : suggestionTier
+        Task { await client.addSuggestion(kind: suggestionKind, text: text, tier: tier) }
     }
 
     private func kindTint(_ kind: String) -> Color {
@@ -536,19 +513,156 @@ struct KiraView: View {
         }
     }
 
+    /// Display order for tier rows — mildest first (the scheduler's own
+    /// overlap precedence is the reverse: most explicit wins).
+    static let tierOrder = ["neutral", "apple", "banana", "avocado"]
+
     private func cadenceLine(_ scheduler: KiraSchedulerStatus) -> String {
         var parts: [String] = []
         if let interval = scheduler.intervalMinutes { parts.append("every \(interval)m") }
-        if scheduler.unlimitedImages {
-            parts.append("∞ img (fit cycle)")
-        } else if let images = scheduler.imageCount {
-            parts.append("\(images) img")
-        }
-        if let videos = scheduler.videoCount { parts.append("\(videos) video (\(scheduler.videoMode ?? "?"))") }
-        if let start = scheduler.activeHoursStart, let end = scheduler.activeHoursEnd {
-            parts.append("\(Self.windowLabel(start))–\(Self.windowLabel(end))")
+        if scheduler.tiers.isEmpty {
+            // Pre-v2 daemon: legacy flat summary.
+            if scheduler.unlimitedImages {
+                parts.append("∞ img (fit cycle)")
+            } else if let images = scheduler.imageCount {
+                parts.append("\(images) img")
+            }
+            if let videos = scheduler.videoCount { parts.append("\(videos) video") }
+            if let start = scheduler.activeHoursStart, let end = scheduler.activeHoursEnd {
+                parts.append("\(Self.windowLabel(start))–\(Self.windowLabel(end))")
+            }
+        } else {
+            for mode in Self.tierOrder {
+                guard let tier = scheduler.tiers[mode] else { continue }
+                var bit = modeEmoji(mode)
+                if let start = tier.activeHoursStart, let end = tier.activeHoursEnd {
+                    bit += " \(Self.windowLabel(start))–\(Self.windowLabel(end))"
+                } else {
+                    bit += " 24/7"
+                }
+                bit += tier.unlimitedImages ? " ∞" : " \(tier.imageCount)img"
+                if mode != "neutral" && tier.videoCount > 0 { bit += " \(tier.videoCount)v" }
+                parts.append(bit)
+            }
         }
         return parts.joined(separator: " · ")
+    }
+
+    private func streamSummary(_ stream: KiraStreamStatus) -> String {
+        let mode = stream.effectiveMode.map { "\(modeEmoji($0)) \($0)" } ?? "idle (no window open)"
+        switch stream.source {
+        case "override-todd": return "\(mode) — your override"
+        case "override-kira": return "\(mode) — Kira's choice"
+        case "none-open": return mode
+        default: return "\(mode) — schedule"
+        }
+    }
+
+    // ── Tier rows (tiered scheduler v2) ──
+
+    /// Mutate-and-PUT: the server treats the tiers map as a full replacement.
+    private func putTiers(_ mutate: (inout [String: KiraTierConfig]) -> Void) {
+        guard var tiers = client.scheduler?.tiers else { return }
+        mutate(&tiers)
+        Task { await client.updateSchedulerTiers(tiers) }
+    }
+
+    @ViewBuilder private func tierRow(_ mode: String, scheduler: KiraSchedulerStatus) -> some View {
+        HStack(spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { scheduler.tiers[mode] != nil },
+                set: { on in
+                    putTiers { tiers in
+                        if on {
+                            tiers[mode] = KiraTierConfig(
+                                activeHoursStart: nil, activeHoursEnd: nil,
+                                imageCount: 2, unlimitedImages: false,
+                                videoCount: mode == "neutral" ? 0 : 1)
+                        } else {
+                            tiers.removeValue(forKey: mode)
+                        }
+                    }
+                })) {
+                Text("\(modeEmoji(mode)) \(mode)")
+                    .font(.caption)
+                    .frame(width: 78, alignment: .leading)
+            }
+            .toggleStyle(.checkbox)
+            .disabled(client.actionInFlight)
+
+            if let tier = scheduler.tiers[mode] {
+                Toggle("window", isOn: Binding(
+                    get: { tier.activeHoursStart != nil },
+                    set: { on in
+                        putTiers { tiers in
+                            tiers[mode]?.activeHoursStart = on ? "20:00" : nil
+                            tiers[mode]?.activeHoursEnd = on ? "08:00" : nil
+                        }
+                    }))
+                    .toggleStyle(.checkbox).font(.caption)
+                    .disabled(client.actionInFlight)
+                    .help("Off = this tier is eligible 24/7. Overnight windows wrap midnight; the most explicit open tier wins overlaps.")
+                if tier.activeHoursStart != nil {
+                    Picker("", selection: tierHourBinding(mode, isStart: true)) {
+                        ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
+                    }
+                    .labelsHidden().frame(width: 86)
+                    .disabled(client.actionInFlight)
+                    Text("–").font(.caption).foregroundStyle(.tertiary)
+                    Picker("", selection: tierHourBinding(mode, isStart: false)) {
+                        ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
+                    }
+                    .labelsHidden().frame(width: 86)
+                    .disabled(client.actionInFlight)
+                }
+                Stepper("img: \(tier.unlimitedImages ? "∞" : String(tier.imageCount))",
+                        onIncrement: { putTiers { $0[mode]?.imageCount = tier.imageCount + 1 } },
+                        onDecrement: { putTiers { $0[mode]?.imageCount = max(0, tier.imageCount - 1) } })
+                    .font(.caption)
+                    .disabled(client.actionInFlight || tier.unlimitedImages)
+                Toggle("∞", isOn: Binding(
+                    get: { tier.unlimitedImages },
+                    set: { on in putTiers { $0[mode]?.unlimitedImages = on } }))
+                    .toggleStyle(.checkbox).font(.caption)
+                    .disabled(client.actionInFlight)
+                    .help("Unlimited-within-cycle: image renders chain until the cycle (or this tier's window) closes.")
+                if mode != "neutral" {
+                    Stepper("vid: \(tier.videoCount)",
+                            onIncrement: { putTiers { $0[mode]?.videoCount = tier.videoCount + 1 } },
+                            onDecrement: { putTiers { $0[mode]?.videoCount = max(0, tier.videoCount - 1) } })
+                        .font(.caption)
+                        .disabled(client.actionInFlight)
+                } else {
+                    Text("stills only").font(.caption2).foregroundStyle(.tertiary)
+                        .help("Neutral is the Autocord film stream — no video.")
+                }
+                Spacer(minLength: 0)
+            } else {
+                Text("off").font(.caption2).foregroundStyle(.tertiary)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// Hour-grain binding for one end of a tier's window (writes the pair).
+    private func tierHourBinding(_ mode: String, isStart: Bool) -> Binding<Int> {
+        Binding(
+            get: {
+                let tier = client.scheduler?.tiers[mode]
+                return Self.hour(from: isStart ? tier?.activeHoursStart : tier?.activeHoursEnd) ?? (isStart ? 20 : 8)
+            },
+            set: { h in
+                putTiers { tiers in
+                    guard var tier = tiers[mode] else { return }
+                    var start = Self.hour(from: tier.activeHoursStart) ?? 20
+                    var end = Self.hour(from: tier.activeHoursEnd) ?? 8
+                    if isStart { start = h } else { end = h }
+                    guard start != end else { return }   // zero-length → server 400; use the window toggle for 24/7
+                    tier.activeHoursStart = String(format: "%02d:00", start)
+                    tier.activeHoursEnd = String(format: "%02d:00", end)
+                    tiers[mode] = tier
+                }
+            })
     }
 
     // ── Content-window helpers ──
@@ -575,25 +689,6 @@ struct KiraView: View {
         let minutes = bits.count > 1 ? String(bits[1]) : "00"
         let base = hourLabel(h)
         return minutes == "00" ? base : base.replacingOccurrences(of: " ", with: ":\(minutes) ")
-    }
-
-    /// Binding for one end of the window; writing either end PUTs the pair.
-    private func windowHourBinding(_ scheduler: KiraSchedulerStatus, isStart: Bool) -> Binding<Int> {
-        Binding(
-            get: { Self.hour(from: isStart ? scheduler.activeHoursStart : scheduler.activeHoursEnd) ?? (isStart ? 20 : 8) },
-            set: { h in
-                var start = Self.hour(from: scheduler.activeHoursStart) ?? 20
-                var end = Self.hour(from: scheduler.activeHoursEnd) ?? 8
-                if isStart { start = h } else { end = h }
-                // The daemon rejects a zero-length window (use the toggle for
-                // 24/7) — don't send an update the server will 400.
-                guard start != end else { return }
-                Task {
-                    await client.updateSchedulerPolicy(
-                        ["activeHours": ["start": String(format: "%02d:00", start),
-                                         "end": String(format: "%02d:00", end)]])
-                }
-            })
     }
 
     private func chip(_ text: String?, tint: Color) -> some View {

--- a/Sources/ComfyBoxDesktop/Views/KiraView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct KiraView: View {
     @Bindable var client: KiraClient
     @State private var tokenDraft: String = ""
+    @State private var hostDraft: String = ""
+    @State private var portDraft: String = ""
     @State private var suggestionDraft: String = ""
     @State private var suggestionKind: String = "image"
     /// Which cards are expanded. Empty by default → every card starts collapsed
@@ -57,6 +59,8 @@ struct KiraView: View {
         .navigationTitle("Kira")
         .onAppear {
             tokenDraft = client.token
+            hostDraft = client.binding.host
+            portDraft = String(client.binding.port)
             client.startPolling()
         }
         .onDisappear {
@@ -181,34 +185,48 @@ struct KiraView: View {
             .font(.callout)
             .foregroundStyle(.secondary)
         HStack {
-            TextField("Host", text: Binding(
-                get: { client.binding.host },
-                set: { client.binding.host = $0 }))
+            // Drafts, not live bindings (Kimi review 2026-07-27): binding.didSet
+            // persists to UserDefaults and restarts polling, so typing directly
+            // into client.binding did both on EVERY keystroke. Apply commits once.
+            TextField("Host", text: $hostDraft)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 160)
-            TextField("Port", value: Binding(
-                get: { client.binding.port },
-                set: { client.binding.port = $0 }), format: .number.grouping(.never))
+            TextField("Port", text: $portDraft)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 70)
             SecureField("Daemon API token", text: $tokenDraft)
                 .textFieldStyle(.roundedBorder)
                 .frame(minWidth: 160)
-                .onSubmit { client.token = tokenDraft }
-            Button("Apply") {
-                client.token = tokenDraft
-                Task { await client.refreshHealth() }
-            }
+                .onSubmit { applyBinding() }
+            Button("Apply") { applyBinding() }
         }
         Text("Token is stored in the macOS Keychain. One switch re-points the whole tab (host-agnostic) — no per-card configuration.")
             .font(.caption2)
             .foregroundStyle(.tertiary)
     }
 
+    /// Commit the binding drafts in one shot (persist + poll restart happen once).
+    private func applyBinding() {
+        client.token = tokenDraft
+        var binding = client.binding
+        binding.host = hostDraft.trimmingCharacters(in: .whitespaces)
+        if let port = Int(portDraft.trimmingCharacters(in: .whitespaces)), (1...65535).contains(port) {
+            binding.port = port
+        } else {
+            portDraft = String(binding.port)   // reject garbage, restore the live value
+        }
+        client.binding = binding   // no-op if unchanged (didSet guards equality)
+        Task { await client.refreshHealth() }
+    }
+
     // MARK: - Live dashboard cards (D2–D4)
 
     @ViewBuilder private var herNowBody: some View {
         if let state = client.state {
+            if let staleNote = client.stateError {
+                // Set only when a refresh failed while a snapshot is on screen.
+                Text(staleNote).font(.caption2).foregroundStyle(.orange)
+            }
             HStack(spacing: 10) {
                 chip(state.mood, tint: .pink)
                 chip(state.energy, tint: .orange)

--- a/Sources/ComfyBoxDesktop/Views/KiraView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraView.swift
@@ -34,6 +34,12 @@ struct KiraView: View {
                     foldable("Her Now", systemImage: "sparkles", "herNow") { herNowBody }
                     foldable("Agenda", systemImage: "list.bullet.rectangle", "agenda") { agendaBody }
                     foldable("Creation", systemImage: "wand.and.rays", "controls") { controlsBody }
+                    foldable("Character", systemImage: "person.text.rectangle", "character") {
+                        KiraCharacterCard(client: client)
+                    }
+                    foldable("Lorebook", systemImage: "book.closed", "lorebook") {
+                        KiraLorebookCard(client: client)
+                    }
                     foldable("Suggestion box", systemImage: "lightbulb", "suggest") { suggestionBody }
                     foldable("Compute", systemImage: "memorychip", "compute") { computeBody }
                     foldable("Recent output", systemImage: "photo.stack", "recent") { recentOutputBody }
@@ -230,6 +236,8 @@ struct KiraView: View {
                 Text("world slice not served yet (A3 gap — barkada/Ube land with it)")
                     .font(.caption2).foregroundStyle(.tertiary)
             }
+            // Editable attributes (Todd 2026-07-27): pin mood, override arc phase.
+            HerNowEditor(client: client)
         } else {
             Text(client.stateError ?? "loading…").font(.caption).foregroundStyle(.tertiary)
         }

--- a/Sources/ComfyBoxDesktop/Views/KiraView.swift
+++ b/Sources/ComfyBoxDesktop/Views/KiraView.swift
@@ -292,6 +292,37 @@ struct KiraView: View {
                         .disabled(client.actionInFlight)
                 }
                 .font(.caption)
+                // Content-creation window (Todd 2026-07-27) — server-local time;
+                // the scheduler skips cycles outside it and the unlimited chain
+                // stops at the edge. Off = 24/7 (activeHours null server-side).
+                HStack(spacing: 10) {
+                    Toggle("Active hours", isOn: Binding(
+                        get: { scheduler.activeHoursStart != nil },
+                        set: { on in
+                            Task {
+                                await client.updateSchedulerPolicy(
+                                    ["activeHours": on
+                                        ? ["start": "20:00", "end": "08:00"]
+                                        : NSNull()])
+                            }
+                        }))
+                        .toggleStyle(.checkbox)
+                        .disabled(client.actionInFlight)
+                        .help("Restrict content creation to a time window (server-local). Overnight windows wrap midnight. Off = 24/7.")
+                    if scheduler.activeHoursStart != nil {
+                        Picker("from", selection: windowHourBinding(scheduler, isStart: true)) {
+                            ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
+                        }
+                        .frame(width: 110)
+                        .disabled(client.actionInFlight)
+                        Picker("to", selection: windowHourBinding(scheduler, isStart: false)) {
+                            ForEach(0..<24, id: \.self) { Text(Self.hourLabel($0)).tag($0) }
+                        }
+                        .frame(width: 110)
+                        .disabled(client.actionInFlight)
+                    }
+                }
+                .font(.caption)
             } else {
                 Text("scheduler status unavailable").font(.caption).foregroundStyle(.tertiary)
             }
@@ -488,7 +519,55 @@ struct KiraView: View {
             parts.append("\(images) img")
         }
         if let videos = scheduler.videoCount { parts.append("\(videos) video (\(scheduler.videoMode ?? "?"))") }
+        if let start = scheduler.activeHoursStart, let end = scheduler.activeHoursEnd {
+            parts.append("\(Self.windowLabel(start))–\(Self.windowLabel(end))")
+        }
         return parts.joined(separator: " · ")
+    }
+
+    // ── Content-window helpers ──
+
+    /// "HH:MM" → hour Int (minutes dropped; the pickers edit at hour grain).
+    private static func hour(from hm: String?) -> Int? {
+        guard let first = hm?.split(separator: ":").first, let h = Int(first) else { return nil }
+        return (0...23).contains(h) ? h : nil
+    }
+
+    private static func hourLabel(_ h: Int) -> String {
+        switch h {
+        case 0: return "12 AM"
+        case 12: return "12 PM"
+        case 1...11: return "\(h) AM"
+        default: return "\(h - 12) PM"
+        }
+    }
+
+    /// Display label for a stored "HH:MM" (keeps minutes when non-zero).
+    private static func windowLabel(_ hm: String) -> String {
+        let bits = hm.split(separator: ":")
+        guard let h = bits.first.flatMap({ Int($0) }) else { return hm }
+        let minutes = bits.count > 1 ? String(bits[1]) : "00"
+        let base = hourLabel(h)
+        return minutes == "00" ? base : base.replacingOccurrences(of: " ", with: ":\(minutes) ")
+    }
+
+    /// Binding for one end of the window; writing either end PUTs the pair.
+    private func windowHourBinding(_ scheduler: KiraSchedulerStatus, isStart: Bool) -> Binding<Int> {
+        Binding(
+            get: { Self.hour(from: isStart ? scheduler.activeHoursStart : scheduler.activeHoursEnd) ?? (isStart ? 20 : 8) },
+            set: { h in
+                var start = Self.hour(from: scheduler.activeHoursStart) ?? 20
+                var end = Self.hour(from: scheduler.activeHoursEnd) ?? 8
+                if isStart { start = h } else { end = h }
+                // The daemon rejects a zero-length window (use the toggle for
+                // 24/7) — don't send an update the server will 400.
+                guard start != end else { return }
+                Task {
+                    await client.updateSchedulerPolicy(
+                        ["activeHours": ["start": String(format: "%02d:00", start),
+                                         "end": String(format: "%02d:00", end)]])
+                }
+            })
     }
 
     private func chip(_ text: String?, tint: Color) -> some View {

--- a/Sources/ComfyBoxDesktop/Views/PresetView.swift
+++ b/Sources/ComfyBoxDesktop/Views/PresetView.swift
@@ -157,7 +157,7 @@ struct PresetView: View {
     private func duplicate(_ preset: ServerPreset) async {
         var copy = preset
         copy.id = UUID().uuidString
-        copy.name = "\(preset.name) Copy"
+        copy.name = "\(preset.name) copy"   // lowercase — matches Save-as-New's " copy" suffix
         await save(copy)
     }
 


### PR DESCRIPTION
Kira Suite tab workstream: per-tier scheduler rows + stream steering (Auto/🍏/⚪️/🍌/🥑), character/lorebook/Her-Now editors, suggestion tier chips, world map editor (GET/PUT /v1/kira/world), and ❤️/😐 taste verdicts on recent output (POST /v1/kira/taste). Already live in /Applications via deploy-desktop.sh; this lands it on main.

Coordination note: does NOT touch Sources/ZImage/Server — no overlap with claude/ltx2-haze-optimization (other session's branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvyodATzyvUcGi4bntyMZM